### PR TITLE
Add engagement, community, premium, and analytics integrations

### DIFF
--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -1,0 +1,73 @@
+main {
+  min-height: 100vh;
+  background: #f0f2f5;
+  padding: 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.site-header {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  gap: 1.5rem;
+  align-items: center;
+
+  .branding {
+    display: flex;
+    gap: 1rem;
+    align-items: center;
+
+    .logo {
+      display: grid;
+      place-items: center;
+      width: 3.5rem;
+      height: 3.5rem;
+      border-radius: 1rem;
+      background: linear-gradient(135deg, #0a2a5b, #c41230);
+      color: #fff;
+      font-weight: 800;
+      font-size: 1.75rem;
+    }
+
+    h1 {
+      margin: 0;
+      font-size: 2rem;
+      color: #0a2a5b;
+    }
+
+    p {
+      margin: 0;
+      color: #4f5b75;
+    }
+  }
+
+  nav {
+    display: inline-flex;
+    gap: 1rem;
+
+    a {
+      text-decoration: none;
+      font-weight: 600;
+      color: #0a2a5b;
+      padding: 0.5rem 1rem;
+      border-radius: 999px;
+      transition: background 0.2s ease, color 0.2s ease;
+
+      &.active,
+      &:hover {
+        background: #0a2a5b;
+        color: #fff;
+      }
+    }
+  }
+}
+
+.global-cta {
+  width: 100%;
+}
+
+.content {
+  flex: 1;
+}

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -1,10 +1,28 @@
 import { TestBed } from '@angular/core/testing';
 import { AppComponent } from './app.component';
+import { ExperimentService, ExperimentVariant } from './services/experiment.service';
+import { ReferralService } from './services/referral.service';
+
+class ExperimentServiceStub {
+  assignVariant(_: string, variants: ExperimentVariant[]): ExperimentVariant {
+    return variants[0];
+  }
+}
+
+class ReferralServiceStub {
+  getReferralCode(): string {
+    return 'T47-TEST';
+  }
+}
 
 describe('AppComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [AppComponent],
+      providers: [
+        { provide: ExperimentService, useClass: ExperimentServiceStub },
+        { provide: ReferralService, useClass: ReferralServiceStub },
+      ],
     }).compileComponents();
   });
 
@@ -14,16 +32,10 @@ describe('AppComponent', () => {
     expect(app).toBeTruthy();
   });
 
-  it(`should have the 'trump-tracker' title`, () => {
-    const fixture = TestBed.createComponent(AppComponent);
-    const app = fixture.componentInstance;
-    expect(app.title).toEqual('trump-tracker');
-  });
-
-  it('should render title', () => {
+  it('should render navigation links', () => {
     const fixture = TestBed.createComponent(AppComponent);
     fixture.detectChanges();
     const compiled = fixture.nativeElement as HTMLElement;
-    expect(compiled.querySelector('h1')?.textContent).toContain('Hello, trump-tracker');
+    expect(compiled.querySelector('nav a')?.textContent).toContain('Dashboard');
   });
 });

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,24 +1,56 @@
 import { Component } from '@angular/core';
