### PR TITLE
Add engagement panel, polls microservice, and social preview tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,27 @@
 
 This project was generated with [Angular CLI](https://github.com/angular/angular-cli) version 18.0.3.
 
+## Engagement services
+
+The front-end now integrates with a companion Express microservice that powers polls, newsletter capture, analytics tracking, and dynamic OpenGraph image generation.
+
+1. Start the engagement service:
+   ```bash
+   cd backend/engagement-service
+   npm install
+   npm start
+   ```
+2. Run the Angular app in a separate terminal with `ng serve`.
+
+The Angular services expect the engagement service to be available at `http://localhost:4000`. Update `EngagementService` if you need a different origin.
+
+## Key features
+
+- Dedicated engagement sidebar featuring a newsletter sign-up form, social share controls, and live poll snapshots.
+- Poll and survey results sourced from the engagement microservice.
+- Dynamic OpenGraph image previews for each story to enrich social sharing.
+- Analytics events fired for newsletter conversions and share interactions.
+
 ## Development server
 
 Run `ng serve` for a dev server. Navigate to `http://localhost:4200/`. The application will automatically reload if you change any of the source files.

--- a/backend/engagement-service/README.md
+++ b/backend/engagement-service/README.md
@@ -1,0 +1,32 @@
+# Engagement Service
+
+This lightweight Express service powers the front-end engagement features:
+
+- Provides curated poll/survey results via `/polls`
+- Captures newsletter signups at `/newsletter/signup`
+- Accepts analytics events at `/analytics/events`
+- Generates dynamic OpenGraph preview images through `/og-image`
+
+## Getting Started
+
+```bash
+cd backend/engagement-service
+npm install
+npm start
+```
+
+The server listens on `http://localhost:4000` by default. Update the Angular application's environment configuration or service constants if you change the port.
+
+### API Overview
+
+| Method | Endpoint | Description |
+| ------ | -------- | ----------- |
+| `GET` | `/health` | Health check returning `{ status: 'ok' }`. |
+| `GET` | `/polls` | Returns poll questions with aggregated vote counts and percentages. |
+| `POST` | `/polls/:id/vote` | Increment a poll option and log an analytics event. |
+| `POST` | `/newsletter/signup` | Record a newsletter signup for downstream processing. |
+| `POST` | `/analytics/events` | Store social share, conversion, or other engagement events. |
+| `GET` | `/analytics/events` | Summarize stored analytics events. |
+| `GET` | `/og-image` | Returns an SVG social preview image. Pass `title`, `source`, and `date` query params. |
+
+The data is stored in memory for simplicity; integrate a persistent store or external service as needed for production.

--- a/backend/engagement-service/index.js
+++ b/backend/engagement-service/index.js
@@ -1,0 +1,153 @@
+import express from 'express';
+import cors from 'cors';
+
+const app = express();
+const port = process.env.PORT || 4000;
+
+app.use(cors());
+app.use(express.json());
+
+const polls = [
+  {
+    id: 'gop-primary-confidence',
+    question: 'How confident are you that Trump will secure the GOP nomination?',
+    options: [
+      { id: 'very-confident', label: 'Very confident', votes: 4871 },
+      { id: 'somewhat-confident', label: 'Somewhat confident', votes: 1984 },
+      { id: 'not-confident', label: 'Not confident', votes: 763 }
+    ],
+    lastUpdated: new Date('2024-03-21T14:00:00Z').toISOString()
+  },
+  {
+    id: 'general-election-outlook',
+    question: 'What is your outlook on Trump in the general election?',
+    options: [
+      { id: 'win', label: 'Likely win', votes: 3120 },
+      { id: 'tossup', label: 'Too close to call', votes: 2795 },
+      { id: 'loss', label: 'Likely loss', votes: 2145 }
+    ],
+    lastUpdated: new Date('2024-03-20T17:30:00Z').toISOString()
+  }
+];
+
+const analyticsEvents = [];
+const newsletterSignups = [];
+
+function summarizePoll(poll) {
+  const totalVotes = poll.options.reduce((sum, option) => sum + option.votes, 0);
+  return {
+    ...poll,
+    totalVotes,
+    options: poll.options.map(option => ({
+      ...option,
+      percentage: totalVotes ? Math.round((option.votes / totalVotes) * 100) : 0
+    }))
+  };
+}
+
+app.get('/health', (_req, res) => {
+  res.json({ status: 'ok' });
+});
+
+app.get('/polls', (_req, res) => {
+  res.json({ polls: polls.map(summarizePoll) });
+});
+
+app.post('/polls/:id/vote', (req, res) => {
+  const poll = polls.find(p => p.id === req.params.id);
+  if (!poll) {
+    return res.status(404).json({ message: 'Poll not found' });
+  }
+  const { optionId } = req.body || {};
+  const option = poll.options.find(o => o.id === optionId);
+  if (!option) {
+    return res.status(400).json({ message: 'Invalid option' });
+  }
+  option.votes += 1;
+  poll.lastUpdated = new Date().toISOString();
+  analyticsEvents.push({
+    type: 'poll_vote',
+    timestamp: new Date().toISOString(),
+    pollId: poll.id,
+    optionId
+  });
+  res.json({ poll: summarizePoll(poll) });
+});
+
+app.post('/newsletter/signup', (req, res) => {
+  const { email, storyId } = req.body || {};
+  if (!email) {
+    return res.status(400).json({ message: 'Email is required' });
+  }
+  const record = {
+    email,
+    storyId: storyId || null,
+    timestamp: new Date().toISOString()
+  };
+  newsletterSignups.push(record);
+  analyticsEvents.push({
+    type: 'newsletter_signup',
+    timestamp: record.timestamp,
+    storyId: record.storyId,
+    emailHash: Buffer.from(email).toString('base64')
+  });
+  res.status(201).json({ message: 'Thanks for signing up!' });
+});
+
+app.post('/analytics/events', (req, res) => {
+  const { eventName, payload } = req.body || {};
+  if (!eventName) {
+    return res.status(400).json({ message: 'eventName is required' });
+  }
+  analyticsEvents.push({
+    type: eventName,
+    payload: payload || {},
+    timestamp: new Date().toISOString()
+  });
+  res.status(202).json({ status: 'queued' });
+});
+
+app.get('/analytics/events', (_req, res) => {
+  const summary = analyticsEvents.reduce((acc, event) => {
+    acc[event.type] = (acc[event.type] || 0) + 1;
+    return acc;
+  }, {});
+  res.json({ totalEvents: analyticsEvents.length, summary });
+});
+
+app.get('/og-image', (req, res) => {
+  const title = (req.query.title || 'Trump 47 Campaign Update').toString();
+  const source = (req.query.source || 'Campaign Tracker').toString();
+  const date = (req.query.date || new Date().toISOString()).toString();
+
+  const svg = `<?xml version="1.0" encoding="UTF-8"?>
+  <svg width="1200" height="630" viewBox="0 0 1200 630" xmlns="http://www.w3.org/2000/svg">
+    <defs>
+      <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+        <stop offset="0%" stop-color="#0f172a" />
+        <stop offset="100%" stop-color="#1d4ed8" />
+      </linearGradient>
+      <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
+        <feDropShadow dx="0" dy="10" stdDeviation="15" flood-color="rgba(15, 23, 42, 0.4)" />
+      </filter>
+    </defs>
+    <rect width="1200" height="630" fill="url(#bg)" />
+    <g filter="url(#shadow)">
+      <rect x="80" y="120" width="1040" height="360" rx="32" fill="rgba(15, 23, 42, 0.65)" stroke="rgba(255,255,255,0.25)" stroke-width="2" />
+    </g>
+    <text x="110" y="220" fill="#93c5fd" font-family="'Inter', sans-serif" font-size="42" font-weight="600">${source}</text>
+    <foreignObject x="110" y="250" width="980" height="200">
+      <div xmlns="http://www.w3.org/1999/xhtml" style="color:#f8fafc;font-family:'Inter',sans-serif;font-size:64px;font-weight:700;line-height:1.1;">
+        ${title.replace(/&/g, '&amp;')}
+      </div>
+    </foreignObject>
+    <text x="110" y="520" fill="#bfdbfe" font-family="'Inter', sans-serif" font-size="32">${new Date(date).toLocaleString('en-US', { timeZone: 'UTC', month: 'long', day: 'numeric', year: 'numeric' })} • ${new Date(date).toLocaleTimeString('en-US', { timeZone: 'UTC', hour: '2-digit', minute: '2-digit' })} UTC</text>
+  </svg>`;
+
+  res.setHeader('Content-Type', 'image/svg+xml');
+  res.send(svg);
+});
+
+app.listen(port, () => {
+  console.log(`Engagement service listening on port ${port}`);
+});

--- a/backend/engagement-service/package.json
+++ b/backend/engagement-service/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "engagement-service",
+  "version": "1.0.0",
+  "description": "Microservice providing poll data, newsletter capture, analytics tracking, and dynamic OpenGraph image generation.",
+  "main": "index.js",
+  "type": "module",
+  "scripts": {
+    "start": "node index.js"
+  },
+  "dependencies": {
+    "cors": "^2.8.5",
+    "express": "^4.19.2"
+  }
+}

