### PR TITLE
Add themed shell layout and dark mode toggle

### DIFF
--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -4,26 +4,13 @@ import { AppComponent } from './app.component';
 describe('AppComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [AppComponent],
+      imports: [AppComponent]
     }).compileComponents();
   });
 
-  it('should create the app', () => {
+  it('should create the app shell', () => {
     const fixture = TestBed.createComponent(AppComponent);
     const app = fixture.componentInstance;
     expect(app).toBeTruthy();
-  });
-
-  it(`should have the 'trump-tracker' title`, () => {
-    const fixture = TestBed.createComponent(AppComponent);
-    const app = fixture.componentInstance;
-    expect(app.title).toEqual('trump-tracker');
-  });
-
-  it('should render title', () => {
-    const fixture = TestBed.createComponent(AppComponent);
-    fixture.detectChanges();
-    const compiled = fixture.nativeElement as HTMLElement;
-    expect(compiled.querySelector('h1')?.textContent).toContain('Hello, trump-tracker');
   });
 });

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,24 +1,10 @@
 import { Component } from '@angular/core';
 import { RouterOutlet } from '@angular/router';
-import { NewsFeedComponent } from './components/news-feed/news-feed.component';
 
 @Component({
   selector: 'app-root',
   standalone: true,
-  imports: [RouterOutlet, NewsFeedComponent],
-  template: `
-    <main>
-      <app-news-feed></app-news-feed>
-    </main>
-  `,
-  styles: [`
-    main {
-      min-height: 100vh;
-      background: #f0f2f5;
-      padding: 20px 0;
-    }
-  `]
+  imports: [RouterOutlet],
+  template: '<router-outlet></router-outlet>'
 })
-export class AppComponent {
-  title = 'Trump 47 Campaign Tracker';
-}
+export class AppComponent {}

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -1,3 +1,17 @@
 import { Routes } from '@angular/router';
+import { ShellComponent } from './components/shell/shell.component';
+import { NewsFeedComponent } from './components/news-feed/news-feed.component';
 
-export const routes: Routes = [];
+export const routes: Routes = [
+  {
+    path: '',
+    component: ShellComponent,
+    children: [
+      { path: '', component: NewsFeedComponent }
+    ]
+  },
+  {
+    path: '**',
+    redirectTo: ''
+  }
+];

--- a/src/app/components/featured-stories/featured-stories.component.html
+++ b/src/app/components/featured-stories/featured-stories.component.html
@@ -1,0 +1,25 @@
+<section class="featured-stories" aria-labelledby="featured-heading" id="stories">
+  <div class="featured-stories__header">
+    <h2 id="featured-heading">Featured stories</h2>
+    <p class="featured-stories__description">Curated highlights from the campaign trail.</p>
+  </div>
+
+  <ul class="featured-stories__list">
+    <li *ngFor="let story of stories" class="featured-stories__item">
+      <article>
+        <header>
+          <p class="featured-stories__topic">{{ story.topic }}</p>
+          <h3>{{ story.title }}</h3>
+        </header>
+        <p>{{ story.excerpt }}</p>
+        <a
+          class="featured-stories__link"
+          [href]="story.url"
+          target="_blank"
+          rel="noopener noreferrer"
+          >Read the update<span aria-hidden="true"> →</span></a
+        >
+      </article>
+    </li>
+  </ul>
+</section>

--- a/src/app/components/featured-stories/featured-stories.component.scss
+++ b/src/app/components/featured-stories/featured-stories.component.scss
@@ -1,0 +1,89 @@
+.featured-stories {
+  background: var(--surface-raised);
+  border-radius: var(--radius-xl);
+  padding: var(--space-lg);
+  box-shadow: var(--shadow-md);
+  border: 1px solid var(--border-subtle);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-md);
+}
+
+.featured-stories__header {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xs);
+
+  h2 {
+    font-size: 1.25rem;
+    font-weight: 700;
+  }
+
+  .featured-stories__description {
+    color: var(--text-muted);
+  }
+}
+
+.featured-stories__list {
+  list-style: none;
+  display: grid;
+  gap: var(--space-md);
+  padding: 0;
+  margin: 0;
+}
+
+.featured-stories__item {
+  article {
+    background: var(--surface-muted);
+    border-radius: var(--radius-lg);
+    padding: var(--space-md);
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-sm);
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+    border: 1px solid transparent;
+
+    &:focus-within,
+    &:hover {
+      transform: translateY(-2px);
+      box-shadow: var(--shadow-elevated);
+      border-color: var(--accent-muted-strong);
+    }
+
+    h3 {
+      font-size: 1.1rem;
+    }
+
+    p {
+      color: var(--text-muted);
+    }
+  }
+}
+
+.featured-stories__topic {
+  display: inline-flex;
+  align-self: flex-start;
+  padding: 0 var(--space-xs);
+  height: 1.5rem;
+  align-items: center;
+  border-radius: var(--radius-pill);
+  background: var(--accent-muted);
+  color: var(--accent-strong);
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+}
+
+.featured-stories__link {
+  font-weight: 600;
+  color: var(--accent);
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-xxs);
+
+  &:focus-visible,
+  &:hover {
+    text-decoration: underline;
+    outline: none;
+  }
+}

