### PR TITLE
Add timeline and topic routes with curated metadata backend

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -46,8 +46,8 @@
                 },
                 {
                   "type": "anyComponentStyle",
-                  "maximumWarning": "2kB",
-                  "maximumError": "4kB"
+                  "maximumWarning": "8kB",
+                  "maximumError": "12kB"
                 }
               ],
               "outputHashing": "all"

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@angular/animations": "^18.0.0",
+        "@angular/cdk": "^18.2.14",
         "@angular/common": "^18.0.0",
         "@angular/compiler": "^18.0.0",
         "@angular/core": "^18.0.0",
@@ -16,6 +17,11 @@
         "@angular/platform-browser": "^18.0.0",
         "@angular/platform-browser-dynamic": "^18.0.0",
         "@angular/router": "^18.0.0",
+        "@swimlane/ngx-charts": "^23.0.1",
+        "cors": "^2.8.5",
+        "d3": "^7.9.0",
+        "express": "^5.1.0",
+        "marked": "^16.4.0",
         "rss-parser": "^3.13.0",
         "rxjs": "~7.8.0",
         "tslib": "^2.3.0",
@@ -350,6 +356,23 @@
         "tailwindcss": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@angular/cdk": {
+      "version": "18.2.14",
+      "resolved": "https://registry.npmjs.org/@angular/cdk/-/cdk-18.2.14.tgz",
+      "integrity": "sha512-vDyOh1lwjfVk9OqoroZAP8pf3xxKUvyl+TVR8nJxL4c5fOfUFkD7l94HaanqKSRwJcI2xiztuu92IVoHn8T33Q==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "optionalDependencies": {
+        "parse5": "^7.1.2"
+      },
+      "peerDependencies": {
+        "@angular/common": "^18.0.0 || ^19.0.0",
+        "@angular/core": "^18.0.0 || ^19.0.0",
+        "rxjs": "^6.5.3 || ^7.4.0"
       }
     },
     "node_modules/@angular/cli": {
@@ -4238,6 +4261,39 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@swimlane/ngx-charts": {
+      "version": "23.0.1",
+      "resolved": "https://registry.npmjs.org/@swimlane/ngx-charts/-/ngx-charts-23.0.1.tgz",
+      "integrity": "sha512-mvdJTjBjUNoDj/R3AopYyVkVNrv0Zsrlh71CIQLVhBOs6PSV1mT3o7ukBFu8ct4w38wTfiGr8G+twHiYM1TEKA==",
+      "license": "MIT",
+      "dependencies": {
+        "d3-array": "^3.2.0",
+        "d3-brush": "^3.0.0",
+        "d3-color": "^3.1.0",
+        "d3-ease": "^3.0.1",
+        "d3-format": "^3.1.0",
+        "d3-hierarchy": "^3.1.2",
+        "d3-interpolate": "^3.0.1",
+        "d3-sankey": "^0.12.3",
+        "d3-scale": "^4.0.2",
+        "d3-selection": "^3.0.0",
+        "d3-shape": "^3.2.0",
+        "d3-time-format": "^4.1.0",
+        "d3-transition": "^3.0.1",
+        "gradient-path": "^2.3.0",
+        "tslib": "^2.3.1"
+      },
+      "peerDependencies": {
+        "@angular/animations": "18.x || 19.x || 20.x",
+        "@angular/cdk": "18.x || 19.x || 20.x",
+        "@angular/common": "18.x || 19.x || 20.x",
+        "@angular/core": "18.x || 19.x || 20.x",
+        "@angular/forms": "18.x || 19.x || 20.x",
+        "@angular/platform-browser": "18.x || 19.x || 20.x",
+        "@angular/platform-browser-dynamic": "18.x || 19.x || 20.x",
+        "rxjs": "7.x"
+      }
+    },
     "node_modules/@tufjs/canonical-json": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@tufjs/canonical-json/-/canonical-json-2.0.0.tgz",
@@ -4524,6 +4580,12 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/tinycolor2": {
+      "version": "1.4.6",
+      "resolved": "https://registry.npmjs.org/@types/tinycolor2/-/tinycolor2-1.4.6.tgz",
+      "integrity": "sha512-iEN8J0BoMnsWBqjVbWH/c0G0Hh7O21lpR2/+PrvAVgWdzL7eexIFm4JN/Wn10PTcmNdtS6U67r499mlWMXOxNw==",
+      "license": "MIT"
     },
     "node_modules/@types/wrap-ansi": {
       "version": "3.0.0",
@@ -5358,7 +5420,6 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
       "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -5446,7 +5507,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.1.tgz",
       "integrity": "sha512-BhYE+WDaywFg2TBWYNXAE+8B1ATnThNBqXHP5nQu0jWJdVvY2hvkpyB3qOmtmDePiS5/BDQ8wASEWGMWRG148g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -5460,7 +5520,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.3.tgz",
       "integrity": "sha512-YTd+6wGlNlPxSuri7Y6X8tY2dmm12UMH66RpKMhiX6rsk5wXXnYgbUcOt8kiS31/AjfoTOvCsE+w8nZQLQnzHA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.1",
@@ -5896,10 +5955,9 @@
       "license": "MIT"
     },
     "node_modules/content-disposition": {
-      "version": "0.5.4",
-      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
-      "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
-      "dev": true,
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.0.tgz",
+      "integrity": "sha512-Au9nRL8VNUut/XSzbQA38+M78dzP4D+eqg3gfJHMIHHYa3bg067xj1KxMUWj+VULbiZMowKngFFbKczUrNJ1mg==",
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "5.2.1"
@@ -5912,7 +5970,6 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
       "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -5929,18 +5986,19 @@
       "version": "0.7.2",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
       "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
     },
     "node_modules/cookie-signature": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
-      "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
-      "dev": true,
-      "license": "MIT"
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
     },
     "node_modules/copy-anything": {
       "version": "2.0.6",
@@ -6005,7 +6063,6 @@
       "version": "2.8.5",
       "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
       "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "object-assign": "^4",
@@ -6176,6 +6233,468 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/d3": {
+      "version": "7.9.0",
+      "resolved": "https://registry.npmjs.org/d3/-/d3-7.9.0.tgz",
+      "integrity": "sha512-e1U46jVP+w7Iut8Jt8ri1YsPOvFpg46k+K8TpCb0P+zjCkjkPnV7WzfDJzMHy1LnA+wj5pLT1wjO901gLXeEhA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "3",
+        "d3-axis": "3",
+        "d3-brush": "3",
+        "d3-chord": "3",
+        "d3-color": "3",
+        "d3-contour": "4",
+        "d3-delaunay": "6",
+        "d3-dispatch": "3",
+        "d3-drag": "3",
+        "d3-dsv": "3",
+        "d3-ease": "3",
+        "d3-fetch": "3",
+        "d3-force": "3",
+        "d3-format": "3",
+        "d3-geo": "3",
+        "d3-hierarchy": "3",
+        "d3-interpolate": "3",
+        "d3-path": "3",
+        "d3-polygon": "3",
+        "d3-quadtree": "3",
+        "d3-random": "3",
+        "d3-scale": "4",
+        "d3-scale-chromatic": "3",
+        "d3-selection": "3",
+        "d3-shape": "3",
+        "d3-time": "3",
+        "d3-time-format": "4",
+        "d3-timer": "3",
+        "d3-transition": "3",
+        "d3-zoom": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-axis": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-axis/-/d3-axis-3.0.0.tgz",
+      "integrity": "sha512-IH5tgjV4jE/GhHkRV0HiVYPDtvfjHQlQfJHs0usq7M30XcSBvOotpmH1IgkcXsO/5gEQZD43B//fc7SRT5S+xw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-brush": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-brush/-/d3-brush-3.0.0.tgz",
+      "integrity": "sha512-ALnjWlVYkXsVIGlOsuWH1+3udkYFI48Ljihfnh8FZPF2QS9o+PzGLBslO0PjzVoHLZ2KCVgAM8NVkXPJB2aNnQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-selection": "3",
+        "d3-transition": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-chord": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-chord/-/d3-chord-3.0.1.tgz",
+      "integrity": "sha512-VE5S6TNa+j8msksl7HwjxMHDM2yNK3XCkusIlpX5kwauBfXuyLAtNg9jCp/iHH61tgI4sb6R/EIMWCqEIdjT/g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-contour": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-contour/-/d3-contour-4.0.2.tgz",
+      "integrity": "sha512-4EzFTRIikzs47RGmdxbeUvLWtGedDUNkTcmzoeyg4sP/dvCexO47AaQL7VKy/gul85TOxw+IBgA8US2xwbToNA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-delaunay": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
+      "integrity": "sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A==",
+      "license": "ISC",
+      "dependencies": {
+        "delaunator": "5"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dispatch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-3.0.1.tgz",
+      "integrity": "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-drag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-3.0.0.tgz",
+      "integrity": "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-selection": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dsv": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dsv/-/d3-dsv-3.0.1.tgz",
+      "integrity": "sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q==",
+      "license": "ISC",
+      "dependencies": {
+        "commander": "7",
+        "iconv-lite": "0.6",
+        "rw": "1"
+      },
+      "bin": {
+        "csv2json": "bin/dsv2json.js",
+        "csv2tsv": "bin/dsv2dsv.js",
+        "dsv2dsv": "bin/dsv2dsv.js",
+        "dsv2json": "bin/dsv2json.js",
+        "json2csv": "bin/json2dsv.js",
+        "json2dsv": "bin/json2dsv.js",
+        "json2tsv": "bin/json2dsv.js",
+        "tsv2csv": "bin/dsv2dsv.js",
+        "tsv2json": "bin/dsv2json.js"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dsv/node_modules/commander": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/d3-dsv/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-fetch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-fetch/-/d3-fetch-3.0.1.tgz",
+      "integrity": "sha512-kpkQIM20n3oLVBKGg6oHrUchHM3xODkTzjMoj7aWQFq5QEM+R6E4WkzT5+tojDY7yjez8KgCBRoj4aEr99Fdqw==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dsv": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-force": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-force/-/d3-force-3.0.0.tgz",
+      "integrity": "sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-quadtree": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.0.tgz",
+      "integrity": "sha512-YyUI6AEuY/Wpt8KWLgZHsIU86atmikuoOmCfommt0LYHiQSPjvX2AcFc38PX0CBpr2RCyZhjex+NS/LPOv6YqA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-geo": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-3.1.1.tgz",
+      "integrity": "sha512-637ln3gXKXOwhalDzinUgY83KzNWZRKbYubaG+fGVuc/dxO64RRljtCTnf5ecMyE1RIdtqpkVcq0IbtU2S8j2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.5.0 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-hierarchy": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-hierarchy/-/d3-hierarchy-3.1.2.tgz",
+      "integrity": "sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-polygon": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-polygon/-/d3-polygon-3.0.1.tgz",
+      "integrity": "sha512-3vbA7vXYwfe1SYhED++fPUQlWSYTTGmFmQiany/gdbiWgU/iEyQzyymwL9SkJjFFuCS4902BSzewVGsHHmHtXg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-quadtree": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-3.0.1.tgz",
+      "integrity": "sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-random": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-random/-/d3-random-3.0.1.tgz",
+      "integrity": "sha512-FXMe9GfxTxqd5D6jFsQ+DJ8BJS4E/fT5mqqdjovykEB2oFbTMDVdg1MGFxfQW+FBOGoB++k8swBrgwSHT1cUXQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-sankey": {
+      "version": "0.12.3",
+      "resolved": "https://registry.npmjs.org/d3-sankey/-/d3-sankey-0.12.3.tgz",
+      "integrity": "sha512-nQhsBRmM19Ax5xEIPLMY9ZmJ/cDvd1BG3UVvt5h3WRxKg5zGRbvnteTyWAbzeSvlh3tW7ZEmq4VwR5mB3tutmQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-array": "1 - 2",
+        "d3-shape": "^1.2.0"
+      }
+    },
+    "node_modules/d3-sankey/node_modules/d3-array": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.12.1.tgz",
+      "integrity": "sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "internmap": "^1.0.0"
+      }
+    },
+    "node_modules/d3-sankey/node_modules/d3-path": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-1.0.9.tgz",
+      "integrity": "sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/d3-sankey/node_modules/d3-shape": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-1.3.7.tgz",
+      "integrity": "sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-path": "1"
+      }
+    },
+    "node_modules/d3-sankey/node_modules/internmap": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-1.0.1.tgz",
+      "integrity": "sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw==",
+      "license": "ISC"
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale-chromatic": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
+      "integrity": "sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-interpolate": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-selection": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
+      "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-transition": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-3.0.1.tgz",
+      "integrity": "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-dispatch": "1 - 3",
+        "d3-ease": "1 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "d3-selection": "2 - 3"
+      }
+    },
+    "node_modules/d3-zoom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-3.0.0.tgz",
+      "integrity": "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-selection": "2 - 3",
+        "d3-transition": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/date-format": {
       "version": "4.0.14",
       "resolved": "https://registry.npmjs.org/date-format/-/date-format-4.0.14.tgz",
