### PR TITLE
Ensure Clear Filters button resets news filters

### DIFF
--- a/src/app/components/news-feed/news-feed.component.ts
+++ b/src/app/components/news-feed/news-feed.component.ts
@@ -80,7 +80,7 @@ export class NewsFeedComponent implements OnInit, OnDestroy {
   clearFilters(): void {
     this.searchTerm = '';
     this.selectedSource = '';
-    this.updateFilters({});
+    this.stateService.resetFilters();
   }
 
   get availableSources(): string[] {

--- a/src/app/services/news-state.service.ts
+++ b/src/app/services/news-state.service.ts
@@ -65,6 +65,10 @@ export class NewsStateService {
     });
   }
 
+  resetFilters(): void {
+    this.filters.next({});
+  }
+
   // Data Operations
   fetchNews(): void {
     this.newsApiService.getNews().subscribe({


### PR DESCRIPTION
## Summary
- add a dedicated `resetFilters` helper in `NewsStateService` to replace the filter state with a blank object
- update the news feed component to call `resetFilters` when clearing UI inputs so any active filters are fully cleared

## Testing
- npm test -- --watch=false *(fails: Chrome browser binary not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ea7be1390083269d64cbbe0ee255b7