--- a/src/app/components/featured-stories/featured-stories.component.ts
+++ b/src/app/components/featured-stories/featured-stories.component.ts
@@ -1,0 +1,40 @@
+import { CommonModule } from '@angular/common';
+import { Component, ChangeDetectionStrategy } from '@angular/core';
+
+type FeaturedStory = {
+  title: string;
+  excerpt: string;
+  topic: string;
+  url: string;
+};
+
+@Component({
+  selector: 'app-featured-stories',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './featured-stories.component.html',
+  styleUrls: ['./featured-stories.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class FeaturedStoriesComponent {
+  readonly stories: FeaturedStory[] = [
+    {
+      title: 'Ground Game Intensifies in Swing States',
+      excerpt: 'Organizers ramp up door-to-door outreach in Pennsylvania and Arizona as polling margins tighten.',
+      topic: 'Field Operations',
+      url: 'https://www.donaldjtrump.com/news/'
+    },
+    {
+      title: 'Fundraising Push Sets New Monthly Record',
+      excerpt: 'Digital campaigns and grassroots donations combine for a historic funding surge across small-dollar donors.',
+      topic: 'Fundraising',
+      url: 'https://www.donaldjtrump.com/news/'
+    },
+    {
+      title: 'Policy Rollout Focuses on Energy Independence',
+      excerpt: 'The campaign outlines a renewed strategy for domestic energy production aimed at lowering costs for families.',
+      topic: 'Policy',
+      url: 'https://www.donaldjtrump.com/news/'
+    }
+  ];
+}

--- a/src/app/components/insights-sidebar/insights-sidebar.component.html
+++ b/src/app/components/insights-sidebar/insights-sidebar.component.html
@@ -1,0 +1,23 @@
+<aside class="insights" aria-labelledby="insights-heading" id="insights">
+  <div class="insights__header">
+    <h2 id="insights-heading">Campaign insights</h2>
+    <p class="insights__description">Key performance signals updated throughout the day.</p>
+  </div>
+
+  <ul class="insights__metrics" role="list">
+    <li *ngFor="let insight of insights" class="insights__metric" [attr.data-trend]="insight.trend">
+      <div class="insights__metric-header">
+        <p class="insights__metric-label">{{ insight.label }}</p>
+        <p class="insights__metric-value">{{ insight.value }}</p>
+      </div>
+      <p class="insights__metric-description">{{ insight.description }}</p>
+    </li>
+  </ul>
+
+  <section class="insights__actions" aria-labelledby="actions-heading">
+    <h3 id="actions-heading">Next actions</h3>
+    <ol>
+      <li *ngFor="let action of keyActions">{{ action }}</li>
+    </ol>
+  </section>
+</aside>

--- a/src/app/components/insights-sidebar/insights-sidebar.component.scss
+++ b/src/app/components/insights-sidebar/insights-sidebar.component.scss
@@ -1,0 +1,93 @@
+.insights {
+  background: var(--surface-raised);
+  border-radius: var(--radius-xl);
+  padding: var(--space-lg);
+  box-shadow: var(--shadow-md);
+  border: 1px solid var(--border-subtle);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-lg);
+}
+
+.insights__header {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xs);
+
+  h2 {
+    font-size: 1.25rem;
+    font-weight: 700;
+  }
+
+  .insights__description {
+    color: var(--text-muted);
+  }
+}
+
+.insights__metrics {
+  display: grid;
+  gap: var(--space-sm);
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.insights__metric {
+  border-radius: var(--radius-lg);
+  padding: var(--space-md);
+  background: var(--surface-muted);
+  border: 1px solid transparent;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+
+  &[data-trend='up'] {
+    border-color: var(--trend-positive);
+  }
+
+  &[data-trend='down'] {
+    border-color: var(--trend-negative);
+  }
+
+  &[data-trend='steady'] {
+    border-color: var(--trend-neutral);
+  }
+
+  &:focus-within,
+  &:hover {
+    box-shadow: var(--shadow-elevated);
+  }
+}
+
+.insights__metric-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  margin-bottom: var(--space-xs);
+}
+
+.insights__metric-label {
+  font-weight: 600;
+  color: var(--text-muted);
+}
+
+.insights__metric-value {
+  font-size: 1.5rem;
+  font-weight: 700;
+}
+
+.insights__metric-description {
+  color: var(--text-muted);
+}
+
+.insights__actions {
+  h3 {
+    font-size: 1.1rem;
+    margin-bottom: var(--space-sm);
+  }
+
+  ol {
+    padding-left: 1.25rem;
+    display: grid;
+    gap: var(--space-xs);
+    color: var(--text-muted);
+  }
+}