@@ -6190,7 +6709,6 @@
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
       "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -6273,11 +6791,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/delaunator": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/delaunator/-/delaunator-5.0.1.tgz",
+      "integrity": "sha512-8nvh+XBe96aCESrGOqMp/84b13H9cdKbG5P2ejQCh4d4sK9RL4371qou9drQjMhvnPmhWl5hnmqbEE0fXr9Xnw==",
+      "license": "ISC",
+      "dependencies": {
+        "robust-predicates": "^3.0.2"
+      }
+    },
     "node_modules/depd": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
       "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -6407,7 +6933,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
       "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.1",
@@ -6429,7 +6954,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
@@ -6575,7 +7099,7 @@
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
       "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
-      "dev": true,
+      "devOptional": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.12"
@@ -6642,7 +7166,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
       "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -6652,7 +7175,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -6669,7 +7191,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
       "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
@@ -6745,7 +7266,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
       "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/eslint-scope": {
@@ -6809,7 +7329,6 @@
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
       "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -6887,116 +7406,224 @@
       "license": "Apache-2.0"
     },
     "node_modules/express": {
-      "version": "4.21.2",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.21.2.tgz",
-      "integrity": "sha512-28HqgMZAmih1Czt9ny7qr6ek2qddF4FclbMzwhCREB6OFfH+rXAnuNCwo1/wFvrtbgsQDb4kSbX9de9lFbrXnA==",
-      "dev": true,
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.1.0.tgz",
+      "integrity": "sha512-DT9ck5YIRU+8GYzzU5kT3eHGA5iL+1Zd0EutOmTE9Dtk+Tvuzd23VBU+ec7HPNSTxXYO55gPV/hq4pSBJDjFpA==",
       "license": "MIT",
       "dependencies": {
-        "accepts": "~1.3.8",
-        "array-flatten": "1.1.1",
-        "body-parser": "1.20.3",
-        "content-disposition": "0.5.4",
-        "content-type": "~1.0.4",
-        "cookie": "0.7.1",
-        "cookie-signature": "1.0.6",
-        "debug": "2.6.9",
-        "depd": "2.0.0",
-        "encodeurl": "~2.0.0",
-        "escape-html": "~1.0.3",
-        "etag": "~1.8.1",
-        "finalhandler": "1.3.1",
-        "fresh": "0.5.2",
-        "http-errors": "2.0.0",
-        "merge-descriptors": "1.0.3",
-        "methods": "~1.1.2",
-        "on-finished": "2.4.1",
-        "parseurl": "~1.3.3",
-        "path-to-regexp": "0.1.12",
-        "proxy-addr": "~2.0.7",
-        "qs": "6.13.0",
-        "range-parser": "~1.2.1",
-        "safe-buffer": "5.2.1",
-        "send": "0.19.0",
-        "serve-static": "1.16.2",
-        "setprototypeof": "1.2.0",
-        "statuses": "2.0.1",
-        "type-is": "~1.6.18",
-        "utils-merge": "1.0.1",
-        "vary": "~1.1.2"
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.0",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
       },
       "engines": {
-        "node": ">= 0.10.0"
+        "node": ">= 18"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
       }
     },
-    "node_modules/express/node_modules/cookie": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.1.tgz",
-      "integrity": "sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w==",
-      "dev": true,
+    "node_modules/express/node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
       "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
       "engines": {
         "node": ">= 0.6"
       }
     },
-    "node_modules/express/node_modules/debug": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "dev": true,
+    "node_modules/express/node_modules/body-parser": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.0.tgz",
+      "integrity": "sha512-02qvAaxv8tp7fBa/mw1ga98OGm+eCbqzJOKoRt70sLmfEEi+jyBYVTDGfCL/k06/4EMk/z01gCe7HoCH/f2LTg==",
       "license": "MIT",
       "dependencies": {
-        "ms": "2.0.0"
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.0",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.6.3",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.0",
+        "raw-body": "^3.0.0",
+        "type-is": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/express/node_modules/encodeurl": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
       "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
       }
     },
     "node_modules/express/node_modules/finalhandler": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.1.tgz",
-      "integrity": "sha512-6BN9trH7bp3qvnrRyzsBz+g3lZxTNZTbVO2EV1CS0WIcDbawYVdYvGflME/9QP0h0pYlCDBCTjYa9nZzMDpyxQ==",
-      "dev": true,
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.0.tgz",
+      "integrity": "sha512-/t88Ty3d5JWQbWYgaOGCCYfXRwV1+be02WqYYlL6h0lEiUAMPM8o8qKGO01YIkOHzka2up08wvgYD0mDiI+q3Q==",
       "license": "MIT",
       "dependencies": {
-        "debug": "2.6.9",
-        "encodeurl": "~2.0.0",
-        "escape-html": "~1.0.3",
-        "on-finished": "2.4.1",
-        "parseurl": "~1.3.3",
-        "statuses": "2.0.1",
-        "unpipe": "~1.0.0"
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
       },
       "engines": {
         "node": ">= 0.8"
       }
     },
-    "node_modules/express/node_modules/ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-      "dev": true,
-      "license": "MIT"
+    "node_modules/express/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
-    "node_modules/express/node_modules/statuses": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
-      "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
-      "dev": true,
+    "node_modules/express/node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/express/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/express/node_modules/mime-types": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.1.tgz",
+      "integrity": "sha512-xRc4oEhT6eaBpU1XF7AjpOFD+xQmXNB5OVKwp4tqCuBpHLS/ZbBDrc07mYTDqVMg6PfxUjjNp85O6Cd2Z/5HWA==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/express/node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/express/node_modules/qs": {
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
+      "integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/express/node_modules/raw-body": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.1.tgz",
+      "integrity": "sha512-9G8cA+tuMS75+6G/TzW8OtLzmBDMo8p1JRxN5AZ+LAp8uxGA8V8GZm4GQ4/N5QNQEnLmg6SS7wyuSmbKepiKqA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "3.1.2",
+        "http-errors": "2.0.0",
+        "iconv-lite": "0.7.0",
+        "unpipe": "1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/express/node_modules/raw-body/node_modules/iconv-lite": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.0.tgz",
+      "integrity": "sha512-cf6L2Ds3h57VVmkZe+Pn+5APsT7FpqJtEhhieDCvrE2MK5Qk9MyffgQyuxQTm6BChfeZNtcOLHp9IcWRVcIcBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express/node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/express/node_modules/type-is": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
+      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^1.0.5",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/extend": {
@@ -7260,7 +7887,6 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
       "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -7281,13 +7907,12 @@
       }
     },
     "node_modules/fresh": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
-      "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
-      "dev": true,
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
       "license": "MIT",
       "engines": {
-        "node": ">= 0.6"
+        "node": ">= 0.8"
       }
     },
     "node_modules/fs-extra": {
@@ -7344,7 +7969,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -7387,7 +8011,6 @@
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.7.tgz",
       "integrity": "sha512-VW6Pxhsrk0KAOqs3WEd0klDiF/+V7gQOpAvY1jVU/LHmaD/kQO4523aiJuikX/QAKYiW6x8Jh+RJej1almdtCA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.1",
@@ -7412,7 +8035,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
       "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "dunder-proto": "^1.0.1",
@@ -7512,7 +8134,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
       "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -7527,6 +8148,15 @@
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/gradient-path": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/gradient-path/-/gradient-path-2.3.0.tgz",
+      "integrity": "sha512-vZdF/Z0EpqUztzWXFjFC16lqcialHacYoRonslk/bC6CuujkuIrqx7etlzdYHY4SnUU94LRWESamZKfkGh7yYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "tinygradient": "^1.0.0"
+      }
     },
     "node_modules/handle-thing": {
       "version": "2.0.1",
@@ -7549,7 +8179,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -7578,7 +8207,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
       "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -7715,7 +8343,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
       "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "depd": "2.0.0",
@@ -7732,7 +8359,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
       "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -7996,7 +8622,6 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/ini": {
@@ -8007,6 +8632,15 @@
       "license": "ISC",
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/ip-address": {
@@ -8202,6 +8836,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
     },
     "node_modules/is-regex": {
       "version": "1.2.1",
@@ -9335,11 +9975,22 @@
         "node": "^16.14.0 || >=18.0.0"
       }
     },
+    "node_modules/marked": {
+      "version": "16.4.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-16.4.0.tgz",
+      "integrity": "sha512-CTPAcRBq57cn3R8n3hwc2REddc28hjR7RzDXQ+lXLmMJYqn20BaI2cGw6QjgZGIgVfp2Wdfw4aMzgNteQ6qJgQ==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
       "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -9376,11 +10027,13 @@
       }
     },
     "node_modules/merge-descriptors": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
-      "integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==",
-      "dev": true,
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
       "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
@@ -9750,7 +10403,6 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/msgpackr": {
@@ -10234,7 +10886,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -10244,7 +10895,6 @@
       "version": "1.13.3",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.3.tgz",
       "integrity": "sha512-kDCGIbxkDSXE3euJZZXzc6to7fCrKHNI/hSRQnRuQ+BWjFNzZwiFF8fj/6o2t2G9/jTj8PSIYTfCLelLZEeRpA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -10264,7 +10914,6 @@
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
       "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ee-first": "1.1.1"
@@ -10287,7 +10936,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
@@ -10587,7 +11235,7 @@
       "version": "7.2.1",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.2.1.tgz",
       "integrity": "sha512-BuBYQYlv1ckiPdQi/ohiivi9Sagc9JG+Ozs0r7b/0iK3sKmrb0b9FdWdBbOdx6hBCM/F9Ir82ofnBhtZOjCRPQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "entities": "^4.5.0"
@@ -10628,7 +11276,6 @@
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
       "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -10696,11 +11343,14 @@
       "license": "ISC"
     },
     "node_modules/path-to-regexp": {
-      "version": "0.1.12",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
-      "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
-      "dev": true,
-      "license": "MIT"
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
+      "integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/path-type": {
       "version": "5.0.0",
@@ -10966,7 +11616,6 @@
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
       "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "forwarded": "0.2.0",
@@ -10980,7 +11629,6 @@
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
       "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.10"
@@ -11062,7 +11710,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
       "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -11386,6 +12033,12 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/robust-predicates": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.2.tgz",
+      "integrity": "sha512-IXgzBWvWQwE6PrDI05OvmXUIruQTcoMDzRsOd5CDvHCVLcLHMTSYvOK5Cm46kWqlV3yAbuSpBZdJ5oP5OUoStg==",
+      "license": "Unlicense"
+    },
     "node_modules/rollup": {
       "version": "4.22.4",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.22.4.tgz",
@@ -11420,6 +12073,22 @@
         "@rollup/rollup-win32-ia32-msvc": "4.22.4",
         "@rollup/rollup-win32-x64-msvc": "4.22.4",
         "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
       }
     },
     "node_modules/rss-parser": {
@@ -11478,6 +12147,12 @@
         "queue-microtask": "^1.2.2"
       }
     },
