### PR TITLE
feat: add story detail page with contextual modules

### DIFF
--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -14,16 +14,16 @@ describe('AppComponent', () => {
     expect(app).toBeTruthy();
   });
 
-  it(`should have the 'trump-tracker' title`, () => {
+  it('should have the tracker title', () => {
     const fixture = TestBed.createComponent(AppComponent);
     const app = fixture.componentInstance;
-    expect(app.title).toEqual('trump-tracker');
+    expect(app.title).toEqual('Trump 47 Campaign Tracker');
   });
 
   it('should render title', () => {
     const fixture = TestBed.createComponent(AppComponent);
     fixture.detectChanges();
     const compiled = fixture.nativeElement as HTMLElement;
-    expect(compiled.querySelector('h1')?.textContent).toContain('Hello, trump-tracker');
+    expect(compiled.querySelector('.brand')?.textContent).toContain('Trump 47 Campaign Tracker');
   });
 });

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,21 +1,69 @@
 import { Component } from '@angular/core';
-import { RouterOutlet } from '@angular/router';
-import { NewsFeedComponent } from './components/news-feed/news-feed.component';
+import { RouterOutlet, RouterModule } from '@angular/router';
 
 @Component({
   selector: 'app-root',
   standalone: true,
-  imports: [RouterOutlet, NewsFeedComponent],
+  imports: [RouterOutlet, RouterModule],
   template: `
-    <main>
-      <app-news-feed></app-news-feed>
-    </main>
+    <div class="app-shell">
+      <header class="app-header">
+        <div class="container">
+          <a routerLink="/" class="brand" aria-label="Trump 47 Campaign Tracker home">
+            Trump 47 Campaign Tracker
+          </a>
+          <p class="tagline">Realtime updates, context, and analysis on campaign developments.</p>
+        </div>
+      </header>
+      <main class="app-main">
+        <div class="container">
+          <router-outlet></router-outlet>
+        </div>
+      </main>
+    </div>
   `,
   styles: [`
-    main {
+    .app-shell {
       min-height: 100vh;
-      background: #f0f2f5;
-      padding: 20px 0;
+      display: flex;
+      flex-direction: column;
+      background: var(--background);
+    }
+
+    .app-header {
+      background: linear-gradient(135deg, rgba(255, 69, 0, 0.95), rgba(255, 107, 61, 0.95));
+      padding: 32px 0;
+      color: #fff;
+      box-shadow: 0 10px 30px rgba(255, 69, 0, 0.2);
+    }
+
+    .brand {
+      font-size: clamp(1.6rem, 4vw, 2.2rem);
+      font-weight: 700;
+      color: inherit;
+      text-decoration: none;
+    }
+
+    .tagline {
+      margin-top: 8px;
+      max-width: 640px;
+      font-size: 1rem;
+      opacity: 0.85;
+    }
+
+    .app-main {
+      flex: 1;
+      padding: 32px 0 64px;
+    }
+
+    @media (max-width: 768px) {
+      .app-header {
+        padding: 24px 0;
+      }
+
+      .app-main {
+        padding: 24px 0 48px;
+      }
     }
   `]
 })

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -1,3 +1,16 @@
 import { Routes } from '@angular/router';
+import { NewsFeedComponent } from './components/news-feed/news-feed.component';
+import { StoryDetailComponent } from './components/story/story-detail/story-detail.component';
 
-export const routes: Routes = [];
+export const routes: Routes = [
+  {
+    path: '',
+    component: NewsFeedComponent,
+    title: 'Trump 47 Campaign Tracker'
+  },
+  {
+    path: 'news/:id',
+    component: StoryDetailComponent,
+    title: 'Story detail • Trump 47 Campaign Tracker'
+  }
+];

--- a/src/app/components/news-item/news-item.component.html
+++ b/src/app/components/news-item/news-item.component.html
@@ -2,7 +2,11 @@
   <div class="news-content">
     <header>
       <h2>
-        <a [href]="item.link" target="_blank" rel="noopener noreferrer">
+        <a
+          [routerLink]="detailRoute"
+          class="story-link"
+          [attr.aria-label]="'View story details: ' + item.title"
+        >
           {{ item.title }}
         </a>
       </h2>
@@ -10,7 +14,7 @@
       <div class="meta">
         <span class="source">{{ item.source }}</span>
         <span class="category" *ngIf="item.category">{{ item.category }}</span>