--- a/src/app/components/insights-sidebar/insights-sidebar.component.ts
+++ b/src/app/components/insights-sidebar/insights-sidebar.component.ts
@@ -1,0 +1,46 @@
+import { CommonModule } from '@angular/common';
+import { Component, ChangeDetectionStrategy } from '@angular/core';
+
+type Insight = {
+  label: string;
+  value: string;
+  trend: 'up' | 'down' | 'steady';
+  description: string;
+};
+
+@Component({
+  selector: 'app-insights-sidebar',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './insights-sidebar.component.html',
+  styleUrls: ['./insights-sidebar.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class InsightsSidebarComponent {
+  readonly insights: Insight[] = [
+    {
+      label: 'Digital reach',
+      value: '2.1M',
+      trend: 'up',
+      description: 'Impressions across official channels in the last 48 hours'
+    },
+    {
+      label: 'Grassroots events',
+      value: '38',
+      trend: 'steady',
+      description: 'Scheduled rallies and town halls this week'
+    },
+    {
+      label: 'Volunteer signups',
+      value: '+14%',
+      trend: 'up',
+      description: 'Week-over-week increase in new volunteers'
+    }
+  ];
+
+  readonly keyActions: string[] = [
+    'Track upcoming debate preparation milestones',
+    'Highlight localized policy rollouts for supporters',
+    'Coordinate regional press availability with rapid response team'
+  ];
+}

--- a/src/app/components/news-feed/news-feed.component.html
+++ b/src/app/components/news-feed/news-feed.component.html
@@ -1,9 +1,9 @@
-<div class="news-feed">
+<div class="news-feed" role="region" aria-labelledby="news-feed-heading">
   <header>
-    <h1>Trump 2024 Campaign News</h1>
+    <h1 id="news-feed-heading">Trump 2024 Campaign News</h1>
 
     <div class="controls">
-      <div class="filters">
+      <div class="filters" role="search">
         <input
           type="text"
           [ngModel]="searchTerm"
@@ -46,7 +46,7 @@
           <span *ngIf="!loading">Refresh</span>
           <span *ngIf="loading">Refreshing...</span>
         </button>
-        <span class="last-updated" aria-label="Last updated time">
+        <span class="last-updated" aria-label="Last updated time" aria-live="polite">
           Last updated: {{ lastUpdatedText }}
         </span>
       </div>
@@ -65,7 +65,7 @@
     </button>
   </div>
 
-  <div *ngIf="!loading || newsItems.length" class="news-items">
+  <div *ngIf="!loading || newsItems.length" class="news-items" role="list">
     <div *ngIf="filteredItems.length === 0" class="no-results" role="status">
       <p *ngIf="hasActiveFilters">
         No news items found matching your search criteria.
@@ -78,7 +78,9 @@
 
     <app-news-item
       *ngFor="let item of filteredItems"
-      [item]="item">
+      [item]="item"
+      role="listitem"
+      class="news-items__item">
     </app-news-item>
   </div>
 </div>

--- a/src/app/components/news-feed/news-feed.component.scss
+++ b/src/app/components/news-feed/news-feed.component.scss
@@ -1,269 +1,220 @@
 .news-feed {
-  max-width: 1200px;
-  margin: 0 auto;
-  padding: 20px;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-lg);
+}
 
-  @media (max-width: 768px) {
-    padding: 16px;
-  }
+.news-feed header {
+  background: var(--surface-raised);
+  border-radius: var(--radius-xl);
+  padding: clamp(1.5rem, 4vw, 2.5rem);
+  border: 1px solid var(--border-subtle);
+  box-shadow: var(--shadow-md);
+  display: grid;
+  gap: var(--space-lg);
+}
 
-  header {
-    margin-bottom: 40px;
+.news-feed header h1 {
+  color: var(--text-primary);
+  font-size: clamp(2rem, 4vw, 3rem);
+  font-weight: 800;
+  text-align: left;
+  line-height: 1.1;
+}
 
-    h1 {
-      color: var(--text-primary);
-      text-align: center;
-      margin-bottom: 32px;
-      font-size: clamp(2rem, 5vw, 3rem);
-      font-weight: 800;
-      letter-spacing: -0.03em;
-      line-height: 1.2;
-    }
+.news-feed .controls {
+  display: grid;
+  gap: var(--space-md);
+}
 
-    .controls {
-      background: var(--card-background);
-      padding: clamp(16px, 3vw, 24px);
-      border-radius: 20px;
-      box-shadow: var(--shadow);
-      border: 1px solid var(--border-color);
+.news-feed .controls .filters {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-sm);
+}
 
-      .filters {
-        display: flex;
-        gap: 16px;
-        margin-bottom: 24px;
+.news-feed .controls .filters .search-input,
+.news-feed .controls .filters .source-select {
+  flex: 1 1 220px;
+  min-width: 180px;
+  padding: var(--space-sm) var(--space-md);
+  border-radius: var(--radius-lg);
+  border: 2px solid var(--border-subtle);
+  background: var(--surface-muted);
+  color: var(--text-primary);
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
 
-        @media (max-width: 768px) {
-          flex-direction: column;
-          gap: 12px;
-        }
+.news-feed .controls .filters .search-input:focus,
+.news-feed .controls .filters .source-select:focus {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: var(--shadow-focus);
+}
 
-        .search-input {
-          flex: 1;
-          padding: 12px 16px;
-          border: 2px solid var(--border-color);
-          border-radius: 12px;
-          font-size: 1rem;
-          transition: all 0.2s ease;
+.news-feed .controls .filters .search-input::placeholder {
+  color: var(--text-muted);
+}
 
-          &:focus {
-            outline: none;
-            border-color: var(--primary-color);
-            box-shadow: 0 0 0 4px rgba(255, 69, 0, 0.1);
-          }
+.news-feed .controls .filters .clear-btn {
+  flex: 0 0 auto;
+  padding: var(--space-sm) var(--space-md);
+  border-radius: var(--radius-pill);
+  border: 1px solid var(--border-subtle);
+  background: transparent;
+  color: var(--text-muted);
+  font-weight: 600;
+  cursor: pointer;
+  transition: background-color 0.2s ease, color 0.2s ease;
+}
 
-          &::placeholder {
-            color: var(--text-tertiary);
-          }
-        }
+.news-feed .controls .filters .clear-btn:hover,
+.news-feed .controls .filters .clear-btn:focus-visible {
+  background: var(--accent-muted);
+  color: var(--text-primary);
+  outline: none;
+}
 
-        .source-select {
-          padding: 12px 16px;
-          border: 2px solid var(--border-color);
-          border-radius: 12px;
-          font-size: 1rem;
-          min-width: 180px;
-          cursor: pointer;
-          background: var(--card-background);
-          transition: all 0.2s ease;
+.news-feed .controls .refresh-control {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-sm);
+  align-items: center;
+  justify-content: space-between;
+}
 
-          @media (max-width: 768px) {
-            width: 100%;
-          }
+.news-feed .controls .refresh-control .refresh-btn {
+  background: var(--accent);
+  color: var(--text-inverse);
+  border: none;
+  border-radius: var(--radius-pill);
+  padding: var(--space-sm) var(--space-lg);
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.2s ease, background-color 0.2s ease, box-shadow 0.2s ease;
+}
 
-          &:focus {
-            outline: none;
-            border-color: var(--primary-color);
-            box-shadow: 0 0 0 4px rgba(255, 69, 0, 0.1);
-          }
-        }
+.news-feed .controls .refresh-control .refresh-btn:hover:not(:disabled),
+.news-feed .controls .refresh-control .refresh-btn:focus-visible:not(:disabled) {
+  background: var(--accent-strong);
+  transform: translateY(-1px);
+  box-shadow: var(--shadow-elevated);
+  outline: none;
+}
 
-        .clear-btn {
-          padding: 12px 20px;
-          background: var(--background);
-          border: 1px solid var(--border-color);
-          border-radius: 12px;
-          cursor: pointer;
-          font-size: 1rem;
-          font-weight: 500;
-          color: var(--text-secondary);
-          transition: all 0.2s ease;
+.news-feed .controls .refresh-control .refresh-btn:disabled {
+  background: var(--primary-light);
+  cursor: not-allowed;
+  transform: none;
+}
 
-          @media (max-width: 768px) {
-            width: 100%;
-          }
+.news-feed .controls .refresh-control .last-updated {
+  color: var(--text-muted);
+  font-size: 0.9rem;
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-xxs);
+}
 
-          &:hover {
-            background: var(--border-color);
-            color: var(--text-primary);
-          }
-        }
-      }
+.news-feed .controls .refresh-control .last-updated::before {
+  content: '';
+  width: 0.5rem;
+  height: 0.5rem;
+  border-radius: 999px;
+  background: var(--trend-positive);
+  box-shadow: 0 0 0 3px rgba(34, 197, 94, 0.25);
+}
 
-      .refresh-control {
-        display: flex;
-        align-items: center;
-        justify-content: space-between;
-        flex-wrap: wrap;
-        gap: 16px;
+.news-feed .loading,
+.news-feed .error,
+.news-feed .no-results {
+  border-radius: var(--radius-xl);
+  border: 1px solid var(--border-subtle);
+  box-shadow: var(--shadow-md);
+  padding: clamp(2rem, 5vw, 3rem);
+  background: var(--surface-raised);
+  text-align: center;
+}
 
-        .refresh-btn {
-          padding: 12px 24px;
-          background: var(--primary-color);
-          color: white;
-          border: none;
-          border-radius: 12px;
-          cursor: pointer;
-          font-size: 1rem;
-          font-weight: 600;
-          min-width: 120px;
-          transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+.news-feed .loading .loading-spinner {
+  display: inline-block;
+  width: 3rem;
+  height: 3rem;
+  border: 4px solid var(--primary-light);
+  border-top: 4px solid var(--accent);
+  border-radius: 50%;
+  animation: spin 1s linear infinite;
+  margin-bottom: var(--space-md);
+}
 
-          &:hover:not(:disabled) {
-            background: var(--primary-hover);
-            transform: translateY(-2px);
-            box-shadow: var(--shadow);
-          }
+.news-feed .error {
+  color: var(--alert-error-text);
+  background: var(--alert-error-bg);
+  border-color: var(--alert-error-border);
+}
 
-          &:disabled {
-            background: var(--primary-light);
-            cursor: not-allowed;
-            transform: none;
-          }
-        }
+.news-feed .error .retry-btn {
+  margin-top: var(--space-sm);
+  padding: var(--space-sm) var(--space-lg);
+  border-radius: var(--radius-pill);
+  border: none;
+  background: var(--alert-error-text);
+  color: var(--text-inverse);
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
 
-        .last-updated {
-          color: var(--text-tertiary);
-          font-size: 0.9rem;
-          display: flex;
-          align-items: center;
-          gap: 8px;
+.news-feed .error .retry-btn:hover,
+.news-feed .error .retry-btn:focus-visible {
+  transform: translateY(-1px);
+  box-shadow: var(--shadow-md);
+  outline: none;
+}
 
-          &::before {
-            content: '';
-            display: inline-block;
-            width: 8px;
-            height: 8px;
-            background: #22c55e;
-            border-radius: 50%;
-            box-shadow: 0 0 0 4px rgba(34, 197, 94, 0.2);
-          }
-        }
-      }
-    }
-  }
+.news-feed .no-results p {
+  color: var(--text-muted);
+}
 