--- a/src/app/components/engagement-panel/engagement-panel.component.html
+++ b/src/app/components/engagement-panel/engagement-panel.component.html
@@ -1,0 +1,60 @@
+<section class="engagement-panel" aria-labelledby="engagement-heading">
+  <h2 id="engagement-heading">Stay in the loop</h2>
+  <p class="panel-subtitle">
+    Get campaign headlines in your inbox and boost stories that matter.
+  </p>
+
+  <form class="newsletter-form" (ngSubmit)="submitNewsletter()" novalidate>
+    <label for="newsletter-email" class="sr-only">Email address</label>
+    <input
+      id="newsletter-email"
+      type="email"
+      name="email"
+      [(ngModel)]="email"
+      placeholder="you@example.com"
+      [disabled]="isSubmitting"
+      required
+    >
+    <button type="submit" [disabled]="isSubmitting">
+      <span *ngIf="!isSubmitting">Subscribe</span>
+      <span *ngIf="isSubmitting">Joining...</span>
+    </button>
+  </form>
+
+  <p *ngIf="successMessage" class="status success" role="status">{{ successMessage }}</p>
+  <p *ngIf="errorMessage" class="status error" role="alert">{{ errorMessage }}</p>
+
+  <div class="share">
+    <h3>Share this story</h3>
+    <div class="share-buttons">
+      <a
+        [href]="'https://twitter.com/intent/tweet?text=' + encode(shareText) + '&url=' + encode(shareUrl)"
+        target="_blank"
+        rel="noopener noreferrer"
+        (click)="onShare('twitter')"
+        aria-label="Share on Twitter"
+      >
+        <span aria-hidden="true">𝕏</span>
+      </a>
+      <a
+        [href]="'https://www.facebook.com/sharer/sharer.php?u=' + encode(shareUrl)"
+        target="_blank"
+        rel="noopener noreferrer"
+        (click)="onShare('facebook')"
+        aria-label="Share on Facebook"
+      >
+        <span aria-hidden="true">f</span>
+      </a>
+      <a
+        [href]="'https://www.linkedin.com/shareArticle?mini=true&url=' + encode(shareUrl) + '&title=' + encode(shareText)"
+        target="_blank"
+        rel="noopener noreferrer"
+        (click)="onShare('linkedin')"
+        aria-label="Share on LinkedIn"
+      >
+        <span aria-hidden="true">in</span>
+      </a>
+    </div>
+    <p class="share-tip">Your shares help surface the campaign stories readers engage with most.</p>
+  </div>
+</section>

