### PR TITLE
Reset news filters when clearing selections

### DIFF
--- a/src/app/components/news-feed/news-feed.component.ts
+++ b/src/app/components/news-feed/news-feed.component.ts
@@ -80,7 +80,7 @@ export class NewsFeedComponent implements OnInit, OnDestroy {
   clearFilters(): void {
     this.searchTerm = '';
     this.selectedSource = '';
-    this.updateFilters({});
+    this.stateService.resetFilters();
   }
 
   get availableSources(): string[] {

--- a/src/app/services/news-state.service.ts
+++ b/src/app/services/news-state.service.ts
@@ -65,6 +65,10 @@ export class NewsStateService {
     });
   }
 
+  resetFilters(): void {
+    this.filters.next({});
+  }
+
   // Data Operations
   fetchNews(): void {
     this.newsApiService.getNews().subscribe({


### PR DESCRIPTION
## Summary
- add a resetFilters helper on the news state service to replace the current filter object
- update the news feed component's clear action to call the new helper after clearing local state

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68ea7d2328648326972e1bf28090c256