-  .loading {
-    text-align: center;
-    padding: clamp(40px, 8vh, 80px) clamp(20px, 4vw, 40px);
-    background: var(--card-background);
-    border-radius: 20px;
-    margin: 32px 0;
-    box-shadow: var(--shadow);
-    border: 1px solid var(--border-color);
+.news-feed .no-results .clear-btn {
+  margin-left: var(--space-xxs);
+  padding: var(--space-xs) var(--space-md);
+  border-radius: var(--radius-pill);
+  border: none;
+  background: var(--accent-muted);
+  color: var(--accent-strong);
+  font-weight: 600;
+  cursor: pointer;
+}
 
-    .loading-spinner {
-      display: inline-block;
-      width: 50px;
-      height: 50px;
-      margin-bottom: 20px;
-      border: 4px solid var(--primary-light);
-      border-top: 4px solid var(--primary-color);
-      border-radius: 50%;
-      animation: spin 1s linear infinite;
-    }
+.news-feed .no-results .clear-btn:hover,
+.news-feed .no-results .clear-btn:focus-visible {
+  background: var(--accent-strong);
+  color: var(--text-inverse);
+  outline: none;
+}
 
-    p {
-      color: var(--text-secondary);
-      margin: 0;
-      font-size: 1.1rem;
-    }
-  }
+.news-feed .news-items {
+  display: grid;
+  gap: var(--space-lg);
+  animation: slideUp 0.4s ease-out;
+}
 