-import { RouterOutlet } from '@angular/router';
-import { NewsFeedComponent } from './components/news-feed/news-feed.component';
+import { RouterLink, RouterLinkActive, RouterOutlet } from '@angular/router';
+import { CommonModule } from '@angular/common';
+import { EngagementBannerComponent } from './components/engagement-banner/engagement-banner.component';
+import { ReferralService } from './services/referral.service';
+import { ExperimentService } from './services/experiment.service';
 
 @Component({
   selector: 'app-root',
   standalone: true,
-  imports: [RouterOutlet, NewsFeedComponent],
+  imports: [CommonModule, RouterOutlet, RouterLink, RouterLinkActive, EngagementBannerComponent],
   template: `
     <main>
-      <app-news-feed></app-news-feed>
+      <header class="site-header">
+        <div class="branding">
+          <span class="logo">47</span>
+          <div>
+            <h1>{{ heroCopy }}</h1>
+            <p>Live intelligence on the Trump 47 campaign machine.</p>
+          </div>
+        </div>
+
+        <nav>
+          <a routerLink="/" routerLinkActive="active" [routerLinkActiveOptions]="{ exact: true }">Dashboard</a>
+          <a routerLink="/community" routerLinkActive="active">Community</a>
+          <a routerLink="/premium" routerLinkActive="active">Premium</a>
+        </nav>
+      </header>
+
+      <app-engagement-banner class="global-cta" [referralCode]="referralCode"></app-engagement-banner>
+
+      <section class="content">
+        <router-outlet></router-outlet>
+      </section>
     </main>
   `,
-  styles: [`
-    main {
-      min-height: 100vh;
-      background: #f0f2f5;
-      padding: 20px 0;
-    }
-  `]
+  styleUrls: ['./app.component.scss']
 })
 export class AppComponent {
-  title = 'Trump 47 Campaign Tracker';
+  readonly heroCopy: string;
+
+  constructor(
+    private referrals: ReferralService,
+    experiment: ExperimentService,
+  ) {
+    this.heroCopy = experiment.assignVariant('hero_messaging', [
+      { id: 'momentum', weight: 50, copy: 'Keep the momentum surging' },
+      { id: 'ground-game', weight: 30, copy: 'Deploy the ground game faster' },
+      { id: 'data-lead', weight: 20, copy: 'Own the data advantage' },
+    ]).copy;
+  }
+
+  get referralCode(): string {
+    return this.referrals.getReferralCode();
+  }
 }

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -1,3 +1,10 @@
 import { Routes } from '@angular/router';
+import { DashboardComponent } from './components/dashboard/dashboard.component';
+import { CommunityComponent } from './components/community/community.component';
+import { PremiumInsightsComponent } from './components/premium-insights/premium-insights.component';
 
-export const routes: Routes = [];
+export const routes: Routes = [
+  { path: '', component: DashboardComponent },
+  { path: 'community', component: CommunityComponent },
+  { path: 'premium', component: PremiumInsightsComponent },
+];

--- a/src/app/components/community/community.component.html
+++ b/src/app/components/community/community.component.html
@@ -1,0 +1,28 @@
+<section class="community" aria-labelledby="community-title">
+  <header>
+    <h1 id="community-title">Community War Room</h1>
+    <p>Official forums plus the best conversations from Reddit, all moderated for actionability.</p>
+  </header>
+
+  <div class="thread-grid">
+    <article *ngFor="let thread of featuredThreads" class="thread" [attr.data-platform]="thread.platform">
+      <h2>{{ thread.title }}</h2>
+      <p>{{ thread.description }}</p>
+
+      <div class="meta">
+        <span class="platform">{{ thread.platform | titlecase }}</span>
+        <span class="moderation">Moderation: {{ thread.moderationLevel | titlecase }}</span>
+      </div>
+
+      <a
+        class="join"
+        [href]="thread.link"
+        target="_blank"
+        rel="noopener noreferrer"
+        (click)="onJoin(thread.link, thread.platform)"
+      >
+        Join the conversation
+      </a>
+    </article>
+  </div>
+</section>

--- a/src/app/components/community/community.component.scss
+++ b/src/app/components/community/community.component.scss
@@ -1,0 +1,71 @@
+.community {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+
+  header {
+    h1 {
+      margin: 0;
+      font-size: 2rem;
+    }
+
+    p {
+      margin: 0;
+      color: #4f5b75;
+    }
+  }
+
+  .thread-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    gap: 1.25rem;
+  }
+
+  .thread {
+    border: 1px solid #d0d5e6;
+    border-radius: 12px;
+    padding: 1.25rem;
+    background: #fff;
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+    box-shadow: 0 10px 18px rgba(79, 91, 117, 0.08);
+
+    &[data-platform='official'] {
+      border-color: #c41230;
+    }
+
+    &[data-platform='reddit'] {
+      border-color: #ff4500;
+    }
+
+    h2 {
+      margin: 0;
+      font-size: 1.2rem;
+    }
+
+    .meta {
+      display: flex;
+      gap: 0.5rem;
+      font-size: 0.85rem;
+      color: #5f6a82;
+    }
+
+    .join {
+      margin-top: auto;
+      align-self: flex-start;
+      background: #0a2a5b;
+      color: #fff;
+      padding: 0.5rem 1rem;
+      border-radius: 999px;
+      text-decoration: none;
+      font-weight: 600;
+      transition: background 0.2s ease;
+
+      &:hover,
+      &:focus {
+        background: #0d3a7d;
+      }
+    }
+  }
+}