--- a/src/app/components/engagement-panel/engagement-panel.component.scss
+++ b/src/app/components/engagement-panel/engagement-panel.component.scss
@@ -1,0 +1,120 @@
+.engagement-panel {
+  background: #0f172a;
+  color: #f8fafc;
+  border-radius: 16px;
+  padding: 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  box-shadow: 0 20px 45px rgba(15, 23, 42, 0.35);
+}
+
+h2 {
+  font-size: 1.5rem;
+  margin: 0;
+}
+
+.panel-subtitle {
+  margin: 0;
+  color: rgba(248, 250, 252, 0.7);
+  line-height: 1.4;
+}
+
+.newsletter-form {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.newsletter-form input {
+  border: none;
+  border-radius: 10px;
+  padding: 12px;
+  font-size: 0.95rem;
+}
+
+.newsletter-form button {
+  border: none;
+  border-radius: 10px;
+  padding: 12px;
+  font-size: 0.95rem;
+  background: linear-gradient(135deg, #2563eb, #7c3aed);
+  color: #fff;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.newsletter-form button:disabled {
+  opacity: 0.7;
+  cursor: not-allowed;
+  transform: none;
+  box-shadow: none;
+}
+
+.newsletter-form button:not(:disabled):hover {
+  transform: translateY(-1px);
+  box-shadow: 0 12px 30px rgba(59, 130, 246, 0.35);
+}
+
+.status {
+  margin: 0;
+  font-size: 0.85rem;
+}
+
+.status.success {
+  color: #34d399;
+}
+
+.status.error {
+  color: #f87171;
+}
+
+.share {
+  border-top: 1px solid rgba(248, 250, 252, 0.1);
+  padding-top: 16px;
+}
+
+.share h3 {
+  margin: 0 0 12px;
+  font-size: 1rem;
+}
+
+.share-buttons {
+  display: flex;
+  gap: 12px;
+}
+
+.share-buttons a {
+  width: 44px;
+  height: 44px;
+  border-radius: 12px;
+  background: rgba(148, 163, 184, 0.15);
+  color: #f8fafc;
+  display: grid;
+  place-items: center;
+  font-weight: 600;
+  text-decoration: none;
+  transition: transform 0.2s ease, background 0.2s ease;
+}
+
+.share-buttons a:hover {
+  transform: translateY(-2px);
+  background: rgba(148, 163, 184, 0.3);
+}
+
+.share-tip {
+  margin: 12px 0 0;
+  color: rgba(248, 250, 252, 0.6);
+  font-size: 0.8rem;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  border: 0;
+}

--- a/src/app/components/engagement-panel/engagement-panel.component.ts
+++ b/src/app/components/engagement-panel/engagement-panel.component.ts
@@ -1,0 +1,77 @@
+import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { NewsItem } from '../../models/news.model';
+import { EngagementService } from '../../services/engagement.service';
+
+@Component({
+  selector: 'app-engagement-panel',
+  standalone: true,
+  imports: [CommonModule, FormsModule],
+  templateUrl: './engagement-panel.component.html',
+  styleUrls: ['./engagement-panel.component.scss']
+})
+export class EngagementPanelComponent {
+  @Input() story: NewsItem | null = null;
+  @Output() signupCompleted = new EventEmitter<void>();
+
+  email = '';
+  isSubmitting = false;
+  successMessage = '';
+  errorMessage = '';
+
+  constructor(private engagementService: EngagementService) { }
+
+  get shareText(): string {
+    if (!this.story) {
+      return 'Follow the latest developments in the Trump 2024 campaign.';
+    }
+    return `${this.story.title} — via Trump 47 Campaign Tracker`;
+  }
+
+  get shareUrl(): string {
+    return this.story?.link || 'https://trump47.example/news';
+  }
+
+  encode(value: string): string {
+    return encodeURIComponent(value);
+  }
+
+  submitNewsletter(): void {
+    this.errorMessage = '';
+    this.successMessage = '';
+
+    if (!this.email) {
+      this.errorMessage = 'Please enter a valid email address.';
+      return;
+    }
+
+    this.isSubmitting = true;
+    this.engagementService.submitNewsletterSignup(this.email, this.story?.id).subscribe({
+      next: () => {
+        this.isSubmitting = false;
+        this.successMessage = 'Thanks for subscribing! Check your inbox soon.';
+        this.email = '';
+        this.signupCompleted.emit();
+        this.trackEvent('newsletter_signup', { storyId: this.story?.id || null });
+      },
+      error: () => {
+        this.isSubmitting = false;
+        this.errorMessage = 'We were unable to process your signup. Please try again later.';
+      }
+    });
+  }
+
+  onShare(network: 'twitter' | 'facebook' | 'linkedin'): void {
+    const payload = {
+      storyId: this.story?.id || null,
+      network,
+      url: this.shareUrl
+    };
+    this.trackEvent('social_share', payload);
+  }
+
+  private trackEvent(eventName: string, payload: Record<string, unknown>): void {
+    this.engagementService.trackEvent(eventName, payload).subscribe();
+  }
+}

--- a/src/app/components/news-feed/news-feed.component.html
+++ b/src/app/components/news-feed/news-feed.component.html
@@ -53,32 +53,41 @@
     </div>
   </header>
 
-  <div *ngIf="loading && !newsItems.length" class="loading" role="status">
-    <div class="loading-spinner"></div>
-    <p>Loading latest news...</p>
-  </div>
+  <div class="content-layout">
+    <section class="main-column" aria-label="Campaign news">
+      <div *ngIf="loading && !newsItems.length" class="loading" role="status">
+        <div class="loading-spinner"></div>
+        <p>Loading latest news...</p>
+      </div>
 
-  <div *ngIf="error" class="error" role="alert">
-    <p>{{ error }}</p>
-    <button (click)="fetchNews()" class="retry-btn">
-      Try Again
-    </button>
-  </div>
+      <div *ngIf="error" class="error" role="alert">
+        <p>{{ error }}</p>
+        <button (click)="fetchNews()" class="retry-btn">
+          Try Again
+        </button>
+      </div>
 
-  <div *ngIf="!loading || newsItems.length" class="news-items">
-    <div *ngIf="filteredItems.length === 0" class="no-results" role="status">
-      <p *ngIf="hasActiveFilters">
-        No news items found matching your search criteria.
-        <button (click)="clearFilters()" class="clear-btn">Clear Filters</button>
-      </p>
-      <p *ngIf="!hasActiveFilters">
-        No news items available. Try refreshing the page.
-      </p>
-    </div>
+      <div *ngIf="!loading || newsItems.length" class="news-items">
+        <div *ngIf="filteredItems.length === 0" class="no-results" role="status">
+          <p *ngIf="hasActiveFilters">
+            No news items found matching your search criteria.
+            <button (click)="clearFilters()" class="clear-btn">Clear Filters</button>
+          </p>
+          <p *ngIf="!hasActiveFilters">
+            No news items available. Try refreshing the page.
+          </p>
+        </div>
 
-    <app-news-item
-      *ngFor="let item of filteredItems"
-      [item]="item">
-    </app-news-item>
+        <app-news-item
+          *ngFor="let item of filteredItems"
+          [item]="item">
+        </app-news-item>
+      </div>
+    </section>
+
+    <aside class="sidebar" aria-label="Engagement tools">
+      <app-engagement-panel [story]="featuredStory"></app-engagement-panel>
+      <app-poll-widget></app-poll-widget>
+    </aside>
   </div>
 </div>

--- a/src/app/components/news-feed/news-feed.component.scss
+++ b/src/app/components/news-feed/news-feed.component.scss
@@ -3,6 +3,35 @@
   margin: 0 auto;
   padding: 20px;
 
+  .content-layout {
+    display: grid;
+    gap: 24px;
+    grid-template-columns: minmax(0, 1fr);
+
+    @media (min-width: 1024px) {
+      grid-template-columns: minmax(0, 2fr) minmax(0, 1fr);
+      align-items: start;
+    }
+  }
+
+  .main-column {
+    display: flex;
+    flex-direction: column;
+    gap: 24px;
+  }
+
+  .sidebar {
+    display: flex;
+    flex-direction: column;
+    gap: 24px;
+
+    app-engagement-panel,
+    app-poll-widget {
+      width: 100%;
+      display: block;
+    }
+  }
+
   @media (max-width: 768px) {
     padding: 16px;
   }
@@ -257,8 +286,8 @@
     gap: 32px;
     animation: slideUp 0.4s ease-out;
 
-    @media (min-width: 1024px) {
-      grid-template-columns: repeat(2, 1fr);
+    @media (min-width: 768px) {
+      grid-template-columns: repeat(2, minmax(0, 1fr));
     }
   }
 }

--- a/src/app/components/news-feed/news-feed.component.spec.ts
+++ b/src/app/components/news-feed/news-feed.component.spec.ts
@@ -1,6 +1,39 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-
+import { of } from 'rxjs';
 import { NewsFeedComponent } from './news-feed.component';
+import { NewsStateService } from '../../services/news-state.service';
+import { EngagementService } from '../../services/engagement.service';
+
+class NewsStateServiceStub {
+  state$ = of({ items: [], loading: false, error: null, lastUpdated: null });
+  currentState = { items: [], loading: false, error: null, lastUpdated: null };
+  fetchNews = jasmine.createSpy('fetchNews');
+  updateFilters = jasmine.createSpy('updateFilters');
+  resetFilters = jasmine.createSpy('resetFilters');
+  setLoading = jasmine.createSpy('setLoading');
+  setError = jasmine.createSpy('setError');
+  getFilteredItems() {
+    return [];
+  }
+}
+
+class EngagementServiceStub {
+  trackEvent() {
+    return of(void 0);
+  }
+
+  fetchPollResults() {
+    return of([]);
+  }
+
+  submitNewsletterSignup() {
+    return of(void 0);
+  }
+
+  buildOgImageUrl() {
+    return 'https://example.com/og.png';
+  }
+}
 
 describe('NewsFeedComponent', () => {
   let component: NewsFeedComponent;
@@ -8,7 +41,11 @@ describe('NewsFeedComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [NewsFeedComponent]
+      imports: [NewsFeedComponent],
+      providers: [
+        { provide: NewsStateService, useClass: NewsStateServiceStub },
+        { provide: EngagementService, useClass: EngagementServiceStub }
+      ]
     })
     .compileComponents();
 

--- a/src/app/components/news-feed/news-feed.component.ts
+++ b/src/app/components/news-feed/news-feed.component.ts
@@ -5,12 +5,14 @@ import { Subject } from 'rxjs';
 import { takeUntil, debounceTime } from 'rxjs/operators';
 import { NewsStateService } from '../../services/news-state.service';
 import { NewsItemComponent } from '../news-item/news-item.component';
+import { EngagementPanelComponent } from '../engagement-panel/engagement-panel.component';
+import { PollWidgetComponent } from '../poll-widget/poll-widget.component';
 import { NewsItem, NewsFilter } from '../../models/news.model';
 
 @Component({
   selector: 'app-news-feed',
   standalone: true,
-  imports: [CommonModule, FormsModule, NewsItemComponent],
+  imports: [CommonModule, FormsModule, NewsItemComponent, EngagementPanelComponent, PollWidgetComponent],
   templateUrl: './news-feed.component.html',
   styleUrls: ['./news-feed.component.scss']
 })
@@ -98,5 +100,10 @@ export class NewsFeedComponent implements OnInit, OnDestroy {
 
   get hasActiveFilters(): boolean {
     return !!(this.searchTerm || this.selectedSource);
+  }
+
+  get featuredStory(): NewsItem | null {
+    const items = this.filteredItems;
+    return items.length ? items[0] : null;
   }
 }

--- a/src/app/components/news-item/news-item.component.html
+++ b/src/app/components/news-item/news-item.component.html
@@ -26,6 +26,15 @@
       <p>{{ item.content }}</p>
     </div>
 
+    <div class="og-preview" *ngIf="ogImageUrl">
+      <img
+        [src]="ogImageUrl"
+        [alt]="'OpenGraph preview for ' + item.title"
+        loading="lazy"
+      >
+      <p>Dynamic social preview generated for high-impact sharing.</p>
+    </div>
+
     <footer class="actions">
       <a [href]="item.link"
         target="_blank"

--- a/src/app/components/news-item/news-item.component.scss
+++ b/src/app/components/news-item/news-item.component.scss
@@ -135,6 +135,25 @@
       }
     }
 