-  .error {
-    text-align: center;
-    padding: clamp(32px, 6vh, 60px) clamp(20px, 4vw, 40px);
-    background: #fff5f5;
-    border-radius: 20px;
-    margin: 32px 0;
-    color: #e53e3e;
-    box-shadow: var(--shadow);
-    border: 1px solid rgba(229, 62, 62, 0.2);
+.news-feed .news-items__item {
+  width: 100%;
+}
 
-    p {
-      margin: 0 0 20px;
-      font-size: 1.1rem;
-    }
-
-    .retry-btn {
-      padding: 12px 28px;
-      background: #e53e3e;
-      color: white;
-      border: none;
-      border-radius: 12px;
-      cursor: pointer;
-      font-size: 1rem;
-      font-weight: 600;
-      transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
-
-      &:hover {
-        background: #c53030;
-        transform: translateY(-2px);
-        box-shadow: var(--shadow);
-      }
-    }
-  }
-
-  .no-results {
-    text-align: center;
-    padding: clamp(40px, 8vh, 80px) clamp(20px, 4vw, 40px);
-    background: var(--card-background);
-    border-radius: 20px;
-    color: var(--text-secondary);
-    box-shadow: var(--shadow);
-    border: 1px solid var(--border-color);
-
-    p {
-      margin: 0 0 20px;
-      font-size: 1.1rem;
-
-      &:last-child {
-        margin-bottom: 0;
-      }
-    }
-
-    .clear-btn {
-      display: inline-block;
-      margin-left: 8px;
-      padding: 8px 20px;
-      background: var(--primary-light);
-      border: none;
-      border-radius: 20px;
-      color: var(--primary-color);
-      cursor: pointer;
-      font-size: 0.95rem;
-      font-weight: 600;
-      transition: all 0.2s ease;
-
-      &:hover {
-        background: var(--primary-hover);
-        color: white;
-      }
-    }
-  }
-
-  .news-items {
-    display: grid;
+@media (min-width: 900px) {
+  .news-feed .controls {
     grid-template-columns: 1fr;
-    gap: 32px;
-    animation: slideUp 0.4s ease-out;
-
-    @media (min-width: 1024px) {
-      grid-template-columns: repeat(2, 1fr);
-    }
   }
 }
 
 @keyframes spin {
-  0% { transform: rotate(0deg); }
-  100% { transform: rotate(360deg); }
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
 }

--- a/src/app/components/news-item/news-item.component.scss
+++ b/src/app/components/news-item/news-item.component.scss
@@ -1,66 +1,60 @@
 .news-item {
-  background: white;
-  border-radius: 16px;
+  background: var(--surface-card);
+  border-radius: var(--radius-xl);
   overflow: hidden;
-  box-shadow:
-    0 4px 6px -1px rgba(0, 0, 0, 0.1),
-    0 2px 4px -1px rgba(0, 0, 0, 0.06);
-  transition: all 0.4s cubic-bezier(0.165, 0.84, 0.44, 1);
-  border: 1px solid rgba(0, 0, 0, 0.05);
+  box-shadow: var(--shadow-md);
+  transition: transform 0.3s ease, box-shadow 0.3s ease;
+  border: 1px solid var(--border-subtle);
 
-  &:hover {
+  &:hover,
+  &:focus-within {
     transform: translateY(-4px);
-    box-shadow:
-      0 20px 25px -5px rgba(0, 0, 0, 0.1),
-      0 10px 10px -5px rgba(0, 0, 0, 0.04);
+    box-shadow: var(--shadow-elevated);
   }
 
   .news-content {
-    padding: 24px;
+    padding: clamp(1.5rem, 3vw, 2.25rem);
 
     header {
-      margin-bottom: 20px;
+      margin-bottom: var(--space-md);
 
       h2 {
-        margin: 0 0 16px;
-        font-size: 1.75em;
+        margin: 0 0 var(--space-sm);
+        font-size: clamp(1.5rem, 2vw, 1.85rem);
         line-height: 1.3;
         font-weight: 700;
-        letter-spacing: -0.02em;
+        letter-spacing: -0.015em;
 
         a {
-          color: #111827;
+          color: var(--text-primary);
           text-decoration: none;
-          background: linear-gradient(to right, #ff4500, #ff4500);
+          background: linear-gradient(to right, var(--accent), var(--accent));
           background-size: 0% 2px;
           background-position: 0 100%;
           background-repeat: no-repeat;
-          transition: background-size 0.3s ease;
+          transition: background-size 0.3s ease, color 0.3s ease;
 
-          &:hover {
-            color: #ff4500;
+          &:hover,
+          &:focus {
+            color: var(--accent);
             background-size: 100% 2px;
+            outline: none;
           }
         }
       }
 
       .meta {
-        font-size: 0.95em;
+        font-size: 0.95rem;
         display: flex;
         flex-wrap: wrap;
-        gap: 16px;
+        gap: var(--space-sm);
         align-items: center;
 
         .source {
           font-weight: 600;
-          color: #ff4500;
+          color: var(--accent);
           position: relative;
-          padding-left: 24px;
-          transition: color 0.2s ease;
-
-          &:hover {
-            color: darken(#ff4500, 10%);
-          }
+          padding-left: 1.75rem;
 
           &::before {
             content: '';
@@ -68,37 +62,27 @@
             left: 0;
             top: 50%;
             transform: translateY(-50%);
-            width: 16px;
-            height: 16px;
-            background: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="%23ff4500"><path d="M15.3 5.3a6.8 6.8 0 0 0-12.6 0c-.1.2-.1.5.1.7l1.5 1.5a.5.5 0 0 0 .7 0 4.8 4.8 0 0 1 8 0 .5.5 0 0 0 .7 0l1.5-1.5c.2-.2.2-.5.1-.7zM10 13a3 3 0 1 0 0-6 3 3 0 0 0 0 6z"/></svg>') no-repeat center;
-            background-size: contain;
-            transition: transform 0.2s ease;
-          }
-
-          &:hover::before {
-            transform: translateY(-50%) scale(1.1);
+            width: 1rem;
+            height: 1rem;
+            border-radius: 50%;
+            background: var(--accent);
+            box-shadow: 0 0 0 4px var(--accent-muted);
           }
         }
 
         .category {
-          background: #f3f4f6;
-          padding: 6px 14px;
-          border-radius: 24px;
-          font-size: 0.85em;
+          background: var(--surface-muted);
+          padding: 0.35rem 0.9rem;
+          border-radius: var(--radius-pill);
+          font-size: 0.85rem;
           font-weight: 600;
-          color: #374151;
-          transition: all 0.2s ease;
-          border: 1px solid rgba(0, 0, 0, 0.05);
-
-          &:hover {
-            background: #e5e7eb;
-            transform: translateY(-1px);
-          }
+          color: var(--text-muted);
+          border: 1px solid var(--border-subtle);
         }
 
         .date {
-          color: #6b7280;
-          font-size: 0.95em;
+          color: var(--text-muted);
+          font-size: 0.95rem;
           font-weight: 500;
         }
       }
@@ -106,19 +90,17 @@
 
     .content {
       position: relative;
-      margin-bottom: 24px;
-      color: #4b5563;
+      margin-bottom: var(--space-md);
+      color: var(--text-muted);
       line-height: 1.7;
-      font-size: 1.05em;
+      font-size: 1.05rem;
 
       .thumbnail {
         float: left;
         max-width: 240px;
-        margin: 0 24px 12px 0;
-        border-radius: 12px;
-        box-shadow:
-          0 4px 6px -1px rgba(0, 0, 0, 0.1),
-          0 2px 4px -1px rgba(0, 0, 0, 0.06);
+        margin: 0 var(--space-md) var(--space-sm) 0;
+        border-radius: var(--radius-lg);
+        box-shadow: var(--shadow-sm);
         transition: transform 0.3s ease;
 
         &:hover {
@@ -136,35 +118,36 @@
     }
 
     footer.actions {
-      margin-top: 24px;
+      margin-top: var(--space-md);
       text-align: right;
-      padding-top: 20px;
-      border-top: 1px solid #e5e7eb;
+      padding-top: var(--space-md);
+      border-top: 1px solid var(--border-subtle);
 
       .read-more {
         display: inline-flex;
         align-items: center;
-        gap: 8px;
-        color: #ffffff;
-        text-decoration: none;
-        font-size: 0.95em;
+        gap: var(--space-xs);
+        color: var(--text-inverse);
+        font-size: 0.95rem;
         font-weight: 600;
-        padding: 10px 20px;
-        border-radius: 24px;
-        background: linear-gradient(135deg, #ff4500, #ff6b3d);
-        transition: all 0.3s ease;
+        padding: 0.6rem 1.5rem;
+        border-radius: var(--radius-pill);
+        background: linear-gradient(135deg, var(--accent), var(--accent-strong));
+        transition: transform 0.3s ease, box-shadow 0.3s ease;
         box-shadow: 0 2px 4px rgba(255, 69, 0, 0.2);
 
         svg {
           transition: transform 0.3s ease;
         }
 
-        &:hover {
+        &:hover,
+        &:focus-visible {
           transform: translateY(-2px);
-          box-shadow: 0 4px 12px rgba(255, 69, 0, 0.3);
+          box-shadow: 0 6px 18px rgba(255, 69, 0, 0.35);
+          outline: none;
 
           svg {
-            transform: translate(4px, -4px);
+            transform: translate(4px, -3px);
           }
         }
 
@@ -174,5 +157,14 @@
         }
       }
     }
+  }
+}
+
+@media (max-width: 640px) {
+  .news-item .news-content .content .thumbnail {
+    float: none;
+    width: 100%;
+    max-width: 100%;
+    margin: 0 0 var(--space-sm) 0;
   }
 }

--- a/src/app/components/shell/shell.component.html
+++ b/src/app/components/shell/shell.component.html
@@ -1,0 +1,69 @@
+<a class="skip-link" href="#main-content">Skip to main content</a>
+<div class="shell">
+  <header class="shell__header" role="banner">
+    <div class="shell__branding">
+      <span class="shell__logo" aria-hidden="true">47</span>
+      <div>
+        <p class="shell__title">Trump 47 Campaign Tracker</p>
+        <p class="shell__subtitle">Real-time updates from across the campaign trail</p>
+      </div>
+    </div>
+
+    <button
+      type="button"
+      class="theme-toggle"
+      (click)="toggleTheme()"
+      [attr.aria-pressed]="(theme$ | async) === 'dark'"
+    >
+      <span class="visually-hidden">Toggle dark mode</span>
+      <span aria-hidden="true" class="theme-toggle__icon">
+        <svg *ngIf="(theme$ | async) === 'dark'" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+          <path d="M21 12.79A9 9 0 0 1 11.21 3 7 7 0 1 0 21 12.79z" />
+        </svg>
+        <svg *ngIf="(theme$ | async) !== 'dark'" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+          <circle cx="12" cy="12" r="5" />
+          <path d="M12 1v2M12 21v2M4.22 4.22l1.42 1.42M18.36 18.36l1.42 1.42M1 12h2M21 12h2M4.22 19.78l1.42-1.42M18.36 5.64l1.42-1.42" />
+        </svg>
+      </span>
+      <span class="theme-toggle__label" aria-hidden="true">{{ (theme$ | async) === 'dark' ? 'Dark' : 'Light' }} mode</span>
+    </button>
+  </header>
+
+  <nav class="shell__nav" aria-label="Primary navigation">
+    <ul>
+      <li>
+        <a
+          routerLink="/"
+          routerLinkActive="is-active"
+          #rla="routerLinkActive"
+          [routerLinkActiveOptions]="{ exact: true }"
+          [attr.aria-current]="rla.isActive ? 'page' : null"
+        >
+          Campaign Feed
+        </a>
+      </li>
+      <li>
+        <a href="#insights">Insights</a>
+      </li>
+      <li>
+        <a href="#stories">Featured stories</a>
+      </li>
+    </ul>
+  </nav>
+
+  <main id="main-content" class="shell__main" role="main" tabindex="-1">
+    <div class="shell__grid" aria-label="Campaign dashboard layout">
+      <section class="shell__content" aria-labelledby="campaign-feed-heading">
+        <h2 id="campaign-feed-heading" class="visually-hidden">Campaign news feed</h2>
+        <router-outlet></router-outlet>
+      </section>
+      <app-featured-stories class="shell__featured"></app-featured-stories>
+      <app-insights-sidebar class="shell__insights"></app-insights-sidebar>
+    </div>
+  </main>
+
+  <footer class="shell__footer" role="contentinfo">
+    <p>Built for accessibility and real-time insight into the 2024 campaign.</p>
+    <a class="footer__feedback" href="mailto:feedback@trump47tracker.com">Share feedback</a>
+  </footer>
+</div>

--- a/src/app/components/shell/shell.component.scss
+++ b/src/app/components/shell/shell.component.scss
@@ -1,0 +1,212 @@
+.shell {
+  min-height: 100vh;
+  background: var(--surface-page);
+  color: var(--text-primary);
+  display: grid;
+  grid-template-rows: auto auto 1fr auto;
+}
+
+.skip-link {
+  position: absolute;
+  left: -999px;
+  top: auto;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+
+  &:focus {
+    position: static;
+    width: auto;
+    height: auto;
+    margin: var(--space-md);
+    padding: var(--space-xs) var(--space-sm);
+    background: var(--accent-muted);
+    color: var(--text-primary);
+    border-radius: var(--radius-pill);
+    box-shadow: var(--shadow-focus);
+    z-index: 1000;
+  }
+}
+
+.shell__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: var(--space-lg) var(--layout-gutter);
+  border-bottom: 1px solid var(--border-subtle);
+  background: var(--surface-raised);
+  backdrop-filter: blur(6px);
+}
+
+.shell__branding {
+  display: flex;
+  align-items: center;
+  gap: var(--space-md);
+}
+
+.shell__logo {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 3rem;
+  height: 3rem;
+  border-radius: var(--radius-lg);
+  background: linear-gradient(135deg, var(--accent), var(--accent-strong));
+  color: var(--text-inverse);
+  font-weight: 700;
+  font-size: 1.35rem;
+  box-shadow: var(--shadow-elevated);
+}
+
+.shell__title {
+  font-size: clamp(1.25rem, 2vw, 1.75rem);
+  font-weight: 700;
+}
+
+.shell__subtitle {
+  font-size: 0.95rem;
+  color: var(--text-muted);
+}
+
+.theme-toggle {
+  border: none;
+  background: var(--surface-muted);
+  color: var(--text-primary);
+  padding: var(--space-xs) var(--space-sm);
+  border-radius: var(--radius-lg);
+  cursor: pointer;
+  transition: background-color 0.2s ease, transform 0.2s ease;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  box-shadow: var(--shadow-sm);
+
+  &:hover,
+  &:focus-visible {
+    background: var(--accent-muted);
+    transform: translateY(-1px);
+    outline: none;
+  }
+
+  svg {
+    width: 1.25rem;
+    height: 1.25rem;
+    fill: currentColor;
+    stroke: currentColor;
+  }
+}
+
+.theme-toggle__label {
+  margin-left: var(--space-xs);
+  font-weight: 600;
+}
+
+.shell__nav {
+  padding: 0 var(--layout-gutter);
+  background: var(--surface-page);
+  border-bottom: 1px solid var(--border-subtle);
+
+  ul {
+    list-style: none;
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--space-sm);
+    padding: var(--space-sm) 0;
+    margin: 0;
+  }
+
+  a {
+    display: inline-block;
+    padding: var(--space-xs) var(--space-md);
+    border-radius: var(--radius-pill);
+    font-weight: 600;
+    color: var(--text-muted);
+    transition: color 0.2s ease, background-color 0.2s ease;
+
+    &.is-active,
+    &:focus-visible,
+    &:hover {
+      color: var(--text-primary);
+      background: var(--accent-muted);
+      outline: none;
+    }
+  }
+}
+
+.shell__main {
+  padding: var(--space-xl) var(--layout-gutter);
+}
+
+.shell__grid {
+  display: grid;
+  gap: var(--grid-gap);
+  grid-template-columns: minmax(0, 1fr);
+  grid-template-areas: 'content' 'featured' 'insights';
+  align-items: start;
+  max-width: var(--layout-max-width);
+  margin: 0 auto;
+  width: 100%;
+
+  @media (min-width: 900px) {
+    grid-template-columns: minmax(0, 7fr) minmax(0, 5fr);
+    grid-template-areas:
+      'content featured'
+      'content insights';
+  }
+
+  @media (min-width: 1200px) {
+    grid-template-columns: minmax(0, 6fr) minmax(0, 3fr) minmax(0, 3fr);
+    grid-template-areas:
+      'content featured insights';
+  }
+}
+
+.shell__content {
+  grid-area: content;
+  min-width: 0;
+}
+
+.shell__featured {
+  grid-area: featured;
+  width: 100%;
+}
+
+.shell__insights {
+  grid-area: insights;
+  width: 100%;
+}
+
+.shell__footer {
+  padding: var(--space-lg) var(--layout-gutter);
+  background: var(--surface-raised);
+  border-top: 1px solid var(--border-subtle);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xs);
+  color: var(--text-muted);
+  text-align: center;
+}
+
+.footer__feedback {
+  align-self: center;
+  color: var(--accent);
+  font-weight: 600;
+
+  &:hover,
+  &:focus-visible {
+    text-decoration: underline;
+    outline: none;
+  }
+}
+
+@media (max-width: 899px) {
+  .shell__header {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: var(--space-md);
+  }
+
+  .theme-toggle {
+    align-self: flex-end;
+  }
+}

--- a/src/app/components/shell/shell.component.ts
+++ b/src/app/components/shell/shell.component.ts
@@ -1,0 +1,24 @@
+import { AsyncPipe, CommonModule } from '@angular/common';
+import { Component, ChangeDetectionStrategy } from '@angular/core';
+import { RouterLink, RouterLinkActive, RouterOutlet } from '@angular/router';
+import { ThemeService } from '../../services/theme.service';
+import { FeaturedStoriesComponent } from '../featured-stories/featured-stories.component';
+import { InsightsSidebarComponent } from '../insights-sidebar/insights-sidebar.component';
+
+@Component({
+  selector: 'app-shell',
+  standalone: true,
+  imports: [CommonModule, RouterOutlet, RouterLink, RouterLinkActive, AsyncPipe, FeaturedStoriesComponent, InsightsSidebarComponent],
+  templateUrl: './shell.component.html',
+  styleUrls: ['./shell.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class ShellComponent {
+  readonly theme$ = this.themeService.theme$;
+
+  constructor(private readonly themeService: ThemeService) {}
+
+  toggleTheme(): void {
+    this.themeService.toggleTheme();
+  }
+}

--- a/src/app/services/local-storage.service.ts
+++ b/src/app/services/local-storage.service.ts
@@ -1,0 +1,44 @@
+import { Injectable } from '@angular/core';
+
+@Injectable({ providedIn: 'root' })
+export class LocalStorageService {
+  private readonly isBrowser = typeof window !== 'undefined';
+
+  getItem<T = string>(key: string): T | null {
+    if (!this.isBrowser) {
+      return null;
+    }
+
+    try {
+      const value = window.localStorage.getItem(key);
+      return value ? (JSON.parse(value) as T) : null;
+    } catch (error) {
+      console.warn('LocalStorageService: Unable to read key', key, error);
+      return null;
+    }
+  }
+
+  setItem<T>(key: string, value: T): void {
+    if (!this.isBrowser) {
+      return;
+    }
+
+    try {
+      window.localStorage.setItem(key, JSON.stringify(value));
+    } catch (error) {
+      console.warn('LocalStorageService: Unable to persist key', key, error);
+    }
+  }
+
+  removeItem(key: string): void {
+    if (!this.isBrowser) {
+      return;
+    }
+
+    try {
+      window.localStorage.removeItem(key);
+    } catch (error) {
+      console.warn('LocalStorageService: Unable to remove key', key, error);
+    }
+  }
+}

--- a/src/app/services/theme.service.ts
+++ b/src/app/services/theme.service.ts
@@ -1,0 +1,53 @@
+import { DOCUMENT } from '@angular/common';
+import { Inject, Injectable } from '@angular/core';
+import { BehaviorSubject } from 'rxjs';
+import { LocalStorageService } from './local-storage.service';
+
+type ThemePreference = 'light' | 'dark';
+
+@Injectable({ providedIn: 'root' })
+export class ThemeService {
+  private readonly storageKey = 'app-theme';
+  private readonly themeSubject = new BehaviorSubject<ThemePreference>('light');
+
+  readonly theme$ = this.themeSubject.asObservable();
+
+  constructor(
+    @Inject(DOCUMENT) private readonly document: Document,
+    private readonly storage: LocalStorageService
+  ) {
+    const storedPreference = this.storage.getItem<ThemePreference>(this.storageKey);
+
+    if (storedPreference) {
+      this.themeSubject.next(storedPreference);
+    } else if (typeof window !== 'undefined') {
+      const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+      this.themeSubject.next(prefersDark ? 'dark' : 'light');
+    }
+
+    this.applyTheme(this.themeSubject.value);
+
+    this.themeSubject.subscribe(theme => {
+      this.applyTheme(theme);
+      this.storage.setItem(this.storageKey, theme);
+    });
+  }
+
+  toggleTheme(): void {
+    const nextTheme: ThemePreference = this.themeSubject.value === 'light' ? 'dark' : 'light';
+    this.themeSubject.next(nextTheme);
+  }
+
+  setTheme(theme: ThemePreference): void {
+    this.themeSubject.next(theme);
+  }
+
+  get currentTheme(): ThemePreference {
+    return this.themeSubject.value;
+  }
+
+  private applyTheme(theme: ThemePreference): void {
+    const root = this.document.documentElement;
+    root.setAttribute('data-theme', theme);
+  }
+}

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -1,19 +1,81 @@
-/* You can add global styles to this file, and also import other style files */
 @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap');
 
 :root {
-  --primary-color: #ff4500;
-  --primary-hover: #ff3d00;
-  --primary-light: #fff0eb;
-  --text-primary: #111827;
-  --text-secondary: #4b5563;
-  --text-tertiary: #6b7280;
-  --background: #f9fafb;
-  --card-background: #ffffff;
-  --border-color: #e5e7eb;
-  --shadow-sm: 0 1px 2px 0 rgb(0 0 0 / 0.05);
-  --shadow: 0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1);
-  --shadow-md: 0 20px 25px -5px rgb(0 0 0 / 0.1), 0 8px 10px -6px rgb(0 0 0 / 0.1);
+  color-scheme: light;
+  --surface-page: #f4f6fb;
+  --surface-raised: rgba(255, 255, 255, 0.92);
+  --surface-muted: rgba(255, 255, 255, 0.7);
+  --surface-card: #ffffff;
+  --text-primary: #0f172a;
+  --text-muted: #475569;
+  --text-inverse: #f8fafc;
+  --border-subtle: rgba(15, 23, 42, 0.08);
+  --shadow-sm: 0 1px 2px rgba(15, 23, 42, 0.08);
+  --shadow-md: 0 12px 30px -12px rgba(15, 23, 42, 0.2);
+  --shadow-elevated: 0 18px 40px -20px rgba(15, 23, 42, 0.25);
+  --shadow-focus: 0 0 0 4px rgba(79, 70, 229, 0.25);
+  --accent: #ff4500;
+  --accent-strong: #ff2d00;
+  --accent-muted: rgba(255, 69, 0, 0.15);
+  --accent-muted-strong: rgba(255, 69, 0, 0.35);
+  --trend-positive: rgba(34, 197, 94, 0.35);
+  --trend-negative: rgba(248, 113, 113, 0.35);
+  --trend-neutral: rgba(148, 163, 184, 0.35);
+  --alert-error-bg: rgba(229, 62, 62, 0.12);
+  --alert-error-border: rgba(229, 62, 62, 0.35);
+  --alert-error-text: #c53030;
+  --layout-max-width: 1200px;
+  --layout-gutter: clamp(1rem, 3vw, 3rem);
+  --grid-gap: clamp(1.5rem, 3vw, 2.5rem);
+  --radius-lg: 1.25rem;
+  --radius-xl: 1.75rem;
+  --radius-pill: 999px;
+  --space-xxs: 0.25rem;
+  --space-xs: 0.5rem;
+  --space-sm: 0.75rem;
+  --space-md: 1rem;
+  --space-lg: 1.5rem;
+  --space-xl: 2.5rem;
+
+  /* legacy aliases */
+  --background: var(--surface-page);
+  --card-background: var(--surface-card);
+  --border-color: var(--border-subtle);
+  --primary-color: var(--accent);
+  --primary-hover: var(--accent-strong);
+  --primary-light: rgba(255, 69, 0, 0.12);
+  --text-secondary: var(--text-muted);
+  --text-tertiary: #64748b;
+  --shadow: var(--shadow-md);
+}
+
+:root[data-theme='dark'],
+[data-theme='dark'] {
+  color-scheme: dark;
+  --surface-page: #0b1120;
+  --surface-raised: rgba(15, 23, 42, 0.92);
+  --surface-muted: rgba(15, 23, 42, 0.7);
+  --surface-card: #111827;
+  --text-primary: #e2e8f0;
+  --text-muted: #94a3b8;
+  --text-inverse: #0f172a;
+  --border-subtle: rgba(148, 163, 184, 0.3);
+  --shadow-sm: 0 1px 2px rgba(15, 23, 42, 0.6);
+  --shadow-md: 0 12px 30px -12px rgba(15, 23, 42, 0.7);
+  --shadow-elevated: 0 18px 40px -20px rgba(30, 64, 175, 0.65);
+  --shadow-focus: 0 0 0 4px rgba(96, 165, 250, 0.35);
+  --accent: #f97316;
+  --accent-strong: #ea580c;
+  --accent-muted: rgba(249, 115, 22, 0.2);
+  --accent-muted-strong: rgba(249, 115, 22, 0.4);
+  --trend-positive: rgba(74, 222, 128, 0.3);
+  --trend-negative: rgba(248, 113, 113, 0.4);
+  --trend-neutral: rgba(148, 163, 184, 0.4);
+  --alert-error-bg: rgba(220, 38, 38, 0.2);
+  --alert-error-border: rgba(220, 38, 38, 0.4);
+  --alert-error-text: #fca5a5;
+  --primary-light: rgba(249, 115, 22, 0.18);
+  --text-tertiary: #94a3b8;
 }
 
 * {
@@ -23,42 +85,23 @@
 }
 
 body {
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+  font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
-  background-color: var(--background);
+  background-color: var(--surface-page);
   color: var(--text-primary);
-  line-height: 1.5;
+  line-height: 1.6;
+  min-height: 100vh;
 }
 
 a {
-  color: #1a0dab;
+  color: inherit;
   text-decoration: none;
+  transition: color 0.2s ease;
 
   &:hover {
     text-decoration: underline;
   }
-}
-
-.container {
-  width: 100%;
-  max-width: 1200px;
-  margin: 0 auto;
-  padding: 0 1rem;
-}
-
-@media (max-width: 768px) {
-  html {
-    font-size: 14px;
-  }
-}
-
-// Utility classes
-.text-gradient {
-  background: linear-gradient(135deg, var(--primary-color), var(--primary-hover));
-  -webkit-background-clip: text;
-  -webkit-text-fill-color: transparent;
-  background-clip: text;
 }
 
 .visually-hidden {
@@ -73,10 +116,19 @@ a {
   border: 0;
 }
 
-// Animations
+@media (max-width: 768px) {
+  html {
+    font-size: 15px;
+  }
+}
+
 @keyframes fadeIn {
-  from { opacity: 0; }
-  to { opacity: 1; }
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
 }
 
 @keyframes slideUp {


### PR DESCRIPTION
## Summary
- add a shell layout component that wraps routed views with accessible header, navigation, and footer chrome
- introduce featured stories and insights sidebar components that participate in a responsive dashboard grid
- implement global theming tokens with a persisted dark mode toggle powered by a local storage service

## Testing
- npm test -- --watch=false *(fails: Chrome is not installed in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68ea80f20a8c83269f6787e365cbfb34