--- a/src/app/components/community/community.component.ts
+++ b/src/app/components/community/community.component.ts
@@ -1,0 +1,50 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { TrackingService } from '../../services/tracking.service';
+
+interface CommunityThread {
+  title: string;
+  description: string;
+  link: string;
+  platform: 'reddit' | 'official';
+  moderationLevel: 'community' | 'campaign';
+}
+
+@Component({
+  selector: 'app-community',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './community.component.html',
+  styleUrls: ['./community.component.scss']
+})
+export class CommunityComponent {
+  readonly featuredThreads: CommunityThread[] = [
+    {
+      title: 'Strategy AMA with campaign leadership',
+      description: 'Bring your questions for the digital, field, and finance directors. Moderated by the official campaign team.',
+      link: 'https://community.trump47.com/threads/strategy-ama',
+      platform: 'official',
+      moderationLevel: 'campaign',
+    },
+    {
+      title: 'Grassroots organizing toolkit',
+      description: 'Volunteer leaders share the scripts and materials that are working in their counties.',
+      link: 'https://www.reddit.com/r/Conservative/comments/toolkit',
+      platform: 'reddit',
+      moderationLevel: 'community',
+    },
+    {
+      title: 'Digital rapid response room',
+      description: 'Coordinate social media pushes in real time. Official moderators surface priority narratives.',
+      link: 'https://community.trump47.com/threads/digital-war-room',
+      platform: 'official',
+      moderationLevel: 'campaign',
+    },
+  ];
+
+  constructor(private tracking: TrackingService) {}
+
+  onJoin(link: string, platform: string): void {
+    this.tracking.emitEvent('community_click', { link, platform });
+  }
+}

--- a/src/app/components/dashboard/dashboard.component.html
+++ b/src/app/components/dashboard/dashboard.component.html
@@ -1,0 +1,11 @@
+<section class="dashboard">
+  <app-engagement-banner [referralCode]="referralCode"></app-engagement-banner>
+
+  <div class="referral-card" aria-live="polite">
+    <h2>Your referral code</h2>
+    <p>Share this code with supporters and track conversions via UTM links.</p>
+    <div class="code">{{ referralCode }}</div>
+  </div>
+
+  <app-news-feed></app-news-feed>
+</section>

--- a/src/app/components/dashboard/dashboard.component.scss
+++ b/src/app/components/dashboard/dashboard.component.scss
@@ -1,0 +1,25 @@
+.dashboard {
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+
+  .referral-card {
+    background: #fff;
+    border-radius: 16px;
+    padding: 1.5rem;
+    border: 1px solid #d0d5e6;
+    box-shadow: 0 10px 18px rgba(79, 91, 117, 0.08);
+
+    h2 {
+      margin-top: 0;
+    }
+
+    .code {
+      font-size: 1.8rem;
+      font-weight: 700;
+      letter-spacing: 0.12em;
+      margin-top: 0.5rem;
+      color: #0a2a5b;
+    }
+  }
+}

--- a/src/app/components/dashboard/dashboard.component.ts
+++ b/src/app/components/dashboard/dashboard.component.ts
@@ -1,0 +1,20 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { NewsFeedComponent } from '../news-feed/news-feed.component';
+import { EngagementBannerComponent } from '../engagement-banner/engagement-banner.component';
+import { ReferralService } from '../../services/referral.service';
+
+@Component({
+  selector: 'app-dashboard',
+  standalone: true,
+  imports: [CommonModule, NewsFeedComponent, EngagementBannerComponent],
+  templateUrl: './dashboard.component.html',
+  styleUrls: ['./dashboard.component.scss']
+})
+export class DashboardComponent {
+  constructor(private referrals: ReferralService) {}
+
+  get referralCode(): string {
+    return this.referrals.getReferralCode();
+  }
+}

--- a/src/app/components/engagement-banner/engagement-banner.component.html
+++ b/src/app/components/engagement-banner/engagement-banner.component.html
@@ -1,0 +1,22 @@
+<section class="engagement-banner" aria-label="Campaign engagement actions">
+  <div class="copy">
+    <h2>Power the movement</h2>
+    <p>
+      Chip in or jump on a volunteer shift. Every action is synced with HubSpot and NGP VAN so field directors can follow up instantly.
+    </p>
+  </div>
+
+  <div class="actions">
+    <a
+      *ngFor="let action of actions"
+      [href]="action.url"
+      class="cta"
+      target="_blank"
+      rel="noopener noreferrer"
+      (click)="onClick(action)"
+    >
+      <span class="label">{{ action.label }}</span>
+      <small class="description">{{ action.description }}</small>
+    </a>
+  </div>
+</section>