-        <time class="date" [dateTime]="item.pubDate.toISOString()">
+        <time class="date" [dateTime]="toIsoString(item.pubDate)">
           {{ formatDate(item.pubDate) }}
         </time>
       </div>
@@ -27,11 +31,18 @@
     </div>
 
     <footer class="actions">
+      <a
+        [routerLink]="detailRoute"
+        class="view-story"
+        [attr.aria-label]="'Read campaign context for: ' + item.title"
+      >
+        View story
+      </a>
       <a [href]="item.link"
         target="_blank"
         rel="noopener noreferrer"
         class="read-more"
-        [attr.aria-label]="'Read full post: ' + item.title">
+        [attr.aria-label]="'Read full post on Reddit: ' + item.title">
         <span>Read on Reddit</span>
         <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
           <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"></path>

--- a/src/app/components/news-item/news-item.component.scss
+++ b/src/app/components/news-item/news-item.component.scss
@@ -28,7 +28,7 @@
         font-weight: 700;
         letter-spacing: -0.02em;
 
-        a {
+        .story-link {
           color: #111827;
           text-decoration: none;
           background: linear-gradient(to right, #ff4500, #ff4500);
@@ -137,31 +137,53 @@
 
     footer.actions {
       margin-top: 24px;
-      text-align: right;
+      display: flex;
+      flex-wrap: wrap;
+      gap: 12px;
+      justify-content: flex-end;
       padding-top: 20px;
       border-top: 1px solid #e5e7eb;
 
-      .read-more {
+      a {
         display: inline-flex;
         align-items: center;
         gap: 8px;
-        color: #ffffff;
-        text-decoration: none;
         font-size: 0.95em;
         font-weight: 600;
         padding: 10px 20px;
         border-radius: 24px;
-        background: linear-gradient(135deg, #ff4500, #ff6b3d);
+        text-decoration: none;
         transition: all 0.3s ease;
+      }
+
+      .view-story {
+        color: #ffffff;
+        background: linear-gradient(135deg, #ff4500, #ff6b3d);
         box-shadow: 0 2px 4px rgba(255, 69, 0, 0.2);
+
+        &:hover {
+          transform: translateY(-2px);
+          box-shadow: 0 4px 12px rgba(255, 69, 0, 0.3);
+        }
+
+        &:active {
+          transform: translateY(0);
+          box-shadow: 0 2px 4px rgba(255, 69, 0, 0.2);
+        }
+      }
+
+      .read-more {
+        color: #ff4500;
+        border: 1px solid rgba(255, 69, 0, 0.4);
+        background: rgba(255, 240, 235, 0.7);
 
         svg {
           transition: transform 0.3s ease;
         }
 
         &:hover {
-          transform: translateY(-2px);
-          box-shadow: 0 4px 12px rgba(255, 69, 0, 0.3);
+          background: rgba(255, 240, 235, 1);
+          border-color: #ff4500;
 
           svg {
             transform: translate(4px, -4px);
@@ -170,7 +192,7 @@
 
         &:active {
           transform: translateY(0);
-          box-shadow: 0 2px 4px rgba(255, 69, 0, 0.2);
+          box-shadow: none;
         }
       }
     }

--- a/src/app/components/news-item/news-item.component.ts
+++ b/src/app/components/news-item/news-item.component.ts
@@ -1,23 +1,35 @@
 import { Component, Input } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { RouterModule } from '@angular/router';
+import { NewsItem } from '../../models/news.model';
 
 @Component({
   selector: 'app-news-item',
   standalone: true,
-  imports: [CommonModule],
+  imports: [CommonModule, RouterModule],
   templateUrl: './news-item.component.html',
   styleUrl: './news-item.component.scss'
 })
 export class NewsItemComponent {
-  @Input() item: any;
+  @Input() item!: NewsItem;
 
-  formatDate(date: string): string {
-    return new Date(date).toLocaleDateString('en-US', {
+  formatDate(date: Date | string): string {
+    const value = typeof date === 'string' ? new Date(date) : date;
+    return value.toLocaleDateString('en-US', {
       year: 'numeric',
       month: 'long',
       day: 'numeric',
       hour: '2-digit',
       minute: '2-digit'
     });
+  }
+
+  get detailRoute(): string[] {
+    return ['/news', this.item.id];
+  }
+
+  toIsoString(date: Date | string): string {
+    const value = typeof date === 'string' ? new Date(date) : date;
+    return value.toISOString();
   }
 }

--- a/src/app/components/story/key-facts/key-facts.component.html
+++ b/src/app/components/story/key-facts/key-facts.component.html
@@ -1,0 +1,10 @@
+<section class="key-facts" *ngIf="hasSummary">
+  <header>
+    <h2>Key Facts</h2>
+    <p class="subtitle">Essential takeaways from the reporting</p>
+  </header>
+
+  <ul>
+    <li *ngFor="let fact of summary">{{ fact }}</li>
+  </ul>
+</section>

--- a/src/app/components/story/key-facts/key-facts.component.scss
+++ b/src/app/components/story/key-facts/key-facts.component.scss
@@ -1,0 +1,46 @@
+.key-facts {
+  background: var(--card-background);
+  border-radius: 16px;
+  padding: 24px;
+  box-shadow: var(--shadow);
+  border: 1px solid var(--border-color);
+  display: grid;
+  gap: 16px;
+
+  header {
+    h2 {
+      font-size: 1.5rem;
+      margin-bottom: 4px;
+    }
+
+    .subtitle {
+      color: var(--text-tertiary);
+      font-size: 0.95rem;
+    }
+  }
+
+  ul {
+    list-style: none;
+    display: grid;
+    gap: 12px;
+
+    li {
+      position: relative;
+      padding-left: 28px;
+      color: var(--text-secondary);
+      line-height: 1.6;
+
+      &::before {
+        content: '';
+        position: absolute;
+        left: 0;
+        top: 0.55rem;
+        width: 10px;
+        height: 10px;
+        border-radius: 50%;
+        background: linear-gradient(135deg, var(--primary-color), var(--primary-hover));
+        box-shadow: 0 0 0 4px rgba(255, 69, 0, 0.12);
+      }
+    }
+  }
+}

--- a/src/app/components/story/key-facts/key-facts.component.ts
+++ b/src/app/components/story/key-facts/key-facts.component.ts
@@ -1,0 +1,17 @@
+import { Component, Input } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+@Component({
+  selector: 'app-key-facts',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './key-facts.component.html',
+  styleUrls: ['./key-facts.component.scss']
+})
+export class KeyFactsComponent {
+  @Input() summary: string[] | null = null;
+
+  get hasSummary(): boolean {
+    return !!this.summary && this.summary.length > 0;
+  }
+}

--- a/src/app/components/story/source-list/source-list.component.html
+++ b/src/app/components/story/source-list/source-list.component.html
@@ -1,0 +1,18 @@
+<section class="source-list" *ngIf="sources?.length">
+  <header>
+    <h2>Source Material</h2>
+    <p class="subtitle">Dig deeper with the original reporting</p>
+  </header>
+
+  <ul>
+    <li *ngFor="let source of sources; trackBy: trackByUrl">
+      <div class="source-details">
+        <span class="source-type" *ngIf="source.type">{{ source.type }}</span>
+        <a [href]="source.url" target="_blank" rel="noopener noreferrer">
+          {{ source.name }}
+        </a>
+      </div>
+      <p class="source-summary" *ngIf="source.summary">{{ source.summary }}</p>
+    </li>
+  </ul>
+</section>

--- a/src/app/components/story/source-list/source-list.component.scss
+++ b/src/app/components/story/source-list/source-list.component.scss
@@ -1,0 +1,69 @@
+.source-list {
+  background: var(--card-background);
+  border-radius: 16px;
+  padding: 24px;
+  box-shadow: var(--shadow);
+  border: 1px solid var(--border-color);
+  display: grid;
+  gap: 16px;
+
+  header {
+    h2 {
+      font-size: 1.5rem;
+      margin-bottom: 4px;
+    }
+
+    .subtitle {
+      color: var(--text-tertiary);
+      font-size: 0.95rem;
+    }
+  }
+
+  ul {
+    list-style: none;
+    display: grid;
+    gap: 20px;
+  }
+
+  li {
+    display: grid;
+    gap: 8px;
+    padding-bottom: 16px;
+    border-bottom: 1px solid rgba(229, 231, 235, 0.6);
+
+    &:last-child {
+      border-bottom: none;
+      padding-bottom: 0;
+    }
+  }
+
+  .source-details {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    align-items: center;
+
+    a {
+      font-weight: 600;
+      color: var(--primary-color);
+
+      &:hover {
+        color: var(--primary-hover);
+      }
+    }
+  }
+
+  .source-type {
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    padding: 4px 8px;
+    border-radius: 999px;
+    background: rgba(255, 69, 0, 0.12);
+    color: var(--primary-hover);
+  }
+
+  .source-summary {
+    color: var(--text-secondary);
+  }
+}

--- a/src/app/components/story/source-list/source-list.component.ts
+++ b/src/app/components/story/source-list/source-list.component.ts
@@ -1,0 +1,18 @@
+import { Component, Input } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { StorySource } from '../../../models/news.model';
+
+@Component({
+  selector: 'app-source-list',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './source-list.component.html',
+  styleUrls: ['./source-list.component.scss']
+})
+export class SourceListComponent {
+  @Input() sources: StorySource[] | null = null;
+
+  trackByUrl(_index: number, source: StorySource): string {
+    return source.url;
+  }
+}

--- a/src/app/components/story/story-detail/story-detail.component.html
+++ b/src/app/components/story/story-detail/story-detail.component.html
@@ -1,0 +1,40 @@
+<section class="story-detail" *ngIf="!loading && story; else loadingOrError">
+  <nav class="breadcrumb">
+    <a routerLink="/" aria-label="Back to campaign news">← Back to news feed</a>
+  </nav>
+
+  <header class="story-header">
+    <div class="meta">
+      <span class="source">{{ story.source }}</span>
+      <time [dateTime]="story.pubDate.toISOString()">{{ story.pubDate | date: 'longDate' }}</time>
+    </div>
+    <h1>{{ story.title }}</h1>
+    <p class="lede" *ngIf="story.content">{{ story.content }}</p>
+    <a
+      *ngIf="story.link"
+      class="external-cta"
+      [href]="story.link"
+      target="_blank"
+      rel="noopener noreferrer"
+    >
+      Read on Reddit
+    </a>
+  </header>
+
+  <div class="story-body">
+    <app-key-facts [summary]="story.summary"></app-key-facts>
+    <app-story-timeline [events]="story.timelineEvents"></app-story-timeline>
+    <app-source-list [sources]="story.sources"></app-source-list>
+  </div>
+</section>
+
+<ng-template #loadingOrError>
+  <div class="story-status" *ngIf="loading" role="status">
+    <div class="spinner"></div>
+    <p>Loading story details…</p>
+  </div>
+  <div class="story-status" *ngIf="!loading && error" role="alert">
+    <p>{{ error }}</p>
+    <a routerLink="/" class="return-link">Return to news feed</a>
+  </div>
+</ng-template>

--- a/src/app/components/story/story-detail/story-detail.component.scss
+++ b/src/app/components/story/story-detail/story-detail.component.scss
@@ -1,0 +1,116 @@
+.story-detail {
+  display: grid;
+  gap: 32px;
+  padding: 32px 0 64px;
+
+  .breadcrumb {
+    a {
+      color: var(--primary-color);
+      font-weight: 600;
+
+      &:hover {
+        color: var(--primary-hover);
+      }
+    }
+  }
+
+  .story-header {
+    background: var(--card-background);
+    border-radius: 18px;
+    padding: 32px;
+    box-shadow: var(--shadow-md);
+    border: 1px solid rgba(17, 24, 39, 0.08);
+    display: grid;
+    gap: 16px;
+
+    .meta {
+      display: flex;
+      flex-wrap: wrap;
+      align-items: center;
+      gap: 12px;
+      color: var(--text-tertiary);
+
+      .source {
+        font-weight: 700;
+        color: var(--primary-color);
+      }
+    }
+
+    h1 {
+      font-size: clamp(2rem, 4vw, 2.75rem);
+      line-height: 1.2;
+    }
+
+    .lede {
+      font-size: 1.1rem;
+      color: var(--text-secondary);
+      line-height: 1.6;
+    }
+
+    .external-cta {
+      justify-self: flex-start;
+      padding: 12px 20px;
+      border-radius: 999px;
+      background: linear-gradient(135deg, var(--primary-color), var(--primary-hover));
+      color: #fff;
+      font-weight: 600;
+      box-shadow: 0 10px 20px rgba(255, 69, 0, 0.15);
+      transition: transform 0.2s ease, box-shadow 0.2s ease;
+
+      &:hover {
+        transform: translateY(-2px);
+        box-shadow: 0 12px 24px rgba(255, 69, 0, 0.25);
+      }
+    }
+  }
+
+  .story-body {
+    display: grid;
+    gap: 24px;
+  }
+}
+
+.story-status {
+  display: grid;
+  justify-items: center;
+  gap: 16px;
+  padding: 64px 0;
+  color: var(--text-secondary);
+
+  .spinner {
+    width: 48px;
+    height: 48px;
+    border: 4px solid rgba(255, 69, 0, 0.2);
+    border-top-color: var(--primary-color);
+    border-radius: 50%;
+    animation: spin 0.8s linear infinite;
+  }
+
+  .return-link {
+    color: var(--primary-color);
+    font-weight: 600;
+  }
+}
+
+@keyframes spin {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@media (max-width: 768px) {
+  .story-detail {
+    padding: 24px 0 48px;
+
+    .story-header {
+      padding: 24px;
+    }
+
+    .story-body {
+      gap: 20px;
+    }
+  }
+}

--- a/src/app/components/story/story-detail/story-detail.component.ts
+++ b/src/app/components/story/story-detail/story-detail.component.ts
@@ -1,0 +1,88 @@
+import { Component, OnDestroy, OnInit, inject } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ActivatedRoute, RouterModule } from '@angular/router';
+import { Subject, of } from 'rxjs';
+import { switchMap, takeUntil, tap, catchError } from 'rxjs/operators';
+import { Meta, Title } from '@angular/platform-browser';
+
+import { NewsApiService } from '../../../services/news-api.service';
+import { StoryDetail } from '../../../models/news.model';
+import { KeyFactsComponent } from '../key-facts/key-facts.component';
+import { SourceListComponent } from '../source-list/source-list.component';
+import { StoryTimelineComponent } from '../story-timeline/story-timeline.component';
+
+@Component({
+  selector: 'app-story-detail',
+  standalone: true,
+  imports: [CommonModule, RouterModule, KeyFactsComponent, SourceListComponent, StoryTimelineComponent],
+  templateUrl: './story-detail.component.html',
+  styleUrls: ['./story-detail.component.scss']
+})
+export class StoryDetailComponent implements OnInit, OnDestroy {
+  story: StoryDetail | null = null;
+  loading = true;
+  error: string | null = null;
+
+  private readonly destroy$ = new Subject<void>();
+  private readonly meta = inject(Meta);
+  private readonly title = inject(Title);
+
+  constructor(private route: ActivatedRoute, private newsApi: NewsApiService) {}
+
+  ngOnInit(): void {
+    this.route.paramMap
+      .pipe(
+        takeUntil(this.destroy$),
+        switchMap(params => {
+          const id = params.get('id');
+          if (!id) {
+            this.error = 'Story identifier is missing.';
+            this.loading = false;
+            return of(null);
+          }
+
+          this.loading = true;
+          this.error = null;
+          return this.newsApi.getStoryDetail(id).pipe(
+            tap(detail => {
+              if (detail) {
+                this.updateMeta(detail);
+              }
+            }),
+            catchError(error => {
+              this.error = error.message ?? 'Unable to load this story right now.';
+              this.loading = false;
+              return of(null);
+            })
+          );
+        })
+      )
+      .subscribe(detail => {
+        this.loading = false;
+        if (detail) {
+          this.story = detail;
+        }
+      });
+  }
+
+  ngOnDestroy(): void {
+    this.destroy$.next();
+    this.destroy$.complete();
+  }
+
+  private updateMeta(detail: StoryDetail): void {
+    const summary = detail.summary?.[0] ?? detail.content;
+    const pageTitle = `${detail.title} | Trump 47 Campaign Tracker`;
+
+    this.title.setTitle(pageTitle);
+    this.meta.updateTag({ name: 'description', content: summary });
+    this.meta.updateTag({ name: 'og:title', content: pageTitle });
+    this.meta.updateTag({ name: 'og:description', content: summary });
+    if (detail.imageUrl) {
+      this.meta.updateTag({ name: 'og:image', content: detail.imageUrl });
+    }
+    this.meta.updateTag({ name: 'twitter:card', content: 'summary_large_image' });
+    this.meta.updateTag({ name: 'twitter:title', content: pageTitle });
+    this.meta.updateTag({ name: 'twitter:description', content: summary });
+  }
+}

--- a/src/app/components/story/story-timeline/story-timeline.component.html
+++ b/src/app/components/story/story-timeline/story-timeline.component.html
@@ -1,0 +1,17 @@
+<section class="story-timeline" *ngIf="events?.length">
+  <header>
+    <h2>Campaign Timeline</h2>
+    <p class="subtitle">Key developments related to this story</p>
+  </header>
+
+  <ol>
+    <li *ngFor="let event of events">
+      <div class="timeline-node"></div>
+      <div class="timeline-content">
+        <span class="event-date">{{ parseDate(event.date) | date:'MMMM d, y' }}</span>
+        <h3>{{ event.headline }}</h3>
+        <p *ngIf="event.description">{{ event.description }}</p>
+      </div>
+    </li>
+  </ol>
+</section>

--- a/src/app/components/story/story-timeline/story-timeline.component.scss
+++ b/src/app/components/story/story-timeline/story-timeline.component.scss
@@ -1,0 +1,86 @@
+.story-timeline {
+  background: var(--card-background);
+  border-radius: 16px;
+  padding: 24px;
+  box-shadow: var(--shadow);
+  border: 1px solid var(--border-color);
+  display: grid;
+  gap: 20px;
+
+  header {
+    h2 {
+      font-size: 1.5rem;
+      margin-bottom: 4px;
+    }
+
+    .subtitle {
+      color: var(--text-tertiary);
+      font-size: 0.95rem;
+    }
+  }
+
+  ol {
+    position: relative;
+    list-style: none;
+    margin: 0;
+    padding: 0;
+
+    &::before {
+      content: '';
+      position: absolute;
+      left: 16px;
+      top: 0;
+      bottom: 0;
+      width: 2px;
+      background: linear-gradient(180deg, rgba(255, 69, 0, 0.4), rgba(255, 69, 0, 0));
+    }
+  }
+
+  li {
+    position: relative;
+    display: flex;
+    gap: 24px;
+    padding-left: 48px;
+    margin-bottom: 24px;
+
+    &:last-child {
+      margin-bottom: 0;
+    }
+  }
+
+  .timeline-node {
+    position: absolute;
+    left: 8px;
+    top: 6px;
+    width: 16px;
+    height: 16px;
+    border-radius: 50%;
+    border: 4px solid var(--card-background);
+    background: linear-gradient(135deg, var(--primary-color), var(--primary-hover));
+    box-shadow: 0 0 0 4px rgba(255, 69, 0, 0.12);
+  }
+
+  .timeline-content {
+    background: rgba(249, 250, 251, 0.75);
+    border-radius: 12px;
+    padding: 16px 20px;
+    box-shadow: var(--shadow-sm);
+
+    .event-date {
+      font-size: 0.85rem;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      color: var(--text-tertiary);
+    }
+
+    h3 {
+      margin: 8px 0;
+      font-size: 1.15rem;
+    }
+
+    p {
+      margin: 0;
+      color: var(--text-secondary);
+    }
+  }
+}

--- a/src/app/components/story/story-timeline/story-timeline.component.ts
+++ b/src/app/components/story/story-timeline/story-timeline.component.ts
@@ -1,0 +1,18 @@
+import { Component, Input } from '@angular/core';
+import { CommonModule, DatePipe } from '@angular/common';
+import { TimelineEvent } from '../../../models/news.model';
+
+@Component({
+  selector: 'app-story-timeline',
+  standalone: true,
+  imports: [CommonModule, DatePipe],
+  templateUrl: './story-timeline.component.html',
+  styleUrls: ['./story-timeline.component.scss']
+})
+export class StoryTimelineComponent {
+  @Input() events: TimelineEvent[] | null = null;
+
+  parseDate(date: string): Date {
+    return new Date(date);
+  }
+}

--- a/src/app/models/news.model.ts
+++ b/src/app/models/news.model.ts
@@ -9,6 +9,25 @@ export interface NewsItem {
   imageUrl?: string;
 }
 
+export interface StorySource {
+  name: string;
+  url: string;
+  type?: string;
+  summary?: string;
+}
+
+export interface TimelineEvent {
+  date: string;
+  headline: string;
+  description?: string;
+}
+
+export interface StoryDetail extends NewsItem {
+  summary: string[];
+  sources: StorySource[];
+  timelineEvents: TimelineEvent[];
+}
+
 export interface NewsState {
   items: NewsItem[];
   loading: boolean;


### PR DESCRIPTION
## Summary
- add a story detail route that fetches enriched article data and updates per-page SEO metadata
- build reusable key facts, source list, and timeline components for story context
- update the news cards and application shell to support in-app navigation to detailed stories

## Testing
- npm run test -- --watch=false --browsers=ChromeHeadless *(fails: ChromeHeadless binary not available in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ea80f11598832691b4d128179c0e35