+    "node_modules/rw": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
+      "integrity": "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/rxjs": {
       "version": "7.8.1",
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
@@ -11491,7 +12166,6 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -11530,7 +12204,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/sass": {
@@ -11671,65 +12344,61 @@
       }
     },
     "node_modules/send": {
-      "version": "0.19.0",
-      "resolved": "https://registry.npmjs.org/send/-/send-0.19.0.tgz",
-      "integrity": "sha512-dW41u5VfLXu8SJh5bwRmyYUbAoSB3c9uQh6L8h/KtsFREPWpbX1lrljJo186Jc4nmci/sGUZ9a0a0J2zgfq2hw==",
-      "dev": true,
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.0.tgz",
+      "integrity": "sha512-uaW0WwXKpL9blXE2o0bRhoL2EGXIrZxQ2ZQ4mgcfoBxdFmQold+qWsD2jLrfZ0trjKL6vOw0j//eAwcALFjKSw==",
       "license": "MIT",
       "dependencies": {
-        "debug": "2.6.9",
-        "depd": "2.0.0",
-        "destroy": "1.2.0",
-        "encodeurl": "~1.0.2",
-        "escape-html": "~1.0.3",
-        "etag": "~1.8.1",
-        "fresh": "0.5.2",
-        "http-errors": "2.0.0",
-        "mime": "1.6.0",
-        "ms": "2.1.3",
-        "on-finished": "2.4.1",
-        "range-parser": "~1.2.1",
-        "statuses": "2.0.1"
+        "debug": "^4.3.5",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "mime-types": "^3.0.1",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.1"
       },
       "engines": {
-        "node": ">= 0.8.0"
+        "node": ">= 18"
       }
     },
-    "node_modules/send/node_modules/debug": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ms": "2.0.0"
-      }
-    },
-    "node_modules/send/node_modules/debug/node_modules/ms": {
+    "node_modules/send/node_modules/encodeurl": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/send/node_modules/mime": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
-      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
-      "dev": true,
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
       "license": "MIT",
-      "bin": {
-        "mime": "cli.js"
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/send/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/send/node_modules/mime-types": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.1.tgz",
+      "integrity": "sha512-xRc4oEhT6eaBpU1XF7AjpOFD+xQmXNB5OVKwp4tqCuBpHLS/ZbBDrc07mYTDqVMg6PfxUjjNp85O6Cd2Z/5HWA==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
       },
       "engines": {
-        "node": ">=4"
+        "node": ">= 0.6"
       }
     },
     "node_modules/send/node_modules/statuses": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
-      "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
-      "dev": true,
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -11822,26 +12491,24 @@
       "license": "ISC"
     },
     "node_modules/serve-static": {
-      "version": "1.16.2",
-      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.2.tgz",
-      "integrity": "sha512-VqpjJZKadQB/PEbEwvFdO43Ax5dFBZ2UECszz8bQ7pi7wt//PWe1P6MN7eCnjsatYtBT6EuiClbjSWP2WrIoTw==",
-      "dev": true,
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.0.tgz",
+      "integrity": "sha512-61g9pCh0Vnh7IutZjtLGGpTA355+OPn2TyDv/6ivP2h/AdAVX9azsoxmg2/M6nZeQZNYBEwIcsne1mJd9oQItQ==",
       "license": "MIT",
       "dependencies": {
-        "encodeurl": "~2.0.0",
-        "escape-html": "~1.0.3",
-        "parseurl": "~1.3.3",
-        "send": "0.19.0"
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
       },
       "engines": {
-        "node": ">= 0.8.0"
+        "node": ">= 18"
       }
     },
     "node_modules/serve-static/node_modules/encodeurl": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
       "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -11851,7 +12518,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/shallow-clone": {
@@ -11907,7 +12573,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
       "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -11927,7 +12592,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
       "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -11944,7 +12608,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
       "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -11963,7 +12626,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
       "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -12713,6 +13375,22 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/tinycolor2": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/tinycolor2/-/tinycolor2-1.6.0.tgz",
+      "integrity": "sha512-XPaBkWQJdsf3pLKJV9p4qN/S+fm2Oj8AIPo1BTUhg5oxkvm9+SVEGFdhyOz7tTdUTfvxMiAs4sp6/eZO2Ew+pw==",
+      "license": "MIT"
+    },
+    "node_modules/tinygradient": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/tinygradient/-/tinygradient-1.1.5.tgz",
+      "integrity": "sha512-8nIfc2vgQ4TeLnk2lFj4tRLvvJwEfQuabdsmvDdQPT0xlk9TaNtpGd6nNRxXoK6vQhN6RSzj+Cnp5tTQmpxmbw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/tinycolor2": "^1.4.0",
+        "tinycolor2": "^1.0.0"
+      }
+    },
     "node_modules/tmp": {
       "version": "0.0.33",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
@@ -12743,7 +13421,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
       "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.6"
@@ -12976,7 +13653,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
       "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -13085,7 +13761,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
       "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -13808,6 +14483,139 @@
         "balanced-match": "^1.0.0"
       }
     },
+    "node_modules/webpack-dev-server/node_modules/content-disposition": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
+      "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/webpack-dev-server/node_modules/cookie": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.1.tgz",
+      "integrity": "sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/webpack-dev-server/node_modules/cookie-signature": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+      "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/webpack-dev-server/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/webpack-dev-server/node_modules/debug/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/webpack-dev-server/node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/webpack-dev-server/node_modules/express": {
+      "version": "4.21.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.21.2.tgz",
+      "integrity": "sha512-28HqgMZAmih1Czt9ny7qr6ek2qddF4FclbMzwhCREB6OFfH+rXAnuNCwo1/wFvrtbgsQDb4kSbX9de9lFbrXnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "~1.3.8",
+        "array-flatten": "1.1.1",
+        "body-parser": "1.20.3",
+        "content-disposition": "0.5.4",
+        "content-type": "~1.0.4",
+        "cookie": "0.7.1",
+        "cookie-signature": "1.0.6",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "finalhandler": "1.3.1",
+        "fresh": "0.5.2",
+        "http-errors": "2.0.0",
+        "merge-descriptors": "1.0.3",
+        "methods": "~1.1.2",
+        "on-finished": "2.4.1",
+        "parseurl": "~1.3.3",
+        "path-to-regexp": "0.1.12",
+        "proxy-addr": "~2.0.7",
+        "qs": "6.13.0",
+        "range-parser": "~1.2.1",
+        "safe-buffer": "5.2.1",
+        "send": "0.19.0",
+        "serve-static": "1.16.2",
+        "setprototypeof": "1.2.0",
+        "statuses": "2.0.1",
+        "type-is": "~1.6.18",
+        "utils-merge": "1.0.1",
+        "vary": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/webpack-dev-server/node_modules/finalhandler": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.1.tgz",
+      "integrity": "sha512-6BN9trH7bp3qvnrRyzsBz+g3lZxTNZTbVO2EV1CS0WIcDbawYVdYvGflME/9QP0h0pYlCDBCTjYa9nZzMDpyxQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "on-finished": "2.4.1",
+        "parseurl": "~1.3.3",
+        "statuses": "2.0.1",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/webpack-dev-server/node_modules/fresh": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/webpack-dev-server/node_modules/glob": {
       "version": "10.4.5",
       "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
@@ -13854,6 +14662,29 @@
         }
       }
     },