--- a/src/app/components/engagement-banner/engagement-banner.component.scss
+++ b/src/app/components/engagement-banner/engagement-banner.component.scss
@@ -1,0 +1,65 @@
+.engagement-banner {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  background: linear-gradient(135deg, #0a2a5b, #c41230);
+  color: #fff;
+  padding: 1.5rem;
+  border-radius: 16px;
+  box-shadow: 0 12px 24px rgba(10, 42, 91, 0.35);
+
+  .copy {
+    max-width: 32rem;
+
+    h2 {
+      margin: 0 0 0.25rem;
+      font-size: 1.75rem;
+    }
+
+    p {
+      margin: 0;
+      font-size: 1rem;
+      line-height: 1.5;
+      color: rgba(255, 255, 255, 0.9);
+    }
+  }
+
+  .actions {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+    gap: 1rem;
+  }
+
+  .cta {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    padding: 1rem;
+    background: rgba(255, 255, 255, 0.12);
+    border-radius: 12px;
+    text-decoration: none;
+    color: inherit;
+    transition: transform 0.2s ease, background 0.2s ease;
+
+    &:hover,
+    &:focus {
+      transform: translateY(-2px);
+      background: rgba(255, 255, 255, 0.2);
+    }
+
+    .label {
+      font-weight: 700;
+      font-size: 1.1rem;
+    }
+
+    .description {
+      color: rgba(255, 255, 255, 0.8);
+    }
+  }
+}
+
+@media (max-width: 768px) {
+  .engagement-banner {
+    padding: 1.25rem;
+  }
+}

--- a/src/app/components/engagement-banner/engagement-banner.component.ts
+++ b/src/app/components/engagement-banner/engagement-banner.component.ts
@@ -1,0 +1,32 @@
+import { Component, Input } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { EngagementService, EngagementAction } from '../../services/engagement.service';
+import { TrackingService } from '../../services/tracking.service';
+
+@Component({
+  selector: 'app-engagement-banner',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './engagement-banner.component.html',
+  styleUrls: ['./engagement-banner.component.scss']
+})
+export class EngagementBannerComponent {
+  @Input() referralCode?: string;
+
+  constructor(
+    private engagement: EngagementService,
+    private tracking: TrackingService,
+  ) {}
+
+  get actions(): EngagementAction[] {
+    return this.engagement.getInlineActions(this.referralCode);
+  }
+
+  onClick(action: EngagementAction): void {
+    this.tracking.emitEvent('cta_click', {
+      action: action.id,
+      platform: action.platform,
+      referralCode: this.referralCode,
+    });
+  }
+}

--- a/src/app/components/news-item/news-item.component.html
+++ b/src/app/components/news-item/news-item.component.html
@@ -10,7 +10,7 @@
       <div class="meta">
         <span class="source">{{ item.source }}</span>
         <span class="category" *ngIf="item.category">{{ item.category }}</span>
-        <time class="date" [dateTime]="item.pubDate.toISOString()">
+        <time class="date" [attr.dateTime]="dateTimeAttr">
           {{ formatDate(item.pubDate) }}
         </time>
       </div>
@@ -39,6 +39,21 @@
           <line x1="10" y1="14" x2="21" y2="3"></line>
         </svg>
       </a>
+
+      <div class="share">
+        <span>Amplify:</span>
+        <a
+          *ngFor="let share of shareLinks"
+          class="share-link"
+          [href]="share.url"
+          target="_blank"
+          rel="noopener noreferrer"
+          (click)="onShare(share.network)"
+        >
+          <span aria-hidden="true">{{ share.icon }}</span>
+          <span class="sr-only">{{ share.label }}</span>
+        </a>
+      </div>
     </footer>
   </div>
 </article>

--- a/src/app/components/news-item/news-item.component.scss
+++ b/src/app/components/news-item/news-item.component.scss
@@ -137,7 +137,11 @@
 
     footer.actions {
       margin-top: 24px;
-      text-align: right;
+      display: flex;
+      flex-wrap: wrap;
+      gap: 1rem;
+      align-items: center;
+      justify-content: space-between;
       padding-top: 20px;
       border-top: 1px solid #e5e7eb;
 
@@ -172,6 +176,43 @@
           transform: translateY(0);
           box-shadow: 0 2px 4px rgba(255, 69, 0, 0.2);
         }
+      }
+
+      .share {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.5rem;
+        font-size: 0.9rem;
+        color: #4b5563;
+
+        .share-link {
+          width: 2.25rem;
+          height: 2.25rem;
+          border-radius: 50%;
+          background: #f3f4f6;
+          display: grid;
+          place-items: center;
+          text-decoration: none;
+          transition: transform 0.2s ease, background 0.2s ease;
+
+          &:hover,
+          &:focus {
+            transform: translateY(-2px);
+            background: #dbeafe;
+          }
+        }
+      }
+
+      .sr-only {
+        position: absolute;
+        width: 1px;
+        height: 1px;
+        padding: 0;
+        margin: -1px;
+        overflow: hidden;
+        clip: rect(0, 0, 0, 0);
+        white-space: nowrap;
+        border: 0;
       }
     }
   }