+    .og-preview {
+      border: 1px solid #e2e8f0;
+      border-radius: 16px;
+      overflow: hidden;
+      background: #0f172a;
+      margin-bottom: 24px;
+
+      img {
+        width: 100%;
+        display: block;
+      }
+
+      p {
+        margin: 12px 16px 16px;
+        font-size: 0.85rem;
+        color: rgba(226, 232, 240, 0.8);
+      }
+    }
+
     footer.actions {
       margin-top: 24px;
       text-align: right;

--- a/src/app/components/news-item/news-item.component.spec.ts
+++ b/src/app/components/news-item/news-item.component.spec.ts
@@ -1,6 +1,12 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-
 import { NewsItemComponent } from './news-item.component';
+import { EngagementService } from '../../services/engagement.service';
+
+class EngagementServiceStub {
+  buildOgImageUrl() {
+    return 'https://example.com/og.png';
+  }
+}
 
 describe('NewsItemComponent', () => {
   let component: NewsItemComponent;
@@ -8,7 +14,10 @@ describe('NewsItemComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [NewsItemComponent]
+      imports: [NewsItemComponent],
+      providers: [
+        { provide: EngagementService, useClass: EngagementServiceStub }
+      ]
     })
     .compileComponents();
 

--- a/src/app/components/news-item/news-item.component.ts
+++ b/src/app/components/news-item/news-item.component.ts
@@ -1,5 +1,7 @@
 import { Component, Input } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { EngagementService } from '../../services/engagement.service';
+import { NewsItem } from '../../models/news.model';
 
 @Component({
   selector: 'app-news-item',
@@ -9,9 +11,11 @@ import { CommonModule } from '@angular/common';
   styleUrl: './news-item.component.scss'
 })
 export class NewsItemComponent {
-  @Input() item: any;
+  @Input() item!: NewsItem;
 
-  formatDate(date: string): string {
+  constructor(private engagementService: EngagementService) { }
+
+  formatDate(date: Date): string {
     return new Date(date).toLocaleDateString('en-US', {
       year: 'numeric',
       month: 'long',
@@ -19,5 +23,12 @@ export class NewsItemComponent {
       hour: '2-digit',
       minute: '2-digit'
     });
+  }
+
+  get ogImageUrl(): string | null {
+    if (!this.item) {
+      return null;
+    }
+    return this.engagementService.buildOgImageUrl(this.item);
   }
 }

--- a/src/app/components/poll-widget/poll-widget.component.html
+++ b/src/app/components/poll-widget/poll-widget.component.html
@@ -1,0 +1,31 @@
+<aside class="poll-widget" aria-label="Campaign pulse polls">
+  <h2>Campaign pulse</h2>
+  <p class="description">Quick poll results from the grassroots community.</p>
+
+  <ng-container *ngIf="(polls$ | async) as polls; else loading">
+    <article *ngFor="let poll of polls" class="poll" aria-live="polite">
+      <header>
+        <h3>{{ poll.question }}</h3>
+        <span class="updated">Updated {{ poll.lastUpdatedRelative }}</span>
+      </header>
+      <ul>
+        <li *ngFor="let option of poll.options">
+          <span class="label">{{ option.label }}</span>
+          <div class="bar">
+            <div class="fill" [style.width.%]="option.percentage"></div>
+          </div>
+          <span class="value">{{ option.percentage }}%</span>
+        </li>
+      </ul>
+      <footer>
+        <span class="total">{{ poll.totalVotes | number }} responses</span>
+      </footer>
+    </article>
+
+    <p *ngIf="polls.length === 0" class="empty-state">Poll results are coming soon.</p>
+  </ng-container>
+
+  <ng-template #loading>
+    <div class="loading">Loading poll snapshots...</div>
+  </ng-template>
+</aside>

--- a/src/app/components/poll-widget/poll-widget.component.scss
+++ b/src/app/components/poll-widget/poll-widget.component.scss
@@ -1,0 +1,106 @@
+.poll-widget {
+  background: #ffffff;
+  border-radius: 16px;
+  padding: 24px;
+  box-shadow: 0 18px 30px rgba(15, 23, 42, 0.12);
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+h2 {
+  margin: 0;
+  font-size: 1.25rem;
+  color: #0f172a;
+}
+
+.description {
+  margin: 0;
+  color: #475569;
+  font-size: 0.95rem;
+}
+
+.poll {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  border: 1px solid #e2e8f0;
+  border-radius: 12px;
+  padding: 16px;
+  background: #f8fafc;
+}
+
+.poll header {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.poll h3 {
+  margin: 0;
+  font-size: 1rem;
+  color: #111827;
+}
+
+.updated {
+  font-size: 0.75rem;
+  color: #64748b;
+}
+
+.poll ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.poll li {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  align-items: center;
+  gap: 8px;
+}
+
+.label {
+  font-size: 0.9rem;
+  color: #0f172a;
+}
+
+.bar {
+  grid-column: 1 / span 2;
+  height: 8px;
+  background: #e2e8f0;
+  border-radius: 999px;
+  overflow: hidden;
+}
+
+.fill {
+  height: 100%;
+  background: linear-gradient(135deg, #2563eb, #9333ea);
+  border-radius: inherit;
+}
+
+.value {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: #0f172a;
+}
+
+.poll footer {
+  font-size: 0.8rem;
+  color: #475569;
+}
+
+.loading,
+.empty-state {
+  font-size: 0.9rem;
+  color: #475569;
+}
+
+@media (max-width: 1024px) {
+  .poll-widget {
+    order: -1;
+  }
+}

--- a/src/app/components/poll-widget/poll-widget.component.ts
+++ b/src/app/components/poll-widget/poll-widget.component.ts
@@ -1,0 +1,50 @@
+import { Component, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
+import { PollQuestion } from '../../models/engagement.model';
+import { EngagementService } from '../../services/engagement.service';
+
+interface PollViewModel extends PollQuestion {
+  lastUpdatedRelative: string;
+}
+
+@Component({
+  selector: 'app-poll-widget',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './poll-widget.component.html',
+  styleUrls: ['./poll-widget.component.scss']
+})
+export class PollWidgetComponent implements OnInit {
+  polls$!: Observable<PollViewModel[]>;
+
+  constructor(private engagementService: EngagementService) { }
+
+  ngOnInit(): void {
+    this.polls$ = this.engagementService.fetchPollResults().pipe(
+      map(polls => polls.map(poll => ({
+        ...poll,
+        lastUpdatedRelative: this.formatRelativeTime(poll.lastUpdated)
+      })))
+    );
+  }
+
+  private formatRelativeTime(timestamp: string): string {
+    const updated = new Date(timestamp).getTime();
+    const diffMs = Date.now() - updated;
+    const diffMinutes = Math.round(diffMs / 60000);
+
+    if (diffMinutes < 60) {
+      return `${diffMinutes} minute${diffMinutes === 1 ? '' : 's'} ago`;
+    }
+
+    const diffHours = Math.round(diffMinutes / 60);
+    if (diffHours < 24) {
+      return `${diffHours} hour${diffHours === 1 ? '' : 's'} ago`;
+    }
+
+    const diffDays = Math.round(diffHours / 24);
+    return `${diffDays} day${diffDays === 1 ? '' : 's'} ago`;
+  }
+}

--- a/src/app/models/engagement.model.ts
+++ b/src/app/models/engagement.model.ts
@@ -1,0 +1,18 @@
+export interface PollOption {
+  id: string;
+  label: string;
+  votes: number;
+  percentage: number;
+}
+
+export interface PollQuestion {
+  id: string;
+  question: string;
+  options: PollOption[];
+  totalVotes: number;
+  lastUpdated: string;
+}
+
+export interface EngagementEventPayload {
+  [key: string]: unknown;
+}

--- a/src/app/services/engagement.service.ts
+++ b/src/app/services/engagement.service.ts
@@ -1,0 +1,56 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable, of } from 'rxjs';
+import { catchError, map } from 'rxjs/operators';
+import { PollQuestion, EngagementEventPayload } from '../models/engagement.model';
+import { NewsItem } from '../models/news.model';
+
+interface PollResponse {
+  polls: PollQuestion[];
+}
+
+@Injectable({
+  providedIn: 'root'
+})
+export class EngagementService {
+  private readonly baseUrl = 'http://localhost:4000';
+
+  constructor(private http: HttpClient) { }
+
+  fetchPollResults(): Observable<PollQuestion[]> {
+    return this.http.get<PollResponse>(`${this.baseUrl}/polls`).pipe(
+      map(response => response.polls),
+      catchError(error => {
+        console.error('Failed to load poll results', error);
+        return of([]);
+      })
+    );
+  }
+
+  submitNewsletterSignup(email: string, storyId?: string): Observable<void> {
+    return this.http.post<void>(`${this.baseUrl}/newsletter/signup`, { email, storyId }).pipe(
+      catchError(error => {
+        console.error('Failed to submit newsletter signup', error);
+        throw error;
+      })
+    );
+  }
+
+  trackEvent(eventName: string, payload: EngagementEventPayload = {}): Observable<void> {
+    return this.http.post<void>(`${this.baseUrl}/analytics/events`, { eventName, payload }).pipe(
+      catchError(error => {
+        console.error('Failed to track engagement event', error);
+        return of(void 0);
+      })
+    );
+  }
+
+  buildOgImageUrl(story: NewsItem): string {
+    const params = new URLSearchParams({
+      title: story.title,
+      source: story.source || 'Campaign Tracker',
+      date: story.pubDate.toISOString()
+    });
+    return `${this.baseUrl}/og-image?${params.toString()}`;
+  }
+}


### PR DESCRIPTION
## Summary
- add an Express-based engagement service for polls, newsletter capture, analytics, and OpenGraph SVG generation
- surface a sidebar with newsletter signup, social sharing, and poll widgets connected to the new backend
- generate dynamic OG previews for stories and wire analytics tracking for share and signup conversions

## Testing
- `npm test -- --watch=false` *(fails: Chrome browser binary not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ea813a8c148326bf82078530a086de