+    "node_modules/webpack-dev-server/node_modules/merge-descriptors": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
+      "integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/webpack-dev-server/node_modules/mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/webpack-dev-server/node_modules/minimatch": {
       "version": "9.0.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
@@ -13870,6 +14701,13 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/webpack-dev-server/node_modules/path-to-regexp": {
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
+      "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/webpack-dev-server/node_modules/rimraf": {
       "version": "5.0.10",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-5.0.10.tgz",
@@ -13884,6 +14722,67 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/webpack-dev-server/node_modules/send": {
+      "version": "0.19.0",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.19.0.tgz",
+      "integrity": "sha512-dW41u5VfLXu8SJh5bwRmyYUbAoSB3c9uQh6L8h/KtsFREPWpbX1lrljJo186Jc4nmci/sGUZ9a0a0J2zgfq2hw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "fresh": "0.5.2",
+        "http-errors": "2.0.0",
+        "mime": "1.6.0",
+        "ms": "2.1.3",
+        "on-finished": "2.4.1",
+        "range-parser": "~1.2.1",
+        "statuses": "2.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/webpack-dev-server/node_modules/send/node_modules/encodeurl": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
+      "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/webpack-dev-server/node_modules/serve-static": {
+      "version": "1.16.2",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.2.tgz",
+      "integrity": "sha512-VqpjJZKadQB/PEbEwvFdO43Ax5dFBZ2UECszz8bQ7pi7wt//PWe1P6MN7eCnjsatYtBT6EuiClbjSWP2WrIoTw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.3",
+        "send": "0.19.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/webpack-dev-server/node_modules/statuses": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
+      "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/webpack-merge": {
@@ -14140,7 +15039,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/ws": {

--- a/package.json
+++ b/package.json
@@ -6,11 +6,13 @@
     "start": "ng serve",
     "build": "ng build",
     "watch": "ng build --watch --configuration development",
-    "test": "ng test"
+    "test": "ng test",
+    "server": "node server/index.js"
   },
   "private": true,
   "dependencies": {
     "@angular/animations": "^18.0.0",
+    "@angular/cdk": "^18.2.14",
     "@angular/common": "^18.0.0",
     "@angular/compiler": "^18.0.0",
     "@angular/core": "^18.0.0",
@@ -18,6 +20,11 @@
     "@angular/platform-browser": "^18.0.0",
     "@angular/platform-browser-dynamic": "^18.0.0",
     "@angular/router": "^18.0.0",
+    "@swimlane/ngx-charts": "^23.0.1",
+    "cors": "^2.8.5",
+    "d3": "^7.9.0",
+    "express": "^5.1.0",
+    "marked": "^16.4.0",
     "rss-parser": "^3.13.0",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",

--- a/server/data/news-topics.json
+++ b/server/data/news-topics.json
@@ -1,0 +1,295 @@
+{
+  "lastUpdated": "2024-09-30T18:30:00.000Z",
+  "topics": [
+    {
+      "slug": "legal-battles",
+      "title": "Legal Battles and Court Strategy",
+      "summary": "Tracking how Trump's campaign weaponizes ongoing court fights to energize supporters and drive fundraising.",
+      "curatedCopy": "## Courtroom vs. Campaign\nThe campaign treats every filing and hearing as a two-for-one opportunity: legal defense by day, campaign rallying cry by night. Fundraising texts reference each development within minutes, and surrogates translate legal jargon into a persecution narrative built for cable hits.\n\n### Messaging pillars\n- Portray restrictions as election interference.\n- Tie prosecutors to Democratic leaders by name.\n- Pledge to overhaul the justice system on day one.",
+      "callouts": [
+        {
+          "title": "Why it matters",
+          "markdown": "- Legal updates regularly spike small-dollar donations.\n- Base voters cite legal fights as proof the movement is under attack."
+        },
+        {
+          "title": "Watch the calendar",
+          "markdown": "Sentencing and pre-trial hearings align with key fundraising deadlines, giving the campaign recurring content moments."
+        }
+      ],
+      "spotlightIds": ["article-1"],
+      "momentumSeries": [
+        { "date": "2024-09-18", "value": 38 },
+        { "date": "2024-09-22", "value": 47 },
+        { "date": "2024-09-25", "value": 56 },
+        { "date": "2024-09-27", "value": 59 },
+        { "date": "2024-09-30", "value": 61 }
+      ],
+      "events": [
+        {
+          "slug": "georgia-ruling",
+          "title": "Georgia racketeering ruling resets the clock",
+          "date": "2024-09-23T10:00:00.000Z",
+          "description": "A Fulton County judge delays proceedings into 2025. The campaign frames the pause as proof the case is collapsing and uses the reprieve to claim momentum in swing states.",
+          "momentum": 58,
+          "relatedItemIds": ["article-1", "article-2"]
+        },
+        {
+          "slug": "gag-order-fight",
+          "title": "New York gag order fight becomes a censorship narrative",
+          "date": "2024-09-27T18:00:00.000Z",
+          "description": "Surrogates argue that limits on Trump's speech are an attack on supporters, driving sympathetic coverage and op-eds from allies.",
+          "momentum": 62,
+          "relatedItemIds": ["article-3"]
+        },
+        {
+          "slug": "immunity-appeal",
+          "title": "Supreme Court appeal teasers revive immunity storyline",
+          "date": "2024-09-29T14:30:00.000Z",
+          "description": "Campaign lawyers preview new filings that they say will shield Trump from future prosecutions, reinforcing the promise of a second-term crackdown on DOJ critics.",
+          "momentum": 64,
+          "relatedItemIds": ["article-4"]
+        }
+      ]
+    },
+    {
+      "slug": "ground-game",
+      "title": "Swing-State Ground Game",
+      "summary": "Field organizing pushes in the Rust Belt and Sun Belt aimed at closing the early-vote gap.",
+      "curatedCopy": "## Organizing Infrastructure\nField staff are leaning on county GOP offices, faith leaders, and a revived \"Trump Force 47\" volunteer portal. The campaign highlights door-knocking stats at every rally to signal professionalization while maintaining the outsider vibe.\n\n### Key tactics\n1. Overlapping bus tours in Pennsylvania, Michigan, and Georgia.\n2. Micro-targeted radio ads focused on energy costs and border security.\n3. Faith outreach breakfasts that double as data collection events.",
+      "callouts": [
+        {
+          "title": "Staffing snapshot",
+          "markdown": "- 48 paid staffers announced across four battleground states.\n- County captains recruited from 2020 stop-the-steal networks."
+        }
+      ],
+      "spotlightIds": ["article-5"],
+      "momentumSeries": [
+        { "date": "2024-09-18", "value": 32 },
+        { "date": "2024-09-22", "value": 36 },
+        { "date": "2024-09-25", "value": 40 },
+        { "date": "2024-09-27", "value": 44 },
+        { "date": "2024-09-30", "value": 49 }
+      ],
+      "events": [
+        {
+          "slug": "pennsylvania-field-offices",
+          "title": "Six new Pennsylvania field offices open ahead of mail voting",
+          "date": "2024-09-24T15:00:00.000Z",
+          "description": "Campaign claims 8,000 volunteers signed up after the openings, using live streams from each ribbon cutting.",
+          "momentum": 46,
+          "relatedItemIds": ["article-5", "article-6"]
+        },
+        {
+          "slug": "rural-bus-tour",
+          "title": "Rural bus tour spotlights energy message",
+          "date": "2024-09-26T20:00:00.000Z",
+          "description": "Surrogates barnstorm rural Ohio and Michigan touting drilling permits and farmers' fuel costs, capturing local TV coverage.",
+          "momentum": 48,
+          "relatedItemIds": ["article-7"]
+        },
+        {
+          "slug": "latino-faith-outreach",
+          "title": "Latino faith outreach adds bilingual voter guides",
+          "date": "2024-09-28T17:00:00.000Z",
+          "description": "Church partnerships distribute Spanish-language voter packets, part of a broader move to chip into Biden's coalition.",
+          "momentum": 50,
+          "relatedItemIds": ["article-8"]
+        }
+      ]
+    },
+    {
+      "slug": "issue-messaging",
+      "title": "Issue Messaging & Narrative Testing",
+      "summary": "Rapid-response talking points on immigration, inflation, and foreign policy tested across conservative media.",
+      "curatedCopy": "## Narrative Testing\nCampaign pollsters feed nightly findings into surrogate briefings. Messaging pivots quickly to keep the news cycle on favorable terrain, often marrying immigration with inflation to hold focus.\n\n#### Channels\n- Late-night Truth Social posts.\n- Podcast blitzes hosted by allied influencers.\n- Geo-targeted pre-roll ads that shift by state.",
+      "callouts": [
+        {
+          "title": "Rapid-response cadence",
+          "markdown": "Clip packages are cut within 45 minutes of any major Biden gaffe and sent to a 2,000-person surrogate list."
+        }
+      ],
+      "spotlightIds": ["article-9"],
+      "momentumSeries": [
+        { "date": "2024-09-18", "value": 41 },
+        { "date": "2024-09-22", "value": 43 },
+        { "date": "2024-09-25", "value": 47 },
+        { "date": "2024-09-27", "value": 52 },
+        { "date": "2024-09-30", "value": 55 }
+      ],
+      "events": [
+        {
+          "slug": "immigration-ad-blitz",
+          "title": "Immigration ad blitz ties border to inflation",
+          "date": "2024-09-25T12:00:00.000Z",
+          "description": "A wave of digital ads claims rising grocery prices stem from federal spending on migrants, a talking point echoed by surrogates on radio.",
+          "momentum": 53,
+          "relatedItemIds": ["article-9", "article-10"]
+        },
+        {
+          "slug": "debate-prep-messaging",
+          "title": "Debate prep memos leak to conservative outlets",
+          "date": "2024-09-29T11:00:00.000Z",
+          "description": "Selective leaks preview attacks on Biden's foreign policy, keeping the focus on Afghanistan while framing Trump as steady on world affairs.",
+          "momentum": 57,
+          "relatedItemIds": ["article-11"]
+        }
+      ]
+    }
+  ],
+  "items": [
+    {
+      "id": "article-1",
+      "title": "Trump campaign blasts Georgia prosecutors after trial delay",
+      "link": "https://example.com/trump-georgia-delay",
+      "pubDate": "2024-09-23T15:45:00.000Z",
+      "content": "Senior aides told reporters the delay proves the case is political, urging supporters to donate to \"finish the fight\".",
+      "source": "Politico",
+      "category": "Legal",
+      "imageUrl": "https://images.example.com/trump-court.jpg",
+      "topics": ["legal-battles"],
+      "eventSlug": "georgia-ruling",
+      "sentiment": "positive",
+      "momentumScore": 58
+    },
+    {
+      "id": "article-2",
+      "title": "Fundraising text blitz follows Georgia ruling",
+      "link": "https://example.com/fundraising-texts",
+      "pubDate": "2024-09-24T02:30:00.000Z",
+      "content": "Within hours of the judge's order, the campaign sent seven fundraising texts referencing \"witch hunt delays\".",
+      "source": "Axios",
+      "category": "Campaign Finance",
+      "imageUrl": "https://images.example.com/text-blitz.jpg",
+      "topics": ["legal-battles", "ground-game"],
+      "eventSlug": "georgia-ruling",
+      "sentiment": "positive",
+      "momentumScore": 57
+    },
+    {
+      "id": "article-3",
+      "title": "Trump allies decry gag order on conservative media",
+      "link": "https://example.com/gag-order-response",
+      "pubDate": "2024-09-27T22:10:00.000Z",
+      "content": "Surrogates lined up on talk radio to argue that the gag order is really aimed at silencing supporters.",
+      "source": "Fox News",
+      "category": "Media",
+      "imageUrl": "https://images.example.com/gag-order.jpg",
+      "topics": ["legal-battles", "issue-messaging"],
+      "eventSlug": "gag-order-fight",
+      "sentiment": "positive",
+      "momentumScore": 62
+    },
+    {
+      "id": "article-4",
+      "title": "Campaign previews Supreme Court immunity appeal",
+      "link": "https://example.com/immunity-appeal",
+      "pubDate": "2024-09-29T16:05:00.000Z",
+      "content": "Advisers say a conservative majority will rein in the Department of Justice, promising day-one reforms.",
+      "source": "Wall Street Journal",
+      "category": "Legal",
+      "imageUrl": "https://images.example.com/supreme-court.jpg",
+      "topics": ["legal-battles", "issue-messaging"],
+      "eventSlug": "immunity-appeal",
+      "sentiment": "positive",
+      "momentumScore": 64
+    },
+    {
+      "id": "article-5",
+      "title": "Trump opens six field offices across Pennsylvania",
+      "link": "https://example.com/pennsylvania-field",
+      "pubDate": "2024-09-24T18:30:00.000Z",
+      "content": "Ribbon cuttings featured local lawmakers and targeted messages about energy prices.",
+      "source": "Philadelphia Inquirer",
+      "category": "Ground Game",
+      "imageUrl": "https://images.example.com/field-office.jpg",
+      "topics": ["ground-game"],
+      "eventSlug": "pennsylvania-field-offices",
+      "sentiment": "positive",
+      "momentumScore": 46
+    },
+    {
+      "id": "article-6",
+      "title": "Volunteer sign-ups surge after field office blitz",
+      "link": "https://example.com/volunteer-surge",
+      "pubDate": "2024-09-25T14:20:00.000Z",
+      "content": "Campaign claims 8,000 new volunteers, though Democrats dispute the number.",
+      "source": "NBC News",
+      "category": "Ground Game",
+      "imageUrl": "https://images.example.com/volunteers.jpg",
+      "topics": ["ground-game"],
+      "eventSlug": "pennsylvania-field-offices",
+      "sentiment": "neutral",
+      "momentumScore": 44
+    },
+    {
+      "id": "article-7",
+      "title": "Rural bus tour amplifies energy message",
+      "link": "https://example.com/rural-bus",
+      "pubDate": "2024-09-26T22:40:00.000Z",
+      "content": "The bus tour stops at small-town diners with local radio hits about drilling and inflation.",
+      "source": "Cleveland Plain Dealer",
+      "category": "Ground Game",
+      "imageUrl": "https://images.example.com/bus-tour.jpg",
+      "topics": ["ground-game", "issue-messaging"],
+      "eventSlug": "rural-bus-tour",
+      "sentiment": "positive",
+      "momentumScore": 48
+    },
+    {
+      "id": "article-8",
+      "title": "Latino pastors partner with Trump team on voter guides",
+      "link": "https://example.com/latino-voter-guides",
+      "pubDate": "2024-09-28T19:15:00.000Z",
+      "content": "Spanish-language voter packets are distributed alongside food drives in Phoenix and Orlando.",
+      "source": "Univision",
+      "category": "Outreach",
+      "imageUrl": "https://images.example.com/latino-outreach.jpg",
+      "topics": ["ground-game"],
+      "eventSlug": "latino-faith-outreach",
+      "sentiment": "positive",
+      "momentumScore": 50
+    },
+    {
+      "id": "article-9",
+      "title": "Immigration ad blitz links border to inflation",
+      "link": "https://example.com/immigration-ads",
+      "pubDate": "2024-09-25T13:10:00.000Z",
+      "content": "Ads feature grocery carts and Border Patrol footage, testing a new hybrid message.",
+      "source": "Washington Post",
+      "category": "Advertising",
+      "imageUrl": "https://images.example.com/immigration-ads.jpg",
+      "topics": ["issue-messaging"],
+      "eventSlug": "immigration-ad-blitz",
+      "sentiment": "positive",
+      "momentumScore": 53
+    },
+    {
+      "id": "article-10",
+      "title": "Fact-checkers push back on ad claims about migrant spending",
+      "link": "https://example.com/fact-check",
+      "pubDate": "2024-09-26T09:00:00.000Z",
+      "content": "Independent fact-checkers say the numbers are exaggerated, but the campaign doubles down in response videos.",
+      "source": "AP",
+      "category": "Fact Check",
+      "imageUrl": "https://images.example.com/fact-check.jpg",
+      "topics": ["issue-messaging", "legal-battles"],
+      "eventSlug": "immigration-ad-blitz",
+      "sentiment": "negative",
+      "momentumScore": 48
+    },
+    {
+      "id": "article-11",
+      "title": "Debate prep memo outlines foreign policy attacks",
+      "link": "https://example.com/debate-memo",
+      "pubDate": "2024-09-29T13:55:00.000Z",
+      "content": "Leaked slides suggest a focus on Afghanistan, arguing Biden cannot handle crises abroad.",
+      "source": "Bloomberg",
+      "category": "Debate",
+      "imageUrl": "https://images.example.com/debate-prep.jpg",
+      "topics": ["issue-messaging", "legal-battles"],
+      "eventSlug": "debate-prep-messaging",
+      "sentiment": "positive",
+      "momentumScore": 57
+    }
+  ]
+}

--- a/server/index.js
+++ b/server/index.js
@@ -1,0 +1,114 @@
+const express = require('express');
+const cors = require('cors');
+const fs = require('fs');
+const path = require('path');
+
+const DATA_PATH = path.join(__dirname, 'data', 'news-topics.json');
+
+const app = express();
+app.use(cors());
+
+function loadDataset() {
+  const raw = fs.readFileSync(DATA_PATH, 'utf-8');
+  return JSON.parse(raw);
+}
+
+function buildEventIndex(dataset) {
+  return dataset.topics.flatMap(topic => {
+    return topic.events.map(event => {
+      const relatedItems = dataset.items.filter(item => {
+        return item.eventSlug === event.slug && Array.isArray(item.topics) && item.topics.includes(topic.slug);
+      });
+
+      const averageMomentum = relatedItems.length
+        ? relatedItems.reduce((total, item) => total + (item.momentumScore || 0), 0) / relatedItems.length
+        : event.momentum;
+
+      const sentimentBreakdown = relatedItems.reduce(
+        (acc, item) => {
+          const sentiment = item.sentiment || 'unknown';
+          acc[sentiment] = (acc[sentiment] || 0) + 1;
+          return acc;
+        },
+        {}
+      );
+
+      return {
+        topic: topic.slug,
+        topicTitle: topic.title,
+        eventSlug: event.slug,
+        title: event.title,
+        date: event.date,
+        description: event.description,
+        declaredMomentum: event.momentum,
+        relatedItemIds: event.relatedItemIds,
+        averageMomentum,
+        sentimentBreakdown,
+        itemCount: relatedItems.length
+      };
+    });
+  });
+}
+
+app.get('/api/news', (req, res) => {
+  const dataset = loadDataset();
+  const eventIndex = buildEventIndex(dataset);
+
+  const topicFilter = req.query.topic;
+  if (topicFilter) {
+    const topic = dataset.topics.find(t => t.slug === topicFilter);
+    if (!topic) {
+      return res.status(404).json({ message: `Topic '${topicFilter}' not found` });
+    }
+
+    const items = dataset.items.filter(item => Array.isArray(item.topics) && item.topics.includes(topic.slug));
+    const topicEvents = eventIndex.filter(event => event.topic === topic.slug);
+
+    return res.json({
+      lastUpdated: dataset.lastUpdated,
+      topic,
+      items,
+      events: topicEvents
+    });
+  }
+
+  res.json({
+    lastUpdated: dataset.lastUpdated,
+    topics: dataset.topics,
+    items: dataset.items,
+    events: eventIndex
+  });
+});
+
+app.get('/api/topics/:slug', (req, res) => {
+  const dataset = loadDataset();
+  const slug = req.params.slug;
+  const topic = dataset.topics.find(t => t.slug === slug);
+
+  if (!topic) {
+    return res.status(404).json({ message: `Topic '${slug}' not found` });
+  }
+
+  const eventIndex = buildEventIndex(dataset).filter(event => event.topic === slug);
+  const items = dataset.items.filter(item => Array.isArray(item.topics) && item.topics.includes(slug));
+
+  res.json({
+    lastUpdated: dataset.lastUpdated,
+    topic,
+    items,
+    events: eventIndex
+  });
+});
+
+app.get('/health', (_req, res) => {
+  res.json({ status: 'ok' });
+});
+
+if (require.main === module) {
+  const port = process.env.PORT || 3001;
+  app.listen(port, () => {
+    console.log(`News metadata service running on port ${port}`);
+  });
+}
+
+module.exports = app;

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,24 +1,108 @@
 import { Component } from '@angular/core';
-import { RouterOutlet } from '@angular/router';
-import { NewsFeedComponent } from './components/news-feed/news-feed.component';
+import { RouterLink, RouterLinkActive, RouterOutlet } from '@angular/router';
 
 @Component({
   selector: 'app-root',
   standalone: true,
-  imports: [RouterOutlet, NewsFeedComponent],
+  imports: [RouterOutlet, RouterLink, RouterLinkActive],
   template: `
-    <main>
-      <app-news-feed></app-news-feed>
+    <main class="app-shell">
+      <header class="app-header">
+        <div class="branding">
+          <h1>Trump 47 Campaign Tracker</h1>
+          <p class="tagline">Tracking momentum across narratives, events, and daily coverage.</p>
+        </div>
+        <nav class="primary-nav">
+          <a routerLink="/timeline" routerLinkActive="active" [routerLinkActiveOptions]="{ exact: true }">Timeline</a>
+          <a routerLink="/news" routerLinkActive="active">Live feed</a>
+        </nav>
+      </header>
+      <section class="app-content">
+        <router-outlet></router-outlet>
+      </section>
     </main>
   `,
-  styles: [`
-    main {
-      min-height: 100vh;
-      background: #f0f2f5;
-      padding: 20px 0;
-    }
-  `]
+  styles: [
+    `
+      :host {
+        display: block;
+        min-height: 100vh;
+        background: linear-gradient(180deg, #f8f9fa 0%, #edf2ff 100%);
+        font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+        color: #212529;
+      }
+
+      .app-shell {
+        max-width: 1200px;
+        margin: 0 auto;
+        padding: 2rem 1.25rem 4rem;
+      }
+
+      .app-header {
+        display: flex;
+        flex-direction: column;
+        gap: 1.5rem;
+        padding-bottom: 1.5rem;
+        border-bottom: 1px solid rgba(0, 0, 0, 0.08);
+      }
+
+      .branding h1 {
+        margin: 0;
+        font-size: 1.75rem;
+      }
+
+      .branding .tagline {
+        margin: 0.5rem 0 0;
+        color: #495057;
+        font-size: 1rem;
+      }
+
+      .primary-nav {
+        display: flex;
+        gap: 1.25rem;
+      }
+
+      .primary-nav a {
+        text-decoration: none;
+        color: #495057;
+        font-weight: 600;
+        position: relative;
+        padding-bottom: 0.25rem;
+      }
+
+      .primary-nav a.active,
+      .primary-nav a:hover,
+      .primary-nav a:focus {
+        color: #4c6ef5;
+      }
+
+      .primary-nav a.active::after {
+        content: '';
+        position: absolute;
+        left: 0;
+        right: 0;
+        bottom: -0.35rem;
+        height: 3px;
+        border-radius: 999px;
+        background: #4c6ef5;
+      }
+
+      .app-content {
+        margin-top: 2rem;
+      }
+
+      @media (min-width: 768px) {
+        .app-header {
+          flex-direction: row;
+          align-items: center;
+          justify-content: space-between;
+        }
+
+        .branding {
+          max-width: 640px;
+        }
+      }
+    `
+  ]
 })
-export class AppComponent {
-  title = 'Trump 47 Campaign Tracker';
-}
+export class AppComponent {}

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -1,3 +1,28 @@
 import { Routes } from '@angular/router';
 
-export const routes: Routes = [];
+export const routes: Routes = [
+  {
+    path: '',
+    pathMatch: 'full',
+    redirectTo: 'timeline'
+  },
+  {
+    path: 'timeline',
+    loadComponent: () =>
+      import('./routes/timeline/timeline.component').then(m => m.TimelineComponent)
+  },
+  {
+    path: 'topics/:slug',
+    loadComponent: () =>
+      import('./routes/topic-page/topic-page.component').then(m => m.TopicPageComponent)
+  },
+  {
+    path: 'news',
+    loadComponent: () =>
+      import('./components/news-feed/news-feed.component').then(m => m.NewsFeedComponent)
+  },
+  {
+    path: '**',
+    redirectTo: 'timeline'
+  }
+];

--- a/src/app/models/news.model.ts
+++ b/src/app/models/news.model.ts
@@ -7,6 +7,10 @@ export interface NewsItem {
   source: string;
   category?: string;
   imageUrl?: string;
+  topics?: string[];
+  eventSlug?: string;
+  sentiment?: 'positive' | 'negative' | 'neutral' | 'unknown';
+  momentumScore?: number;
 }
 
 export interface NewsState {
@@ -22,4 +26,47 @@ export interface NewsFilter {
   dateFrom?: Date;
   dateTo?: Date;
   searchTerm?: string;
+}
+
+export interface MomentumPoint {
+  date: Date;
+  value: number;
+}
+
+export interface TopicCallout {
+  title: string;
+  markdown: string;
+}
+
+export interface TopicEvent {
+  slug: string;
+  title: string;
+  date: Date;
+  description: string;
+  momentum: number;
+  relatedItemIds: string[];
+}
+
+export interface Topic {
+  slug: string;
+  title: string;
+  summary: string;
+  curatedCopy: string;
+  callouts?: TopicCallout[];
+  heroImage?: string;
+  spotlightIds?: string[];
+  momentumSeries: MomentumPoint[];
+  events: TopicEvent[];
+}
+
+export interface TopicDataset {
+  lastUpdated: Date;
+  topics: Topic[];
+  items: NewsItem[];
+}
+
+export interface TopicDetail {
+  lastUpdated: Date;
+  topic: Topic;
+  items: NewsItem[];
 }

--- a/src/app/routes/timeline/timeline.component.html
+++ b/src/app/routes/timeline/timeline.component.html
@@ -1,0 +1,83 @@
+<section class="timeline" *ngIf="viewState$ | async as state">
+  <div *ngIf="state.state === 'loading'" class="timeline__status timeline__status--loading">
+    Loading topic momentum…
+  </div>
+
+  <div *ngIf="state.state === 'error'" class="timeline__status timeline__status--error">
+    <p>We couldn't load the curated timeline right now.</p>
+    <p class="timeline__status-detail">{{ state.error.message }}</p>
+  </div>
+
+  <ng-container *ngIf="state.state === 'loaded'">
+    <header class="timeline__header">
+      <div>
+        <h1>Campaign Timeline</h1>
+        <p class="timeline__subhead">
+          Curated moments and news grouped by topic, with a quick read on how momentum is shifting.
+        </p>
+      </div>
+      <div class="timeline__meta">
+        <span>Last updated</span>
+        <strong>{{ state.data.lastUpdated | date: 'medium' }}</strong>
+      </div>
+    </header>
+
+    <article
+      class="timeline__topic"
+      *ngFor="let topicView of state.data.topics; trackBy: trackByTopic"
+    >
+      <header class="timeline__topic-header">
+        <div>
+          <h2>{{ topicView.topic.title }}</h2>
+          <p>{{ topicView.topic.summary }}</p>
+        </div>
+        <a class="timeline__topic-link" [routerLink]="['/topics', topicView.topic.slug]">
+          Deep dive →
+        </a>
+      </header>
+
+      <div class="timeline__chart" *ngIf="topicView.momentumChart[0]?.series?.length">
+        <ngx-charts-line-chart
+          [results]="topicView.momentumChart"
+          [scheme]="colorScheme"
+          [timeline]="true"
+          [autoScale]="true"
+          [xAxis]="true"
+          [yAxis]="true"
+          [xAxisLabel]="'Date'"
+          [yAxisLabel]="'Momentum'"
+          [showXAxisLabel]="true"
+          [showYAxisLabel]="true"
+          [roundDomains]="true"
+          [animations]="false"
+        ></ngx-charts-line-chart>
+      </div>
+
+      <div class="timeline__events">
+        <section
+          class="timeline__event"
+          *ngFor="let group of topicView.events; trackBy: trackByEvent"
+        >
+          <header>
+            <h3>{{ group.event.title }}</h3>
+            <span class="timeline__event-date">{{ group.event.date | date: 'mediumDate' }}</span>
+          </header>
+          <p class="timeline__event-description">{{ group.event.description }}</p>
+          <ul class="timeline__news" *ngIf="group.items.length; else emptyState">
+            <li *ngFor="let item of group.items">
+              <a [href]="item.link" target="_blank" rel="noopener noreferrer">
+                {{ item.title }}
+              </a>
+              <small>
+                {{ item.source }} · {{ item.pubDate | date: 'short' }} · Momentum {{ item.momentumScore ?? '—' }}
+              </small>
+            </li>
+          </ul>
+          <ng-template #emptyState>
+            <p class="timeline__empty">No linked coverage yet — check back soon.</p>
+          </ng-template>
+        </section>
+      </div>
+    </article>
+  </ng-container>
+</section>

--- a/src/app/routes/timeline/timeline.component.scss
+++ b/src/app/routes/timeline/timeline.component.scss
@@ -1,0 +1,168 @@
+.timeline {
+  display: flex;
+  flex-direction: column;
+  gap: 2.5rem;
+  padding: 1.5rem 0 3rem;
+}
+
+.timeline__header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 1rem;
+  border-bottom: 1px solid rgba(0, 0, 0, 0.08);
+  padding-bottom: 1rem;
+}
+
+.timeline__subhead {
+  color: #495057;
+  max-width: 640px;
+  margin: 0.25rem 0 0;
+}
+
+.timeline__meta {
+  text-align: right;
+  font-size: 0.875rem;
+  color: #495057;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.timeline__status {
+  padding: 1rem 1.25rem;
+  border-radius: 0.75rem;
+  font-size: 1rem;
+  background: #f8f9fa;
+  border: 1px solid rgba(0, 0, 0, 0.06);
+}
+
+.timeline__status--error {
+  background: #fff5f5;
+  border-color: #ffa8a8;
+  color: #c92a2a;
+}
+
+.timeline__status-detail {
+  margin: 0.5rem 0 0;
+  font-size: 0.875rem;
+}
+
+.timeline__topic {
+  background: #ffffff;
+  border-radius: 1.25rem;
+  padding: 1.5rem;
+  box-shadow: 0 12px 30px rgba(76, 110, 245, 0.08);
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.timeline__topic-header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+@media (min-width: 768px) {
+  .timeline__topic-header {
+    flex-direction: row;
+    justify-content: space-between;
+    align-items: center;
+    gap: 2rem;
+  }
+
+  .timeline__topic-header > div {
+    max-width: 720px;
+  }
+}
+
+.timeline__topic-link {
+  font-weight: 600;
+  color: #4c6ef5;
+  text-decoration: none;
+  align-self: flex-start;
+}
+
+.timeline__topic-link:hover,
+.timeline__topic-link:focus {
+  text-decoration: underline;
+}
+
+.timeline__chart {
+  width: 100%;
+  height: 260px;
+}
+
+.timeline__events {
+  display: grid;
+  gap: 1.5rem;
+}
+
+@media (min-width: 1024px) {
+  .timeline__events {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}
+
+.timeline__event {
+  border: 1px solid rgba(76, 110, 245, 0.15);
+  border-radius: 1rem;
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  background: linear-gradient(180deg, rgba(76, 110, 245, 0.05), transparent);
+}
+
+.timeline__event header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.timeline__event-date {
+  font-size: 0.875rem;
+  color: #495057;
+}
+
+.timeline__event-description {
+  margin: 0;
+  color: #343a40;
+  line-height: 1.5;
+}
+
+.timeline__news {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.timeline__news li a {
+  font-weight: 600;
+  color: #212529;
+  text-decoration: none;
+}
+
+.timeline__news li a:hover,
+.timeline__news li a:focus {
+  color: #4c6ef5;
+  text-decoration: underline;
+}
+
+.timeline__news small {
+  display: block;
+  font-size: 0.75rem;
+  color: #868e96;
+  margin-top: 0.25rem;
+}
+
+.timeline__empty {
+  font-size: 0.875rem;
+  color: #868e96;
+  margin: 0;
+}

--- a/src/app/routes/timeline/timeline.component.ts
+++ b/src/app/routes/timeline/timeline.component.ts
@@ -1,0 +1,97 @@
+import { Component } from '@angular/core';
+import { AsyncPipe, DatePipe, NgFor, NgIf } from '@angular/common';
+import { RouterLink } from '@angular/router';
+import { Color, NgxChartsModule, ScaleType } from '@swimlane/ngx-charts';
+import { map } from 'rxjs/operators';
+
+import { toLoadingState } from '../../models/loading-state.model';
+import { TopicDataService } from '../../services/topic-data.service';
+import { TopicDataset, TopicEvent, Topic, NewsItem } from '../../models/news.model';
+
+interface MomentumChartPoint {
+  name: Date;
+  value: number;
+}
+
+interface MomentumChartSeries {
+  name: string;
+  series: MomentumChartPoint[];
+}
+
+interface TimelineEventGroup {
+  event: TopicEvent;
+  items: NewsItem[];
+}
+
+interface TimelineTopicView {
+  topic: Topic;
+  momentumChart: MomentumChartSeries[];
+  events: TimelineEventGroup[];
+}
+
+interface TimelineViewModel {
+  lastUpdated: Date;
+  topics: TimelineTopicView[];
+}
+
+@Component({
+  selector: 'app-timeline',
+  standalone: true,
+  imports: [NgIf, NgFor, AsyncPipe, DatePipe, RouterLink, NgxChartsModule],
+  templateUrl: './timeline.component.html',
+  styleUrl: './timeline.component.scss'
+})
+export class TimelineComponent {
+  readonly colorScheme: Color = {
+    name: 'timelineMomentum',
+    selectable: false,
+    group: ScaleType.Ordinal,
+    domain: ['#4c6ef5', '#20c997', '#e8590c']
+  };
+
+  readonly viewState$ = toLoadingState(this.topicDataService.getDataset().pipe(
+    map(dataset => this.buildViewModel(dataset))
+  ));
+
+  constructor(private topicDataService: TopicDataService) {}
+
+  trackByTopic(_: number, view: TimelineTopicView): string {
+    return view.topic.slug;
+  }
+
+  trackByEvent(_: number, group: TimelineEventGroup): string {
+    return group.event.slug;
+  }
+
+  private buildViewModel(dataset: TopicDataset): TimelineViewModel {
+    return {
+      lastUpdated: dataset.lastUpdated,
+      topics: dataset.topics.map(topic => this.buildTopicView(topic, dataset.items))
+    };
+  }
+
+  private buildTopicView(topic: Topic, items: NewsItem[]): TimelineTopicView {
+    const events = topic.events.map(event => ({
+      event,
+      items: items.filter(item =>
+        item.eventSlug === event.slug && item.topics?.includes(topic.slug)
+      )
+    }));
+
+    const momentumChart: MomentumChartSeries[] = [
+      {
+        name: topic.title,
+        series: topic.momentumSeries.map(point => ({
+          name: point.date,
+          value: point.value
+        }))
+      }
+    ];
+
+    return {
+      topic,
+      events,
+      momentumChart
+    };
+  }
+}

--- a/src/app/routes/topic-page/topic-page.component.html
+++ b/src/app/routes/topic-page/topic-page.component.html
@@ -1,0 +1,77 @@
+<section class="topic" *ngIf="viewState$ | async as state">
+  <div *ngIf="state.state === 'loading'" class="topic__status topic__status--loading">
+    Loading topic briefing…
+  </div>
+
+  <div *ngIf="state.state === 'error'" class="topic__status topic__status--error">
+    <p>We couldn't load this topic right now.</p>
+    <p class="topic__status-detail">{{ state.error.message }}</p>
+    <a routerLink="/timeline" class="topic__back">Back to timeline</a>
+  </div>
+
+  <ng-container *ngIf="state.state === 'loaded'">
+    <a routerLink="/timeline" class="topic__back">← Back to curated timeline</a>
+
+    <header class="topic__header">
+      <div>
+        <h1>{{ state.data.detail.topic.title }}</h1>
+        <p class="topic__summary">{{ state.data.detail.topic.summary }}</p>
+      </div>
+      <aside class="topic__meta">
+        <span>Last updated</span>
+        <strong>{{ state.data.lastUpdated | date: 'medium' }}</strong>
+      </aside>
+    </header>
+
+    <div class="topic__callouts" *ngIf="state.data.callouts.length">
+      <section *ngFor="let callout of state.data.callouts" class="topic__callout">
+        <h2>{{ callout.title }}</h2>
+        <div class="topic__callout-body" [innerHTML]="callout.body"></div>
+      </section>
+    </div>
+
+    <div class="topic__chart" *ngIf="state.data.momentumChart[0]?.series?.length">
+      <ngx-charts-line-chart
+        [results]="state.data.momentumChart"
+        [scheme]="colorScheme"
+        [timeline]="true"
+        [autoScale]="true"
+        [xAxis]="true"
+        [yAxis]="true"
+        [xAxisLabel]="'Date'"
+        [yAxisLabel]="'Momentum'"
+        [showXAxisLabel]="true"
+        [showYAxisLabel]="true"
+        [animations]="false"
+      ></ngx-charts-line-chart>
+    </div>
+
+    <article class="topic__body" [innerHTML]="state.data.curatedHtml"></article>
+
+    <section class="topic__events">
+      <header>
+        <h2>Key developments</h2>
+      </header>
+      <div class="topic__event-grid">
+        <article class="topic__event" *ngFor="let group of state.data.eventGroups; trackBy: trackByEvent">
+          <header>
+            <h3>{{ group.event.title }}</h3>
+            <span class="topic__event-date">{{ group.event.date | date: 'medium' }}</span>
+          </header>
+          <p class="topic__event-description">{{ group.event.description }}</p>
+          <ul class="topic__news" *ngIf="group.items.length; else empty">
+            <li *ngFor="let item of group.items">
+              <a [href]="item.link" target="_blank" rel="noopener noreferrer">
+                {{ item.title }}
+              </a>
+              <small>{{ item.source }} · {{ item.pubDate | date: 'short' }} · Momentum {{ item.momentumScore ?? '—' }}</small>
+            </li>
+          </ul>
+          <ng-template #empty>
+            <p class="topic__empty">No linked stories yet for this moment.</p>
+          </ng-template>
+        </article>
+      </div>
+    </section>
+  </ng-container>
+</section>

--- a/src/app/routes/topic-page/topic-page.component.scss
+++ b/src/app/routes/topic-page/topic-page.component.scss
@@ -1,0 +1,188 @@
+.topic {
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+  padding: 1.5rem 0 3rem;
+}
+
+.topic__back {
+  color: #4c6ef5;
+  text-decoration: none;
+  font-weight: 600;
+  width: fit-content;
+}
+
+.topic__back:hover,
+.topic__back:focus {
+  text-decoration: underline;
+}
+
+.topic__header {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  border-bottom: 1px solid rgba(0, 0, 0, 0.08);
+  padding-bottom: 1rem;
+}
+
+@media (min-width: 768px) {
+  .topic__header {
+    flex-direction: row;
+    justify-content: space-between;
+    align-items: flex-end;
+  }
+}
+
+.topic__summary {
+  margin: 0.5rem 0 0;
+  color: #495057;
+  max-width: 720px;
+}
+
+.topic__meta {
+  text-align: right;
+  font-size: 0.875rem;
+  color: #495057;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.topic__status {
+  padding: 1rem 1.25rem;
+  border-radius: 0.75rem;
+  background: #f8f9fa;
+  border: 1px solid rgba(0, 0, 0, 0.08);
+}
+
+.topic__status--error {
+  background: #fff5f5;
+  border-color: #ffa8a8;
+  color: #c92a2a;
+}
+
+.topic__status-detail {
+  margin-top: 0.5rem;
+  font-size: 0.875rem;
+}
+
+.topic__callouts {
+  display: grid;
+  gap: 1.5rem;
+}
+
+@media (min-width: 1024px) {
+  .topic__callouts {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+.topic__callout {
+  background: #ffffff;
+  border-radius: 1rem;
+  padding: 1.25rem;
+  box-shadow: 0 12px 30px rgba(32, 201, 151, 0.08);
+}
+
+.topic__callout-body {
+  margin-top: 0.75rem;
+  color: #343a40;
+  line-height: 1.6;
+}
+
+.topic__chart {
+  width: 100%;
+  height: 260px;
+}
+
+.topic__body {
+  background: #ffffff;
+  border-radius: 1.25rem;
+  padding: 1.5rem;
+  box-shadow: 0 12px 30px rgba(14, 116, 144, 0.08);
+  line-height: 1.7;
+  color: #212529;
+}
+
+.topic__body h2,
+.topic__body h3 {
+  margin-top: 1.5rem;
+}
+
+.topic__events {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.topic__event-grid {
+  display: grid;
+  gap: 1.5rem;
+}
+
+@media (min-width: 1024px) {
+  .topic__event-grid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}
+
+.topic__event {
+  border: 1px solid rgba(32, 201, 151, 0.2);
+  border-radius: 1rem;
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  background: linear-gradient(180deg, rgba(32, 201, 151, 0.08), transparent);
+}
+
+.topic__event header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.topic__event-date {
+  font-size: 0.875rem;
+  color: #495057;
+}
+
+.topic__event-description {
+  margin: 0;
+  color: #343a40;
+  line-height: 1.5;
+}
+
+.topic__news {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.topic__news a {
+  color: #212529;
+  text-decoration: none;
+  font-weight: 600;
+}
+
+.topic__news a:hover,
+.topic__news a:focus {
+  text-decoration: underline;
+  color: #20c997;
+}
+
+.topic__news small {
+  display: block;
+  font-size: 0.75rem;
+  color: #868e96;
+  margin-top: 0.25rem;
+}
+
+.topic__empty {
+  font-size: 0.875rem;
+  color: #868e96;
+  margin: 0;
+}

--- a/src/app/routes/topic-page/topic-page.component.ts
+++ b/src/app/routes/topic-page/topic-page.component.ts
@@ -1,0 +1,100 @@
+import { Component } from '@angular/core';
+import { AsyncPipe, DatePipe, NgFor, NgIf } from '@angular/common';
+import { ActivatedRoute, RouterLink } from '@angular/router';
+import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
+import { Color, NgxChartsModule, ScaleType } from '@swimlane/ngx-charts';
+import { marked } from 'marked';
+import { map, switchMap } from 'rxjs/operators';
+
+import { toLoadingState } from '../../models/loading-state.model';
+import { TopicDataService } from '../../services/topic-data.service';
+import { TopicDetail, NewsItem, TopicEvent } from '../../models/news.model';
+
+interface TopicEventGroup {
+  event: TopicEvent;
+  items: NewsItem[];
+}
+
+interface TopicDetailView {
+  lastUpdated: Date;
+  curatedHtml: SafeHtml;
+  detail: TopicDetail;
+  momentumChart: { name: string; series: { name: Date; value: number }[] }[];
+  eventGroups: TopicEventGroup[];
+  callouts: { title: string; body: SafeHtml }[];
+}
+
+@Component({
+  selector: 'app-topic-page',
+  standalone: true,
+  imports: [NgIf, NgFor, AsyncPipe, DatePipe, RouterLink, NgxChartsModule],
+  templateUrl: './topic-page.component.html',
+  styleUrl: './topic-page.component.scss'
+})
+export class TopicPageComponent {
+  readonly colorScheme: Color = {
+    name: 'topicMomentum',
+    selectable: false,
+    group: ScaleType.Ordinal,
+    domain: ['#4c6ef5']
+  };
+
+  readonly viewState$ = toLoadingState(
+    this.route.paramMap.pipe(
+      map(params => params.get('slug') ?? ''),
+      switchMap(slug => this.topicDataService.getTopicDetail(slug)),
+      map(detail => this.buildView(detail))
+    )
+  );
+
+  constructor(
+    private route: ActivatedRoute,
+    private topicDataService: TopicDataService,
+    private sanitizer: DomSanitizer
+  ) {
+    marked.setOptions({ breaks: true });
+  }
+
+  trackByEvent(_: number, group: TopicEventGroup): string {
+    return group.event.slug;
+  }
+
+  private buildView(detail: TopicDetail): TopicDetailView {
+    const curatedHtml = this.renderMarkdown(detail.topic.curatedCopy || '');
+
+    const callouts = (detail.topic.callouts || []).map(callout => ({
+      title: callout.title,
+      body: this.renderMarkdown(callout.markdown || '')
+    }));
+
+    const momentumChart = [
+      {
+        name: detail.topic.title,
+        series: detail.topic.momentumSeries.map(point => ({
+          name: point.date,
+          value: point.value
+        }))
+      }
+    ];
+
+    const eventGroups = detail.topic.events.map(event => ({
+      event,
+      items: detail.items.filter(item => item.eventSlug === event.slug)
+    }));
+
+    return {
+      lastUpdated: detail.lastUpdated,
+      curatedHtml,
+      detail,
+      momentumChart,
+      eventGroups,
+      callouts
+    };
+  }
+
+  private renderMarkdown(markdown: string): SafeHtml {
+    const rendered = marked.parse(markdown || '');
+    const html = typeof rendered === 'string' ? rendered : '';
+    return this.sanitizer.bypassSecurityTrustHtml(html);
+  }
+}

--- a/src/app/services/topic-data.service.ts
+++ b/src/app/services/topic-data.service.ts
@@ -1,0 +1,119 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { catchError, map, shareReplay } from 'rxjs/operators';
+import {
+  NewsItem,
+  Topic,
+  TopicDataset,
+  TopicDetail,
+  TopicEvent,
+  MomentumPoint
+} from '../models/news.model';
+
+interface RawNewsItem extends Omit<NewsItem, 'pubDate'> {
+  pubDate: string;
+}
+
+interface RawMomentumPoint extends Omit<MomentumPoint, 'date'> {
+  date: string;
+}
+
+interface RawTopicEvent extends Omit<TopicEvent, 'date'> {
+  date: string;
+}
+
+interface RawTopic extends Omit<Topic, 'events' | 'momentumSeries'> {
+  events: RawTopicEvent[];
+  momentumSeries: RawMomentumPoint[];
+}
+
+interface RawTopicDataset {
+  lastUpdated: string;
+  topics: RawTopic[];
+  items: RawNewsItem[];
+}
+
+@Injectable({
+  providedIn: 'root'
+})
+export class TopicDataService {
+  private readonly apiUrl = '/api/news';
+  private readonly fallbackUrl = 'assets/data/news-topics.json';
+  private dataset$?: Observable<TopicDataset>;
+
+  constructor(private http: HttpClient) {}
+
+  getDataset(): Observable<TopicDataset> {
+    if (!this.dataset$) {
+      this.dataset$ = this.fetchDataset().pipe(shareReplay(1));
+    }
+    return this.dataset$;
+  }
+
+  getTopicDetail(slug: string): Observable<TopicDetail> {
+    return this.getDataset().pipe(
+      map(dataset => {
+        const topic = dataset.topics.find(t => t.slug === slug);
+        if (!topic) {
+          throw new Error(`Topic '${slug}' not found`);
+        }
+
+        const items = dataset.items.filter(item => item.topics?.includes(slug));
+        return {
+          lastUpdated: dataset.lastUpdated,
+          topic,
+          items
+        };
+      })
+    );
+  }
+
+  private fetchDataset(): Observable<TopicDataset> {
+    return this.http.get<RawTopicDataset>(this.apiUrl).pipe(
+      map(raw => this.transformDataset(raw)),
+      catchError(() =>
+        this.http
+          .get<RawTopicDataset>(this.fallbackUrl)
+          .pipe(map(raw => this.transformDataset(raw)))
+      )
+    );
+  }
+
+  private transformDataset(raw: RawTopicDataset): TopicDataset {
+    return {
+      lastUpdated: new Date(raw.lastUpdated),
+      topics: raw.topics.map(topic => this.transformTopic(topic)),
+      items: raw.items.map(item => this.transformNewsItem(item))
+    };
+  }
+
+  private transformTopic(raw: RawTopic): Topic {
+    return {
+      ...raw,
+      momentumSeries: raw.momentumSeries.map(point => this.transformMomentum(point)),
+      events: raw.events.map(event => this.transformEvent(event))
+    };
+  }
+
+  private transformEvent(raw: RawTopicEvent): TopicEvent {
+    return {
+      ...raw,
+      date: new Date(raw.date)
+    };
+  }
+
+  private transformMomentum(raw: RawMomentumPoint): MomentumPoint {
+    return {
+      ...raw,
+      date: new Date(raw.date)
+    };
+  }
+
+  private transformNewsItem(raw: RawNewsItem): NewsItem {
+    return {
+      ...raw,
+      pubDate: new Date(raw.pubDate)
+    };
+  }
+}

--- a/src/assets/data/news-topics.json
+++ b/src/assets/data/news-topics.json
@@ -1,0 +1,295 @@
+{
+  "lastUpdated": "2024-09-30T18:30:00.000Z",
+  "topics": [
+    {
+      "slug": "legal-battles",
+      "title": "Legal Battles and Court Strategy",
+      "summary": "Tracking how Trump's campaign weaponizes ongoing court fights to energize supporters and drive fundraising.",
+      "curatedCopy": "## Courtroom vs. Campaign\nThe campaign treats every filing and hearing as a two-for-one opportunity: legal defense by day, campaign rallying cry by night. Fundraising texts reference each development within minutes, and surrogates translate legal jargon into a persecution narrative built for cable hits.\n\n### Messaging pillars\n- Portray restrictions as election interference.\n- Tie prosecutors to Democratic leaders by name.\n- Pledge to overhaul the justice system on day one.",
+      "callouts": [
+        {
+          "title": "Why it matters",
+          "markdown": "- Legal updates regularly spike small-dollar donations.\n- Base voters cite legal fights as proof the movement is under attack."
+        },
+        {
+          "title": "Watch the calendar",
+          "markdown": "Sentencing and pre-trial hearings align with key fundraising deadlines, giving the campaign recurring content moments."
+        }
+      ],
+      "spotlightIds": ["article-1"],
+      "momentumSeries": [
+        { "date": "2024-09-18", "value": 38 },
+        { "date": "2024-09-22", "value": 47 },
+        { "date": "2024-09-25", "value": 56 },
+        { "date": "2024-09-27", "value": 59 },
+        { "date": "2024-09-30", "value": 61 }
+      ],
+      "events": [
+        {
+          "slug": "georgia-ruling",
+          "title": "Georgia racketeering ruling resets the clock",
+          "date": "2024-09-23T10:00:00.000Z",
+          "description": "A Fulton County judge delays proceedings into 2025. The campaign frames the pause as proof the case is collapsing and uses the reprieve to claim momentum in swing states.",
+          "momentum": 58,
+          "relatedItemIds": ["article-1", "article-2"]
+        },
+        {
+          "slug": "gag-order-fight",
+          "title": "New York gag order fight becomes a censorship narrative",
+          "date": "2024-09-27T18:00:00.000Z",
+          "description": "Surrogates argue that limits on Trump's speech are an attack on supporters, driving sympathetic coverage and op-eds from allies.",
+          "momentum": 62,
+          "relatedItemIds": ["article-3"]
+        },
+        {
+          "slug": "immunity-appeal",
+          "title": "Supreme Court appeal teasers revive immunity storyline",
+          "date": "2024-09-29T14:30:00.000Z",
+          "description": "Campaign lawyers preview new filings that they say will shield Trump from future prosecutions, reinforcing the promise of a second-term crackdown on DOJ critics.",
+          "momentum": 64,
+          "relatedItemIds": ["article-4"]
+        }
+      ]
+    },
+    {
+      "slug": "ground-game",
+      "title": "Swing-State Ground Game",
+      "summary": "Field organizing pushes in the Rust Belt and Sun Belt aimed at closing the early-vote gap.",
+      "curatedCopy": "## Organizing Infrastructure\nField staff are leaning on county GOP offices, faith leaders, and a revived \"Trump Force 47\" volunteer portal. The campaign highlights door-knocking stats at every rally to signal professionalization while maintaining the outsider vibe.\n\n### Key tactics\n1. Overlapping bus tours in Pennsylvania, Michigan, and Georgia.\n2. Micro-targeted radio ads focused on energy costs and border security.\n3. Faith outreach breakfasts that double as data collection events.",
+      "callouts": [
+        {
+          "title": "Staffing snapshot",
+          "markdown": "- 48 paid staffers announced across four battleground states.\n- County captains recruited from 2020 stop-the-steal networks."
+        }
+      ],
+      "spotlightIds": ["article-5"],
+      "momentumSeries": [
+        { "date": "2024-09-18", "value": 32 },
+        { "date": "2024-09-22", "value": 36 },
+        { "date": "2024-09-25", "value": 40 },
+        { "date": "2024-09-27", "value": 44 },
+        { "date": "2024-09-30", "value": 49 }
+      ],
+      "events": [
+        {
+          "slug": "pennsylvania-field-offices",
+          "title": "Six new Pennsylvania field offices open ahead of mail voting",
+          "date": "2024-09-24T15:00:00.000Z",
+          "description": "Campaign claims 8,000 volunteers signed up after the openings, using live streams from each ribbon cutting.",
+          "momentum": 46,
+          "relatedItemIds": ["article-5", "article-6"]
+        },
+        {
+          "slug": "rural-bus-tour",
+          "title": "Rural bus tour spotlights energy message",
+          "date": "2024-09-26T20:00:00.000Z",
+          "description": "Surrogates barnstorm rural Ohio and Michigan touting drilling permits and farmers' fuel costs, capturing local TV coverage.",
+          "momentum": 48,
+          "relatedItemIds": ["article-7"]
+        },
+        {
+          "slug": "latino-faith-outreach",
+          "title": "Latino faith outreach adds bilingual voter guides",
+          "date": "2024-09-28T17:00:00.000Z",
+          "description": "Church partnerships distribute Spanish-language voter packets, part of a broader move to chip into Biden's coalition.",
+          "momentum": 50,
+          "relatedItemIds": ["article-8"]
+        }
+      ]
+    },
+    {
+      "slug": "issue-messaging",
+      "title": "Issue Messaging & Narrative Testing",
+      "summary": "Rapid-response talking points on immigration, inflation, and foreign policy tested across conservative media.",
+      "curatedCopy": "## Narrative Testing\nCampaign pollsters feed nightly findings into surrogate briefings. Messaging pivots quickly to keep the news cycle on favorable terrain, often marrying immigration with inflation to hold focus.\n\n#### Channels\n- Late-night Truth Social posts.\n- Podcast blitzes hosted by allied influencers.\n- Geo-targeted pre-roll ads that shift by state.",
+      "callouts": [
+        {
+          "title": "Rapid-response cadence",
+          "markdown": "Clip packages are cut within 45 minutes of any major Biden gaffe and sent to a 2,000-person surrogate list."
+        }
+      ],
+      "spotlightIds": ["article-9"],
+      "momentumSeries": [
+        { "date": "2024-09-18", "value": 41 },
+        { "date": "2024-09-22", "value": 43 },
+        { "date": "2024-09-25", "value": 47 },
+        { "date": "2024-09-27", "value": 52 },
+        { "date": "2024-09-30", "value": 55 }
+      ],
+      "events": [
+        {
+          "slug": "immigration-ad-blitz",
+          "title": "Immigration ad blitz ties border to inflation",
+          "date": "2024-09-25T12:00:00.000Z",
+          "description": "A wave of digital ads claims rising grocery prices stem from federal spending on migrants, a talking point echoed by surrogates on radio.",
+          "momentum": 53,
+          "relatedItemIds": ["article-9", "article-10"]
+        },
+        {
+          "slug": "debate-prep-messaging",
+          "title": "Debate prep memos leak to conservative outlets",
+          "date": "2024-09-29T11:00:00.000Z",
+          "description": "Selective leaks preview attacks on Biden's foreign policy, keeping the focus on Afghanistan while framing Trump as steady on world affairs.",
+          "momentum": 57,
+          "relatedItemIds": ["article-11"]
+        }
+      ]
+    }
+  ],
+  "items": [
+    {
+      "id": "article-1",
+      "title": "Trump campaign blasts Georgia prosecutors after trial delay",
+      "link": "https://example.com/trump-georgia-delay",
+      "pubDate": "2024-09-23T15:45:00.000Z",
+      "content": "Senior aides told reporters the delay proves the case is political, urging supporters to donate to \"finish the fight\".",
+      "source": "Politico",
+      "category": "Legal",
+      "imageUrl": "https://images.example.com/trump-court.jpg",
+      "topics": ["legal-battles"],
+      "eventSlug": "georgia-ruling",
+      "sentiment": "positive",
+      "momentumScore": 58
+    },
+    {
+      "id": "article-2",
+      "title": "Fundraising text blitz follows Georgia ruling",
+      "link": "https://example.com/fundraising-texts",
+      "pubDate": "2024-09-24T02:30:00.000Z",
+      "content": "Within hours of the judge's order, the campaign sent seven fundraising texts referencing \"witch hunt delays\".",
+      "source": "Axios",
+      "category": "Campaign Finance",
+      "imageUrl": "https://images.example.com/text-blitz.jpg",
+      "topics": ["legal-battles", "ground-game"],
+      "eventSlug": "georgia-ruling",
+      "sentiment": "positive",
+      "momentumScore": 57
+    },
+    {
+      "id": "article-3",
+      "title": "Trump allies decry gag order on conservative media",
+      "link": "https://example.com/gag-order-response",
+      "pubDate": "2024-09-27T22:10:00.000Z",
+      "content": "Surrogates lined up on talk radio to argue that the gag order is really aimed at silencing supporters.",
+      "source": "Fox News",
+      "category": "Media",
+      "imageUrl": "https://images.example.com/gag-order.jpg",
+      "topics": ["legal-battles", "issue-messaging"],
+      "eventSlug": "gag-order-fight",
+      "sentiment": "positive",
+      "momentumScore": 62
+    },
+    {
+      "id": "article-4",
+      "title": "Campaign previews Supreme Court immunity appeal",
+      "link": "https://example.com/immunity-appeal",
+      "pubDate": "2024-09-29T16:05:00.000Z",
+      "content": "Advisers say a conservative majority will rein in the Department of Justice, promising day-one reforms.",
+      "source": "Wall Street Journal",
+      "category": "Legal",
+      "imageUrl": "https://images.example.com/supreme-court.jpg",
+      "topics": ["legal-battles", "issue-messaging"],
+      "eventSlug": "immunity-appeal",
+      "sentiment": "positive",
+      "momentumScore": 64
+    },
+    {
+      "id": "article-5",
+      "title": "Trump opens six field offices across Pennsylvania",
+      "link": "https://example.com/pennsylvania-field",
+      "pubDate": "2024-09-24T18:30:00.000Z",
+      "content": "Ribbon cuttings featured local lawmakers and targeted messages about energy prices.",
+      "source": "Philadelphia Inquirer",
+      "category": "Ground Game",
+      "imageUrl": "https://images.example.com/field-office.jpg",
+      "topics": ["ground-game"],
+      "eventSlug": "pennsylvania-field-offices",
+      "sentiment": "positive",
+      "momentumScore": 46
+    },
+    {
+      "id": "article-6",
+      "title": "Volunteer sign-ups surge after field office blitz",
+      "link": "https://example.com/volunteer-surge",
+      "pubDate": "2024-09-25T14:20:00.000Z",
+      "content": "Campaign claims 8,000 new volunteers, though Democrats dispute the number.",
+      "source": "NBC News",
+      "category": "Ground Game",
+      "imageUrl": "https://images.example.com/volunteers.jpg",
+      "topics": ["ground-game"],
+      "eventSlug": "pennsylvania-field-offices",
+      "sentiment": "neutral",
+      "momentumScore": 44
+    },
+    {
+      "id": "article-7",
+      "title": "Rural bus tour amplifies energy message",
+      "link": "https://example.com/rural-bus",
+      "pubDate": "2024-09-26T22:40:00.000Z",
+      "content": "The bus tour stops at small-town diners with local radio hits about drilling and inflation.",
+      "source": "Cleveland Plain Dealer",
+      "category": "Ground Game",
+      "imageUrl": "https://images.example.com/bus-tour.jpg",
+      "topics": ["ground-game", "issue-messaging"],
+      "eventSlug": "rural-bus-tour",
+      "sentiment": "positive",
+      "momentumScore": 48
+    },
+    {
+      "id": "article-8",
+      "title": "Latino pastors partner with Trump team on voter guides",
+      "link": "https://example.com/latino-voter-guides",
+      "pubDate": "2024-09-28T19:15:00.000Z",
+      "content": "Spanish-language voter packets are distributed alongside food drives in Phoenix and Orlando.",
+      "source": "Univision",
+      "category": "Outreach",
+      "imageUrl": "https://images.example.com/latino-outreach.jpg",
+      "topics": ["ground-game"],
+      "eventSlug": "latino-faith-outreach",
+      "sentiment": "positive",
+      "momentumScore": 50
+    },
+    {
+      "id": "article-9",
+      "title": "Immigration ad blitz links border to inflation",
+      "link": "https://example.com/immigration-ads",
+      "pubDate": "2024-09-25T13:10:00.000Z",
+      "content": "Ads feature grocery carts and Border Patrol footage, testing a new hybrid message.",
+      "source": "Washington Post",
+      "category": "Advertising",
+      "imageUrl": "https://images.example.com/immigration-ads.jpg",
+      "topics": ["issue-messaging"],
+      "eventSlug": "immigration-ad-blitz",
+      "sentiment": "positive",
+      "momentumScore": 53
+    },
+    {
+      "id": "article-10",
+      "title": "Fact-checkers push back on ad claims about migrant spending",
+      "link": "https://example.com/fact-check",
+      "pubDate": "2024-09-26T09:00:00.000Z",
+      "content": "Independent fact-checkers say the numbers are exaggerated, but the campaign doubles down in response videos.",
+      "source": "AP",
+      "category": "Fact Check",
+      "imageUrl": "https://images.example.com/fact-check.jpg",
+      "topics": ["issue-messaging", "legal-battles"],
+      "eventSlug": "immigration-ad-blitz",
+      "sentiment": "negative",
+      "momentumScore": 48
+    },
+    {
+      "id": "article-11",
+      "title": "Debate prep memo outlines foreign policy attacks",
+      "link": "https://example.com/debate-memo",
+      "pubDate": "2024-09-29T13:55:00.000Z",
+      "content": "Leaked slides suggest a focus on Afghanistan, arguing Biden cannot handle crises abroad.",
+      "source": "Bloomberg",
+      "category": "Debate",
+      "imageUrl": "https://images.example.com/debate-prep.jpg",
+      "topics": ["issue-messaging", "legal-battles"],
+      "eventSlug": "debate-prep-messaging",
+      "sentiment": "positive",
+      "momentumScore": 57
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add timeline and topic routes that render curated copy, grouped events, and momentum charts for campaign coverage
- introduce a topic data service, shared dataset, and express API that enrich news items with topic and event metadata
- refresh the shell navigation, dependencies, and build budgets to support the new experience

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ea813dabec83268a1b2b7eec2ec634