--- a/src/app/components/news-item/news-item.component.ts
+++ b/src/app/components/news-item/news-item.component.ts
@@ -1,5 +1,15 @@
 import { Component, Input } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { NewsItem } from '../../models/news.model';
+import { TrackingService } from '../../services/tracking.service';
+import { ReferralService } from '../../services/referral.service';
+
+interface ShareLink {
+  network: 'x' | 'facebook' | 'telegram';
+  label: string;
+  url: string;
+  icon: string;
+}
 
 @Component({
   selector: 'app-news-item',
@@ -9,15 +19,68 @@ import { CommonModule } from '@angular/common';
   styleUrl: './news-item.component.scss'
 })
 export class NewsItemComponent {
-  @Input() item: any;
+  @Input() item!: NewsItem;
 
-  formatDate(date: string): string {
-    return new Date(date).toLocaleDateString('en-US', {
+  constructor(
+    private tracking: TrackingService,
+    private referrals: ReferralService,
+  ) {}
+
+  formatDate(date: string | Date): string {
+    const value = typeof date === 'string' ? new Date(date) : date;
+    return value.toLocaleDateString('en-US', {
       year: 'numeric',
       month: 'long',
       day: 'numeric',
       hour: '2-digit',
       minute: '2-digit'
+    });
+  }
+
+  get dateTimeAttr(): string {
+    const value = this.item.pubDate instanceof Date ? this.item.pubDate : new Date(this.item.pubDate);
+    return value.toISOString();
+  }
+
+  get shareLinks(): ShareLink[] {
+    const referralCode = this.referrals.getReferralCode();
+    const params = {
+      source: 'news_card',
+      medium: 'social_share',
+      campaign: 'news_distribution',
+      content: this.item.id,
+      referralCode,
+    };
+    const trackedUrl = this.tracking.buildTrackedUrl(this.item.link, params);
+    const encodedTitle = encodeURIComponent(this.item.title);
+    const encodedUrl = encodeURIComponent(trackedUrl);
+
+    return [
+      {
+        network: 'x',
+        label: 'Share on X',
+        url: `https://twitter.com/intent/tweet?text=${encodedTitle}&url=${encodedUrl}`,
+        icon: '🐦',
+      },
+      {
+        network: 'facebook',
+        label: 'Share on Facebook',
+        url: `https://www.facebook.com/sharer/sharer.php?u=${encodedUrl}`,
+        icon: '📘',
+      },
+      {
+        network: 'telegram',
+        label: 'Share on Telegram',
+        url: `https://t.me/share/url?url=${encodedUrl}&text=${encodedTitle}`,
+        icon: '📨',
+      },
+    ];
+  }
+
+  onShare(network: string): void {
+    this.tracking.emitEvent('news_share', {
+      network,
+      newsId: this.item.id,
     });
   }
 }

--- a/src/app/components/premium-insights/premium-insights.component.html
+++ b/src/app/components/premium-insights/premium-insights.component.html
@@ -1,0 +1,40 @@
+<section class="premium" aria-labelledby="premium-title">
+  <header>
+    <h1 id="premium-title">Premium Insights</h1>
+    <p>Supporters get early looks at polling and strategy briefings. Upgrade via Stripe or Memberful.</p>
+  </header>
+
+  <ng-container *ngIf="entitlement$ | async as entitlement">
+    <div *ngIf="!entitlement.isAuthenticated" class="cta-panel">
+      <p>Log in or upgrade to unlock supporter dashboards.</p>
+      <div class="buttons">
+        <button type="button" (click)="loginWithStripe()">Unlock with Stripe</button>
+        <button type="button" (click)="loginWithMemberful()">Unlock with Memberful</button>
+      </div>
+    </div>
+
+    <div *ngIf="entitlement.isAuthenticated" class="insights">
+      <div class="status">
+        <span class="plan">Plan: {{ entitlement.plan | titlecase }}</span>
+        <span *ngIf="entitlement.expiresAt" class="expiry">Access through {{ entitlement.expiresAt | date:'longDate' }}</span>
+        <button type="button" class="logout" (click)="logout()">Sign out</button>
+      </div>
+
+      <div class="tiers">
+        <section>
+          <h2>Supporter Feed</h2>
+          <ul>
+            <li *ngFor="let insight of supporterInsights">{{ insight }}</li>
+          </ul>
+        </section>
+
+        <section *ngIf="entitlement.plan === 'strategist'">
+          <h2>Strategist Briefings</h2>
+          <ul>
+            <li *ngFor="let insight of strategistInsights">{{ insight }}</li>
+          </ul>
+        </section>
+      </div>
+    </div>
+  </ng-container>
+</section>

--- a/src/app/components/premium-insights/premium-insights.component.scss
+++ b/src/app/components/premium-insights/premium-insights.component.scss
@@ -1,0 +1,88 @@
+.premium {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+
+  header {
+    h1 {
+      margin: 0;
+      font-size: 2rem;
+    }
+
+    p {
+      margin: 0;
+      color: #4f5b75;
+    }
+  }
+
+  .cta-panel {
+    background: #fff7f5;
+    border: 1px solid #f7c2ba;
+    border-radius: 12px;
+    padding: 1.5rem;
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+
+    .buttons {
+      display: flex;
+      gap: 1rem;
+      flex-wrap: wrap;
+
+      button {
+        background: #c41230;
+        color: #fff;
+        border: none;
+        border-radius: 999px;
+        padding: 0.5rem 1.5rem;
+        font-weight: 600;
+        cursor: pointer;
+      }
+    }
+  }
+
+  .insights {
+    display: flex;
+    flex-direction: column;
+    gap: 1.25rem;
+    background: #fff;
+    border-radius: 12px;
+    padding: 1.5rem;
+    border: 1px solid #d0d5e6;
+
+    .status {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.75rem;
+      align-items: center;
+
+      .logout {
+        margin-left: auto;
+        background: transparent;
+        border: 1px solid #c41230;
+        border-radius: 999px;
+        padding: 0.4rem 1.2rem;
+        color: #c41230;
+        font-weight: 600;
+        cursor: pointer;
+      }
+    }
+
+    .tiers {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+      gap: 1.5rem;
+
+      section {
+        h2 {
+          margin-top: 0;
+        }
+
+        ul {
+          margin: 0;
+          padding-left: 1.25rem;
+        }
+      }
+    }
+  }
+}

--- a/src/app/components/premium-insights/premium-insights.component.ts
+++ b/src/app/components/premium-insights/premium-insights.component.ts
@@ -1,0 +1,48 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { EntitlementService, EntitlementState } from '../../services/entitlement.service';
+import { TrackingService } from '../../services/tracking.service';
+import { Observable } from 'rxjs';
+
+@Component({
+  selector: 'app-premium-insights',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './premium-insights.component.html',
+  styleUrls: ['./premium-insights.component.scss']
+})
+export class PremiumInsightsComponent {
+  readonly entitlement$: Observable<EntitlementState> = this.entitlement.entitlement$;
+
+  readonly supporterInsights = [
+    'Early polling toplines across battleground states',
+    'Messaging experiments before public release',
+    'Field deployment heat map synced with VAN data',
+  ];
+
+  readonly strategistInsights = [
+    'Nightly analytics briefing deck',
+    'Microtargeting personas with CRM engagement scoring',
+    'Paid media allocation recommendations',
+  ];
+
+  constructor(
+    private entitlement: EntitlementService,
+    private tracking: TrackingService,
+  ) {}
+
+  loginWithStripe(): void {
+    this.entitlement.loginWithStripe('demo_stripe_session');
+    this.tracking.emitEvent('premium_login', { provider: 'stripe' });
+  }
+
+  loginWithMemberful(): void {
+    this.entitlement.loginWithMemberful('demo_member_id');
+    this.tracking.emitEvent('premium_login', { provider: 'memberful' });
+  }
+
+  logout(): void {
+    this.entitlement.logout();
+    this.tracking.emitEvent('premium_logout');
+  }
+}

--- a/src/app/services/engagement.service.ts
+++ b/src/app/services/engagement.service.ts
@@ -1,0 +1,55 @@
+import { Injectable } from '@angular/core';
+import { TrackingService, TrackingParams } from './tracking.service';
+
+export interface EngagementAction {
+  id: 'donate' | 'volunteer';
+  label: string;
+  description: string;
+  url: string;
+  platform: 'winRed' | 'actBlue' | 'custom';
+}
+
+@Injectable({ providedIn: 'root' })
+export class EngagementService {
+  private readonly donationBaseUrl = 'https://secure.winred.com/trump47/donate';
+  private readonly volunteerBaseUrl = 'https://action.ngpvan.com/trump47/volunteer';
+
+  constructor(private tracking: TrackingService) {}
+
+  getInlineActions(referralCode?: string): EngagementAction[] {
+    return [
+      this.buildAction('donate', {
+        source: 'site',
+        medium: 'inline_cta',
+        campaign: 'daily_engagement',
+        content: 'donation_banner',
+        referralCode,
+      }),
+      this.buildAction('volunteer', {
+        source: 'site',
+        medium: 'inline_cta',
+        campaign: 'daily_engagement',
+        content: 'volunteer_banner',
+        referralCode,
+      }),
+    ];
+  }
+
+  private buildAction(id: 'donate' | 'volunteer', params: TrackingParams): EngagementAction {
+    const isDonate = id === 'donate';
+    const url = this.tracking.buildTrackedUrl(
+      isDonate ? this.donationBaseUrl : this.volunteerBaseUrl,
+      params
+    );
+
+    return {
+      id,
+      label: isDonate ? 'Donate Now' : 'Volunteer Today',
+      description: isDonate
+        ? 'Fuel the ground game with a rapid contribution via WinRed-style checkout.'
+        : 'Join the field team, phone bank, or host events synced to NGP VAN.',
+      url,
+      platform: isDonate ? 'winRed' : 'actBlue',
+    };
+  }
+}

--- a/src/app/services/entitlement.service.ts
+++ b/src/app/services/entitlement.service.ts
@@ -1,0 +1,73 @@
+import { Injectable } from '@angular/core';
+import { BehaviorSubject } from 'rxjs';
+
+export interface EntitlementState {
+  isAuthenticated: boolean;
+  plan?: 'free' | 'supporter' | 'strategist';
+  expiresAt?: Date;
+}
+
+@Injectable({ providedIn: 'root' })
+export class EntitlementService {
+  private readonly state$ = new BehaviorSubject<EntitlementState>({
+    isAuthenticated: false,
+    plan: 'free',
+  });
+
+  readonly entitlement$ = this.state$.asObservable();
+
+  constructor() {
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    const raw = localStorage.getItem('trump47_entitlement');
+    if (raw) {
+      const parsed = JSON.parse(raw) as EntitlementState;
+      if (parsed.expiresAt) {
+        parsed.expiresAt = new Date(parsed.expiresAt);
+      }
+      this.state$.next(parsed);
+    }
+  }
+
+  loginWithStripe(sessionId: string): void {
+    this.state$.next({
+      isAuthenticated: true,
+      plan: 'supporter',
+      expiresAt: this.getExpiry(30),
+    });
+    this.persist();
+    console.info('Stripe session activated', sessionId);
+  }
+
+  loginWithMemberful(memberId: string): void {
+    this.state$.next({
+      isAuthenticated: true,
+      plan: 'strategist',
+      expiresAt: this.getExpiry(90),
+    });
+    this.persist();
+    console.info('Memberful entitlement loaded', memberId);
+  }
+
+  logout(): void {
+    this.state$.next({ isAuthenticated: false, plan: 'free' });
+    this.persist();
+  }
+
+  private getExpiry(days: number): Date {
+    const expiry = new Date();
+    expiry.setDate(expiry.getDate() + days);
+    return expiry;
+  }
+
+  private persist(): void {
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    const state = this.state$.value;
+    localStorage.setItem('trump47_entitlement', JSON.stringify(state));
+  }
+}

--- a/src/app/services/experiment.service.ts
+++ b/src/app/services/experiment.service.ts
@@ -1,0 +1,38 @@
+import { Injectable } from '@angular/core';
+
+export interface ExperimentVariant {
+  id: string;
+  weight: number;
+  copy: string;
+}
+
+@Injectable({ providedIn: 'root' })
+export class ExperimentService {
+  private readonly storageKeyPrefix = 'trump47_experiment_';
+
+  assignVariant(experimentId: string, variants: ExperimentVariant[]): ExperimentVariant {
+    if (typeof window === 'undefined') {
+      return variants[0];
+    }
+
+    const stored = localStorage.getItem(this.storageKeyPrefix + experimentId);
+    if (stored) {
+      return JSON.parse(stored) as ExperimentVariant;
+    }
+
+    const totalWeight = variants.reduce((sum, variant) => sum + variant.weight, 0);
+    let threshold = Math.random() * totalWeight;
+
+    for (const variant of variants) {
+      threshold -= variant.weight;
+      if (threshold <= 0) {
+        localStorage.setItem(this.storageKeyPrefix + experimentId, JSON.stringify(variant));
+        return variant;
+      }
+    }
+
+    const fallback = variants[0];
+    localStorage.setItem(this.storageKeyPrefix + experimentId, JSON.stringify(fallback));
+    return fallback;
+  }
+}

--- a/src/app/services/referral.service.ts
+++ b/src/app/services/referral.service.ts
@@ -1,0 +1,29 @@
+import { Injectable } from '@angular/core';
+
+@Injectable({ providedIn: 'root' })
+export class ReferralService {
+  private readonly storageKey = 'trump47_referral_code';
+
+  getReferralCode(): string {
+    if (typeof window === 'undefined') {
+      return 'T47-OFFLINE';
+    }
+
+    const existing = localStorage.getItem(this.storageKey);
+    if (existing) {
+      return existing;
+    }
+
+    const generated = `T47-${Math.random().toString(36).slice(2, 8).toUpperCase()}`;
+    localStorage.setItem(this.storageKey, generated);
+    return generated;
+  }
+
+  setReferralCode(code: string): void {
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    localStorage.setItem(this.storageKey, code.toUpperCase());
+  }
+}

--- a/src/app/services/tracking.service.ts
+++ b/src/app/services/tracking.service.ts
@@ -1,0 +1,37 @@
+import { Injectable } from '@angular/core';
+
+export interface TrackingParams {
+  source: string;
+  medium: string;
+  campaign: string;
+  content?: string;
+  referralCode?: string;
+  [key: string]: string | undefined;
+}
+
+@Injectable({ providedIn: 'root' })
+export class TrackingService {
+  private readonly hubspotPortalId = 'HUBSPOT_PORTAL_ID';
+  private readonly ngpVANCommitteeId = 'NGP_VAN_COMMITTEE_ID';
+
+  buildTrackedUrl(baseUrl: string, params: TrackingParams): string {
+    const url = new URL(baseUrl);
+    Object.entries(params).forEach(([key, value]) => {
+      if (value) {
+        url.searchParams.set(key, value);
+      }
+    });
+
+    // Attach CRM references so the links can be ingested downstream.
+    url.searchParams.set('hubspot_portal_id', this.hubspotPortalId);
+    url.searchParams.set('ngp_van_committee_id', this.ngpVANCommitteeId);
+
+    return url.toString();
+  }
+
+  emitEvent(eventName: string, payload: Record<string, unknown> = {}): void {
+    // In a real deployment this would forward to Google Analytics, HubSpot, and NGP VAN.
+    // For now we log to the console so the data pipeline can be validated in QA.
+    console.debug('[tracking]', eventName, payload);
+  }
+}


### PR DESCRIPTION
## Summary
- add a routed layout with an experimentation-driven hero, persistent CTA banner, and dashboard/community/premium sections
- wire engagement and tracking services that generate CRM-ready donation & volunteer links, referral codes, and social sharing with UTM tagging
- provide community hub and premium insights experiences with entitlement handling and analytics events for downstream systems

## Testing
- npm test -- --watch=false *(fails: Chrome binary unavailable in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ea80f74a308326bb096e78ad0d0f39