### PR TITLE
Add analytics tracking and personalized recommendations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,8 @@
         "@angular/platform-browser": "^18.0.0",
         "@angular/platform-browser-dynamic": "^18.0.0",
         "@angular/router": "^18.0.0",
+        "cors": "^2.8.5",
+        "express": "^4.19.2",
         "rss-parser": "^3.13.0",
         "rxjs": "~7.8.0",
         "tslib": "^2.3.0",
@@ -4751,7 +4753,6 @@
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
       "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mime-types": "~2.1.34",
@@ -4765,7 +4766,6 @@
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
       "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -4998,7 +4998,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/autoprefixer": {
@@ -5193,7 +5192,6 @@
       "version": "1.20.3",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.3.tgz",
       "integrity": "sha512-7rAxByjUMqQ3/bHJy7D6OGXvx/MMc4IqBn/X0fcM1QUcAItpZrBEYhWGem+tzXH90c+G01ypMcYJBO9Y30203g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "bytes": "3.1.2",
@@ -5218,7 +5216,6 @@
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
       "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "2.0.0"
@@ -5228,7 +5225,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/bonjour-service": {
@@ -5358,7 +5354,6 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
       "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -5446,7 +5441,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.1.tgz",
       "integrity": "sha512-BhYE+WDaywFg2TBWYNXAE+8B1ATnThNBqXHP5nQu0jWJdVvY2hvkpyB3qOmtmDePiS5/BDQ8wASEWGMWRG148g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -5460,7 +5454,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.3.tgz",
       "integrity": "sha512-YTd+6wGlNlPxSuri7Y6X8tY2dmm12UMH66RpKMhiX6rsk5wXXnYgbUcOt8kiS31/AjfoTOvCsE+w8nZQLQnzHA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.1",
@@ -5899,7 +5892,6 @@
       "version": "0.5.4",
       "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
       "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "5.2.1"
@@ -5912,7 +5904,6 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
       "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -5939,7 +5930,6 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/copy-anything": {
@@ -6005,7 +5995,6 @@
       "version": "2.8.5",
       "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
       "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "object-assign": "^4",
@@ -6277,7 +6266,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
       "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -6287,7 +6275,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
       "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8",
@@ -6407,7 +6394,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
       "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.1",
@@ -6429,7 +6415,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
@@ -6460,7 +6445,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
       "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -6642,7 +6626,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
       "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -6652,7 +6635,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -6669,7 +6651,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
       "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
@@ -6745,7 +6726,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
       "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/eslint-scope": {
@@ -6809,7 +6789,6 @@
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
       "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -6890,7 +6869,6 @@
       "version": "4.21.2",
       "resolved": "https://registry.npmjs.org/express/-/express-4.21.2.tgz",
       "integrity": "sha512-28HqgMZAmih1Czt9ny7qr6ek2qddF4FclbMzwhCREB6OFfH+rXAnuNCwo1/wFvrtbgsQDb4kSbX9de9lFbrXnA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "accepts": "~1.3.8",
@@ -6937,7 +6915,6 @@
       "version": "0.7.1",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.1.tgz",
       "integrity": "sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -6947,7 +6924,6 @@
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
       "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "2.0.0"
@@ -6957,7 +6933,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
       "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -6967,7 +6942,6 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.1.tgz",
       "integrity": "sha512-6BN9trH7bp3qvnrRyzsBz+g3lZxTNZTbVO2EV1CS0WIcDbawYVdYvGflME/9QP0h0pYlCDBCTjYa9nZzMDpyxQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "debug": "2.6.9",
@@ -6986,14 +6960,12 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/express/node_modules/statuses": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
       "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -7260,7 +7232,6 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
       "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -7284,7 +7255,6 @@
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
       "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -7344,7 +7314,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -7387,7 +7356,6 @@
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.7.tgz",
       "integrity": "sha512-VW6Pxhsrk0KAOqs3WEd0klDiF/+V7gQOpAvY1jVU/LHmaD/kQO4523aiJuikX/QAKYiW6x8Jh+RJej1almdtCA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.1",
@@ -7412,7 +7380,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
       "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "dunder-proto": "^1.0.1",
@@ -7512,7 +7479,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
       "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -7549,7 +7515,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -7578,7 +7543,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
       "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -7715,7 +7679,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
       "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "depd": "2.0.0",
@@ -7732,7 +7695,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
       "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -7830,7 +7792,6 @@
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
       "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3"
@@ -7996,7 +7957,6 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/ini": {
@@ -9339,7 +9299,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
       "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -9349,7 +9308,6 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
       "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -9379,7 +9337,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
       "integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -9406,7 +9363,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
       "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -9456,7 +9412,6 @@
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
       "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -9466,7 +9421,6 @@
       "version": "2.1.35",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mime-db": "1.52.0"
@@ -9750,7 +9704,6 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/msgpackr": {
@@ -10234,7 +10187,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -10244,7 +10196,6 @@
       "version": "1.13.3",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.3.tgz",
       "integrity": "sha512-kDCGIbxkDSXE3euJZZXzc6to7fCrKHNI/hSRQnRuQ+BWjFNzZwiFF8fj/6o2t2G9/jTj8PSIYTfCLelLZEeRpA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -10264,7 +10215,6 @@
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
       "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ee-first": "1.1.1"
@@ -10628,7 +10578,6 @@
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
       "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -10699,7 +10648,6 @@
       "version": "0.1.12",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
       "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/path-type": {
@@ -10966,7 +10914,6 @@
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
       "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "forwarded": "0.2.0",
@@ -10980,7 +10927,6 @@
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
       "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.10"
@@ -11015,7 +10961,6 @@
       "version": "6.13.0",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.13.0.tgz",
       "integrity": "sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==",
-      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.0.6"
@@ -11062,7 +11007,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
       "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -11072,7 +11016,6 @@
       "version": "2.5.2",
       "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.2.tgz",
       "integrity": "sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "bytes": "3.1.2",
@@ -11491,7 +11434,6 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -11530,7 +11472,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/sass": {
@@ -11674,7 +11615,6 @@
       "version": "0.19.0",
       "resolved": "https://registry.npmjs.org/send/-/send-0.19.0.tgz",
       "integrity": "sha512-dW41u5VfLXu8SJh5bwRmyYUbAoSB3c9uQh6L8h/KtsFREPWpbX1lrljJo186Jc4nmci/sGUZ9a0a0J2zgfq2hw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "debug": "2.6.9",
@@ -11699,7 +11639,6 @@
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
       "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "2.0.0"
@@ -11709,14 +11648,12 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/send/node_modules/mime": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
       "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "mime": "cli.js"
@@ -11729,7 +11666,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
       "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -11825,7 +11761,6 @@
       "version": "1.16.2",
       "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.2.tgz",
       "integrity": "sha512-VqpjJZKadQB/PEbEwvFdO43Ax5dFBZ2UECszz8bQ7pi7wt//PWe1P6MN7eCnjsatYtBT6EuiClbjSWP2WrIoTw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "encodeurl": "~2.0.0",
@@ -11841,7 +11776,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
       "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -11851,7 +11785,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/shallow-clone": {
@@ -11907,7 +11840,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
       "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -11927,7 +11859,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
       "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -11944,7 +11875,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
       "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -11963,7 +11893,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
       "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -12743,7 +12672,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
       "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.6"
@@ -12814,7 +12742,6 @@
       "version": "1.6.18",
       "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
       "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "media-typer": "0.3.0",
@@ -12976,7 +12903,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
       "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -13044,7 +12970,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
       "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4.0"
@@ -13085,7 +13010,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
       "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "start": "ng serve",
     "build": "ng build",
     "watch": "ng build --watch --configuration development",
-    "test": "ng test"
+    "test": "ng test",
+    "server": "node server/index.js"
   },
   "private": true,
   "dependencies": {
@@ -21,7 +22,9 @@
     "rss-parser": "^3.13.0",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",
-    "zone.js": "~0.14.3"
+    "zone.js": "~0.14.3",
+    "express": "^4.19.2",
+    "cors": "^2.8.5"
   },
   "devDependencies": {
     "@angular-devkit/build-angular": "^18.0.3",

--- a/server/analytics-middleware.js
+++ b/server/analytics-middleware.js
@@ -1,0 +1,34 @@
+const { randomUUID } = require('crypto');
+
+function createAnalyticsMiddleware(store) {
+  return function analyticsMiddleware(req, res, next) {
+    if (req.method !== 'POST') {
+      return next();
+    }
+
+    const { type, itemId, dwellTimeMs, userId, metadata } = req.body ?? {};
+    if (!type || !itemId) {
+      return res.status(400).json({ message: 'Missing required fields: type and itemId' });
+    }
+
+    const resolvedUserId = userId || req.headers['x-user-id'] || 'anonymous';
+    const event = store.recordEvent({
+      id: randomUUID(),
+      type,
+      itemId,
+      userId: resolvedUserId,
+      dwellTimeMs: dwellTimeMs ?? null,
+      metadata: {
+        requestId: req.context?.requestId,
+        ...metadata
+      },
+      recordedAt: new Date().toISOString()
+    });
+
+    res.status(201).json({ status: 'recorded', event });
+  };
+}
+
+module.exports = {
+  createAnalyticsMiddleware
+};

--- a/server/analytics-store.js
+++ b/server/analytics-store.js
@@ -1,0 +1,100 @@
+const fs = require('fs');
+const path = require('path');
+
+const ANALYTICS_FILE = path.join(__dirname, 'data', 'analytics-events.json');
+
+const EVENT_WEIGHTS = {
+  click: 1,
+  save: 3,
+  dwell: 0.5
+};
+
+function ensureStore() {
+  if (!fs.existsSync(ANALYTICS_FILE)) {
+    fs.mkdirSync(path.dirname(ANALYTICS_FILE), { recursive: true });
+    fs.writeFileSync(ANALYTICS_FILE, JSON.stringify({ events: [] }, null, 2));
+  }
+}
+
+function readStore() {
+  ensureStore();
+  const raw = fs.readFileSync(ANALYTICS_FILE, 'utf-8');
+  return JSON.parse(raw);
+}
+
+function writeStore(data) {
+  fs.writeFileSync(ANALYTICS_FILE, JSON.stringify(data, null, 2));
+}
+
+class AnalyticsStore {
+  constructor() {
+    ensureStore();
+  }
+
+  recordEvent(event) {
+    const store = readStore();
+    const enriched = {
+      ...event,
+      weight: EVENT_WEIGHTS[event.type] ?? 1
+    };
+    store.events.push(enriched);
+    writeStore(store);
+    return enriched;
+  }
+
+  getEvents() {
+    return readStore().events;
+  }
+
+  getEventsByUser(userId) {
+    if (!userId) {
+      return [];
+    }
+    return this.getEvents().filter(event => event.userId === userId);
+  }
+
+  getEngagementForItem(itemId) {
+    return this.getEvents()
+      .filter(event => event.itemId === itemId)
+      .reduce((acc, event) => acc + (event.weight ?? 0), 0);
+  }
+
+  getSharedCounts() {
+    return this.getEvents()
+      .filter(event => event.type === 'save')
+      .reduce((acc, event) => {
+        acc[event.itemId] = (acc[event.itemId] || 0) + 1;
+        return acc;
+      }, {});
+  }
+
+  getSimilarUsers(userId) {
+    const events = this.getEvents();
+    const userEvents = events.filter(event => event.userId === userId);
+    if (!userEvents.length) {
+      return [];
+    }
+
+    const interactedItems = new Set(userEvents.map(event => event.itemId));
+    const similarityScores = new Map();
+
+    events.forEach(event => {
+      if (event.userId === userId) {
+        return;
+      }
+      if (interactedItems.has(event.itemId)) {
+        const current = similarityScores.get(event.userId) || 0;
+        similarityScores.set(event.userId, current + (event.weight ?? 1));
+      }
+    });
+
+    return Array.from(similarityScores.entries())
+      .map(([id, score]) => ({ id, score }))
+      .sort((a, b) => b.score - a.score);
+  }
+}
+
+module.exports = {
+  AnalyticsStore,
+  EVENT_WEIGHTS
+};

--- a/server/data/.gitignore
+++ b/server/data/.gitignore
@@ -1,0 +1,1 @@
+analytics-events.json

--- a/server/data/news-corpus.json
+++ b/server/data/news-corpus.json
@@ -1,0 +1,122 @@
+[
+  {
+    "id": "rally-energy",
+    "title": "Trump launches energy-focused swing state rally",
+    "summary": "Campaign pivots to domestic energy policy with new pledges on drilling and refinery permits.",
+    "url": "https://example.com/news/rally-energy",
+    "source": "Campaign Daily",
+    "category": "Energy",
+    "tags": ["energy", "campaign", "economy"],
+    "imageUrl": "https://picsum.photos/seed/energy/400/225",
+    "publishedAt": "2024-06-01T13:00:00.000Z",
+    "popularity": 72
+  },
+  {
+    "id": "fundraising-tour",
+    "title": "Record-breaking fundraising tour wraps up in Texas",
+    "summary": "Donor circuit nets the campaign its strongest quarter to date with major bundlers joining the team.",
+    "url": "https://example.com/news/fundraising-tour",
+    "source": "Finance Wire",
+    "category": "Fundraising",
+    "tags": ["fundraising", "finance", "donors"],
+    "imageUrl": "https://picsum.photos/seed/fundraising/400/225",
+    "publishedAt": "2024-06-03T10:30:00.000Z",
+    "popularity": 88
+  },
+  {
+    "id": "foreign-policy-brief",
+    "title": "Campaign advisers outline foreign policy priorities",
+    "summary": "Transition team vets NATO commitments and outlines Asia-Pacific strategy in new white paper.",
+    "url": "https://example.com/news/foreign-policy-brief",
+    "source": "Global Outlook",
+    "category": "Foreign Policy",
+    "tags": ["foreign policy", "defense", "international"],
+    "imageUrl": "https://picsum.photos/seed/foreignpolicy/400/225",
+    "publishedAt": "2024-06-02T15:45:00.000Z",
+    "popularity": 64
+  },
+  {
+    "id": "voter-registration",
+    "title": "Massive voter registration drive targets suburban counties",
+    "summary": "Grassroots organizers focus on suburban swing voters with data-driven outreach.",
+    "url": "https://example.com/news/voter-registration",
+    "source": "Civic Pulse",
+    "category": "Grassroots",
+    "tags": ["grassroots", "voters", "data"],
+    "imageUrl": "https://picsum.photos/seed/voters/400/225",
+    "publishedAt": "2024-06-04T09:15:00.000Z",
+    "popularity": 93
+  },
+  {
+    "id": "policy-immigration",
+    "title": "Immigration policy rollout details border technology plan",
+    "summary": "Campaign announces expanded surveillance and staffing along the southern border.",
+    "url": "https://example.com/news/policy-immigration",
+    "source": "Policy Desk",
+    "category": "Policy",
+    "tags": ["immigration", "policy", "border"],
+    "imageUrl": "https://picsum.photos/seed/immigration/400/225",
+    "publishedAt": "2024-06-05T12:20:00.000Z",
+    "popularity": 81
+  },
+  {
+    "id": "tech-coalition",
+    "title": "Tech coalition forms to advise on digital outreach",
+    "summary": "Silicon Valley supporters emphasize data privacy alongside targeted campaigning.",
+    "url": "https://example.com/news/tech-coalition",
+    "source": "Innovation Ledger",
+    "category": "Technology",
+    "tags": ["technology", "data", "campaign"],
+    "imageUrl": "https://picsum.photos/seed/tech/400/225",
+    "publishedAt": "2024-06-06T17:05:00.000Z",
+    "popularity": 69
+  },
+  {
+    "id": "swing-state-polling",
+    "title": "Internal polling shows momentum in Rust Belt",
+    "summary": "Campaign shares internal numbers highlighting manufacturing towns moving right.",
+    "url": "https://example.com/news/swing-state-polling",
+    "source": "Poll Watch",
+    "category": "Polling",
+    "tags": ["polling", "economy", "rust belt"],
+    "imageUrl": "https://picsum.photos/seed/polling/400/225",
+    "publishedAt": "2024-06-04T19:40:00.000Z",
+    "popularity": 76
+  },
+  {
+    "id": "debate-prep",
+    "title": "Debate prep intensifies with mock town halls",
+    "summary": "Advisers run simulated debate nights focusing on suburban economic messaging.",
+    "url": "https://example.com/news/debate-prep",
+    "source": "Stagecraft",
+    "category": "Debate",
+    "tags": ["debate", "economy", "voters"],
+    "imageUrl": "https://picsum.photos/seed/debate/400/225",
+    "publishedAt": "2024-06-07T08:55:00.000Z",
+    "popularity": 84
+  },
+  {
+    "id": "rural-infrastructure",
+    "title": "Rural infrastructure tour pitches broadband expansion",
+    "summary": "Campaign bus tour outlines infrastructure spending to close rural digital divide.",
+    "url": "https://example.com/news/rural-infrastructure",
+    "source": "Heartland Report",
+    "category": "Infrastructure",
+    "tags": ["infrastructure", "technology", "rural"],
+    "imageUrl": "https://picsum.photos/seed/infrastructure/400/225",
+    "publishedAt": "2024-06-05T08:10:00.000Z",
+    "popularity": 71
+  },
+  {
+    "id": "student-outreach",
+    "title": "Student outreach expands with campus coalition",
+    "summary": "Younger volunteers focus on inflation messaging and career opportunities.",
+    "url": "https://example.com/news/student-outreach",
+    "source": "Campus Chronicle",
+    "category": "Youth Vote",
+    "tags": ["students", "grassroots", "economy"],
+    "imageUrl": "https://picsum.photos/seed/students/400/225",
+    "publishedAt": "2024-06-03T22:25:00.000Z",
+    "popularity": 67
+  }
+]

--- a/server/fallback-cohorts.js
+++ b/server/fallback-cohorts.js
@@ -1,0 +1,17 @@
+module.exports = [
+  {
+    id: 'most-shared-today',
+    label: 'Most shared today',
+    description: 'Stories that other readers have saved or shared the most in the past 24 hours.'
+  },
+  {
+    id: 'campaign-briefing',
+    label: 'Campaign briefing',
+    description: 'A cross-section of campaign fundraising, policy, and grassroots developments.'
+  },
+  {
+    id: 'spotlight-on-issues',
+    label: 'Spotlight on issues',
+    description: 'Hand-picked policy explainers when personal history is not available.'
+  }
+];

--- a/server/index.js
+++ b/server/index.js
@@ -1,0 +1,54 @@
+const express = require('express');
+const cors = require('cors');
+const { randomUUID } = require('crypto');
+const { AnalyticsStore } = require('./analytics-store');
+const { RecommendationEngine } = require('./recommendation-engine');
+const { createAnalyticsMiddleware } = require('./analytics-middleware');
+
+const PORT = process.env.PORT || 3000;
+
+const app = express();
+const analyticsStore = new AnalyticsStore();
+const recommendationEngine = new RecommendationEngine(analyticsStore);
+
+app.use(cors());
+app.use(express.json());
+
+app.use((req, res, next) => {
+  req.context = {
+    requestId: randomUUID(),
+    receivedAt: new Date().toISOString()
+  };
+  next();
+});
+
+app.use('/api/analytics/events', createAnalyticsMiddleware(analyticsStore));
+
+app.get('/api/news/recommended', (req, res) => {
+  const userId = req.query.userId || req.headers['x-user-id'];
+  const limit = Number(req.query.limit ?? 6);
+  const recommendations = recommendationEngine.getRecommendations(userId, limit);
+  res.json({
+    requestedAt: new Date().toISOString(),
+    userId: userId ?? null,
+    ...recommendations
+  });
+});
+
+app.get('/api/analytics/summary', (_req, res) => {
+  const events = analyticsStore.getEvents();
+  res.json({
+    events,
+    totals: {
+      count: events.length
+    }
+  });
+});
+
+if (require.main === module) {
+  app.listen(PORT, () => {
+    console.log(`Analytics and recommendation service listening on port ${PORT}`);
+  });
+}
+
+module.exports = app;

--- a/server/recommendation-engine.js
+++ b/server/recommendation-engine.js
@@ -1,0 +1,176 @@
+const path = require('path');
+const fs = require('fs');
+const { AnalyticsStore, EVENT_WEIGHTS } = require('./analytics-store');
+const fallbackCohorts = require('./fallback-cohorts');
+
+const CORPUS_FILE = path.join(__dirname, 'data', 'news-corpus.json');
+
+function loadCorpus() {
+  const raw = fs.readFileSync(CORPUS_FILE, 'utf-8');
+  return JSON.parse(raw);
+}
+
+function getEventWeight(type) {
+  return EVENT_WEIGHTS[type] ?? 1;
+}
+
+function normalizeScores(scores) {
+  const maxScore = Math.max(...scores.map(score => score.score), 1);
+  return scores.map(entry => ({
+    ...entry,
+    score: entry.score / maxScore
+  }));
+}
+
+class RecommendationEngine {
+  constructor(store = new AnalyticsStore()) {
+    this.store = store;
+    this.corpus = loadCorpus();
+  }
+
+  refreshCorpus() {
+    this.corpus = loadCorpus();
+  }
+
+  getCorpus() {
+    return this.corpus;
+  }
+
+  buildUserProfile(userId) {
+    const events = this.store.getEventsByUser(userId);
+    if (!events.length) {
+      return null;
+    }
+
+    const tagWeights = new Map();
+    const itemEngagement = new Map();
+
+    events.forEach(event => {
+      const item = this.corpus.find(candidate => candidate.id === event.itemId);
+      if (!item) {
+        return;
+      }
+      const weight = getEventWeight(event.type);
+      item.tags.forEach(tag => {
+        const previous = tagWeights.get(tag) || 0;
+        tagWeights.set(tag, previous + weight);
+      });
+      const currentItemEngagement = itemEngagement.get(item.id) || 0;
+      itemEngagement.set(item.id, currentItemEngagement + weight);
+    });
+
+    return {
+      tagWeights,
+      itemEngagement
+    };
+  }
+
+  computeContentScore(userProfile, item) {
+    if (!userProfile) {
+      return 0;
+    }
+    const { tagWeights } = userProfile;
+    return item.tags.reduce((score, tag) => {
+      return score + (tagWeights.get(tag) || 0);
+    }, 0);
+  }
+
+  computeCollaborativeScore(userId, itemId) {
+    const similarUsers = this.store.getSimilarUsers(userId).slice(0, 5);
+    if (!similarUsers.length) {
+      return 0;
+    }
+
+    let score = 0;
+    similarUsers.forEach(user => {
+      const events = this.store.getEventsByUser(user.id)
+        .filter(event => event.itemId === itemId);
+      const eventScore = events.reduce((acc, event) => acc + getEventWeight(event.type), 0);
+      score += eventScore * user.score;
+    });
+
+    return score;
+  }
+
+  getPersonalizedRecommendations(userId, limit = 6) {
+    const userProfile = this.buildUserProfile(userId);
+    if (!userProfile) {
+      return null;
+    }
+
+    const seenItems = new Set(this.store.getEventsByUser(userId).map(event => event.itemId));
+    const scored = this.corpus.map(item => {
+      const contentScore = this.computeContentScore(userProfile, item);
+      const collaborativeScore = this.computeCollaborativeScore(userId, item.id);
+      const popularityBoost = item.popularity * 0.1;
+      const score = contentScore + collaborativeScore + popularityBoost;
+      return { item, score, breakdown: { contentScore, collaborativeScore, popularityBoost } };
+    })
+      .filter(entry => !seenItems.has(entry.item.id))
+      .sort((a, b) => b.score - a.score)
+      .slice(0, limit);
+
+    return {
+      strategy: 'personalized',
+      items: normalizeScores(scored).map(entry => ({
+        ...entry.item,
+        recommendationScore: Number(entry.score.toFixed(3)),
+        breakdown: entry.breakdown
+      }))
+    };
+  }
+
+  getFallbackCohort(limit = 6) {
+    const events = this.store.getEvents();
+    const sharedCounts = this.store.getSharedCounts();
+
+    const mostShared = Object.entries(sharedCounts)
+      .map(([itemId, count]) => ({ itemId, count }))
+      .sort((a, b) => b.count - a.count)
+      .slice(0, limit)
+      .map(entry => this.corpus.find(item => item.id === entry.itemId))
+      .filter(Boolean);
+
+    if (mostShared.length) {
+      return {
+        strategy: 'fallback',
+        cohort: fallbackCohorts[0],
+        items: mostShared
+      };
+    }
+
+    const fallback = fallbackCohorts[1];
+    const curated = this.corpus
+      .slice()
+      .sort((a, b) => b.popularity - a.popularity)
+      .slice(0, limit);
+
+    return {
+      strategy: 'fallback',
+      cohort: fallback,
+      items: curated
+    };
+  }
+
+  getRecommendations(userId, limit = 6) {
+    if (!userId) {
+      const fallback = this.getFallbackCohort(limit);
+      return { ...fallback, cohort: fallback.cohort ?? fallbackCohorts[2] };
+    }
+
+    const personalized = this.getPersonalizedRecommendations(userId, limit);
+    if (personalized && personalized.items.length) {
+      return personalized;
+    }
+
+    const fallback = this.getFallbackCohort(limit);
+    if (!fallback.cohort) {
+      fallback.cohort = fallbackCohorts[2];
+    }
+    return fallback;
+  }
+}
+
+module.exports = {
+  RecommendationEngine
+};

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -17,13 +17,13 @@ describe('AppComponent', () => {
   it(`should have the 'trump-tracker' title`, () => {
     const fixture = TestBed.createComponent(AppComponent);
     const app = fixture.componentInstance;
-    expect(app.title).toEqual('trump-tracker');
+    expect(app.title).toEqual('Trump 47 Campaign Tracker');
   });
 
-  it('should render title', () => {
+  it('should render the recommended feed heading', () => {
     const fixture = TestBed.createComponent(AppComponent);
     fixture.detectChanges();
     const compiled = fixture.nativeElement as HTMLElement;
-    expect(compiled.querySelector('h1')?.textContent).toContain('Hello, trump-tracker');
+    expect(compiled.querySelector('#recommended-heading')?.textContent).toContain('Recommended for you');
   });
 });

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,21 +1,51 @@
 import { Component } from '@angular/core';
 import { RouterOutlet } from '@angular/router';
 import { NewsFeedComponent } from './components/news-feed/news-feed.component';
+import { RecommendedFeedComponent } from './components/recommended-feed/recommended-feed.component';
 
 @Component({
   selector: 'app-root',
   standalone: true,
-  imports: [RouterOutlet, NewsFeedComponent],
+  imports: [RouterOutlet, NewsFeedComponent, RecommendedFeedComponent],
   template: `
-    <main>
-      <app-news-feed></app-news-feed>
+    <main class="app-layout">
+      <section class="app-layout__sidebar">
+        <app-recommended-feed></app-recommended-feed>
+      </section>
+      <section class="app-layout__content">
+        <app-news-feed></app-news-feed>
+      </section>
     </main>
   `,
   styles: [`
-    main {
+    .app-layout {
       min-height: 100vh;
       background: #f0f2f5;
-      padding: 20px 0;
+      padding: 32px;
+      display: grid;
+      grid-template-columns: minmax(260px, 360px) 1fr;
+      gap: 24px;
+    }
+
+    .app-layout__sidebar {
+      position: sticky;
+      top: 32px;
+      align-self: start;
+    }
+
+    .app-layout__content {
+      min-width: 0;
+    }
+
+    @media (max-width: 1024px) {
+      .app-layout {
+        grid-template-columns: 1fr;
+        padding: 16px;
+      }
+
+      .app-layout__sidebar {
+        position: static;
+      }
     }
   `]
 })

--- a/src/app/components/news-feed/news-feed.component.html
+++ b/src/app/components/news-feed/news-feed.component.html
@@ -78,7 +78,9 @@
 
     <app-news-item
       *ngFor="let item of filteredItems"
-      [item]="item">
+      [item]="item"
+      [showSave]="true"
+      analyticsContext="core-feed">
     </app-news-item>
   </div>
 </div>

--- a/src/app/components/news-item/news-item.component.html
+++ b/src/app/components/news-item/news-item.component.html
@@ -1,8 +1,8 @@
-<article class="news-item">
+<article class="news-item" (mouseenter)="onMouseEnter()" (mouseleave)="onMouseLeave()">
   <div class="news-content">
     <header>
       <h2>
-        <a [href]="item.link" target="_blank" rel="noopener noreferrer">
+        <a [href]="item.link" target="_blank" rel="noopener noreferrer" (click)="onReadMoreClick()">
           {{ item.title }}
         </a>
       </h2>
@@ -16,6 +16,14 @@
       </div>
     </header>
 
+    <div class="recommendation-meta" *ngIf="item.metrics?.recommendationScore !== undefined || item.metrics?.strategy">
+      <span class="score" *ngIf="item.metrics?.recommendationScore !== undefined">
+        Match score: {{ item.metrics?.recommendationScore | number:'1.0-2' }}
+      </span>
+      <span class="strategy" *ngIf="item.metrics?.strategy === 'fallback' && item.metrics?.cohortLabel">{{ item.metrics?.cohortLabel }}</span>
+      <span class="strategy" *ngIf="item.metrics?.strategy === 'personalized'">Personalized</span>
+    </div>
+
     <div class="content">
       <img *ngIf="item.imageUrl"
         [src]="item.imageUrl"
@@ -23,7 +31,7 @@
         [title]="item.title"
         class="thumbnail"
         loading="lazy">
-      <p>{{ item.content }}</p>
+      <p>{{ item.summary || item.content }}</p>
     </div>
 
     <footer class="actions">
@@ -31,7 +39,8 @@
         target="_blank"
         rel="noopener noreferrer"
         class="read-more"
-        [attr.aria-label]="'Read full post: ' + item.title">
+        [attr.aria-label]="'Read full post: ' + item.title"
+        (click)="onReadMoreClick()">
         <span>Read on Reddit</span>
         <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
           <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"></path>
@@ -39,6 +48,10 @@
           <line x1="10" y1="14" x2="21" y2="3"></line>
         </svg>
       </a>
+      <button *ngIf="showSave" type="button" class="save" [attr.aria-pressed]="isSaved" (click)="toggleSave()">
+        <span *ngIf="!isSaved">Save for later</span>
+        <span *ngIf="isSaved">Saved</span>
+      </button>
     </footer>
   </div>
 </article>

--- a/src/app/components/news-item/news-item.component.scss
+++ b/src/app/components/news-item/news-item.component.scss
@@ -104,6 +104,27 @@
       }
     }
 
+    .recommendation-meta {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 12px;
+      margin-bottom: 12px;
+      font-size: 0.9em;
+      color: #2563eb;
+
+      .score {
+        font-weight: 600;
+      }
+
+      .strategy {
+        background: rgba(37, 99, 235, 0.1);
+        color: #1d4ed8;
+        padding: 4px 10px;
+        border-radius: 999px;
+        font-weight: 600;
+      }
+    }
+
     .content {
       position: relative;
       margin-bottom: 24px;
@@ -171,6 +192,29 @@
         &:active {
           transform: translateY(0);
           box-shadow: 0 2px 4px rgba(255, 69, 0, 0.2);
+        }
+      }
+
+      .save {
+        margin-left: 16px;
+        border: 1px solid #d1d5db;
+        background: #ffffff;
+        color: #111827;
+        padding: 10px 18px;
+        border-radius: 24px;
+        font-weight: 600;
+        cursor: pointer;
+        transition: all 0.3s ease;
+
+        &[aria-pressed='true'] {
+          background: rgba(16, 185, 129, 0.12);
+          border-color: rgba(5, 150, 105, 0.4);
+          color: #047857;
+        }
+
+        &:hover {
+          transform: translateY(-1px);
+          box-shadow: 0 8px 12px rgba(0, 0, 0, 0.08);
         }
       }
     }

--- a/src/app/components/news-item/news-item.component.ts
+++ b/src/app/components/news-item/news-item.component.ts
@@ -1,5 +1,7 @@
-import { Component, Input } from '@angular/core';
+import { Component, Input, OnDestroy } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { AnalyticsService } from '../../services/analytics.service';
+import { NewsItem } from '../../models/news.model';
 
 @Component({
   selector: 'app-news-item',
@@ -8,10 +10,16 @@ import { CommonModule } from '@angular/common';
   templateUrl: './news-item.component.html',
   styleUrl: './news-item.component.scss'
 })
-export class NewsItemComponent {
-  @Input() item: any;
+export class NewsItemComponent implements OnDestroy {
+  @Input() item!: NewsItem;
+  @Input() showSave = false;
+  @Input() analyticsContext?: string;
 
-  formatDate(date: string): string {
+  isSaved = false;
+
+  constructor(private analytics: AnalyticsService) {}
+
+  formatDate(date: Date | string): string {
     return new Date(date).toLocaleDateString('en-US', {
       year: 'numeric',
       month: 'long',
@@ -19,5 +27,37 @@ export class NewsItemComponent {
       hour: '2-digit',
       minute: '2-digit'
     });
+  }
+
+  onReadMoreClick(): void {
+    this.analytics.trackClick(this.item, this.analyticsMetadata());
+  }
+
+  toggleSave(): void {
+    this.isSaved = !this.isSaved;
+    this.analytics.trackSave(this.item, this.isSaved, this.analyticsMetadata());
+  }
+
+  onMouseEnter(): void {
+    this.analytics.startDwell(this.item);
+  }
+
+  onMouseLeave(): void {
+    this.analytics.endDwell(this.item, this.analyticsMetadata());
+  }
+
+  ngOnDestroy(): void {
+    if (this.item) {
+      this.analytics.endDwell(this.item, this.analyticsMetadata());
+    }
+  }
+
+  private analyticsMetadata(): Record<string, unknown> {
+    return {
+      context: this.analyticsContext,
+      strategy: this.item.metrics?.strategy,
+      cohort: this.item.metrics?.cohortLabel,
+      recommendationScore: this.item.metrics?.recommendationScore
+    };
   }
 }

--- a/src/app/components/recommended-feed/recommended-feed.component.html
+++ b/src/app/components/recommended-feed/recommended-feed.component.html
@@ -1,0 +1,39 @@
+<section class="recommended-feed" aria-labelledby="recommended-heading">
+  <header class="recommended-feed__header">
+    <div>
+      <h2 id="recommended-heading">Recommended for you</h2>
+      <p class="recommended-feed__subtitle" *ngIf="strategy() === 'personalized'">
+        Tailored using your recent reading activity.
+      </p>
+      <p class="recommended-feed__subtitle" *ngIf="strategy() === 'fallback' && cohort() as activeCohort">
+        Showing <strong>{{ activeCohort.label }}</strong> — {{ activeCohort.description }}
+      </p>
+      <p class="recommended-feed__subtitle" *ngIf="strategy() === 'fallback' && !cohort()">
+        Highlights we think you will enjoy even without a reading history.
+      </p>
+    </div>
+    <button type="button" class="recommended-feed__refresh" (click)="refresh()" [disabled]="loading()">
+      Refresh
+    </button>
+  </header>
+
+  <p class="recommended-feed__status" *ngIf="loading()">Loading recommendations…</p>
+  <p class="recommended-feed__status recommended-feed__status--error" *ngIf="errorMessage() as error">
+    {{ error }}
+  </p>
+
+  <ng-container *ngIf="!loading() && !errorMessage()">
+    <p class="recommended-feed__status" *ngIf="!items().length">
+      We need a little more reading history before we can personalize your feed. Check back after exploring a few stories.
+    </p>
+
+    <div class="recommended-feed__items" *ngIf="items().length">
+      <app-news-item
+        *ngFor="let item of items()"
+        [item]="item"
+        [showSave]="true"
+        [analyticsContext]="strategy() === 'personalized' ? 'personalized-recommendation' : 'fallback-recommendation'"
+      ></app-news-item>
+    </div>
+  </ng-container>
+</section>

--- a/src/app/components/recommended-feed/recommended-feed.component.scss
+++ b/src/app/components/recommended-feed/recommended-feed.component.scss
@@ -1,0 +1,74 @@
+.recommended-feed {
+  background: #ffffff;
+  border-radius: 16px;
+  padding: 24px;
+  box-shadow: 0 12px 28px rgba(0, 0, 0, 0.08);
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.recommended-feed__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 16px;
+}
+
+.recommended-feed__header h2 {
+  margin: 0;
+  font-size: 1.5rem;
+}
+
+.recommended-feed__subtitle {
+  margin: 4px 0 0;
+  color: #5f6368;
+  font-size: 0.95rem;
+}
+
+.recommended-feed__refresh {
+  border: none;
+  background: #1a73e8;
+  color: white;
+  padding: 10px 16px;
+  border-radius: 8px;
+  cursor: pointer;
+  font-weight: 600;
+  transition: background 0.2s ease;
+}
+
+.recommended-feed__refresh:disabled {
+  background: #9cb8ec;
+  cursor: not-allowed;
+}
+
+.recommended-feed__refresh:not(:disabled):hover,
+.recommended-feed__refresh:not(:disabled):focus {
+  background: #0f5ad6;
+}
+
+.recommended-feed__status {
+  margin: 0;
+  color: #5f6368;
+  font-size: 0.95rem;
+}
+
+.recommended-feed__status--error {
+  color: #d93025;
+}
+
+.recommended-feed__items {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 16px;
+}
+
+@media (max-width: 768px) {
+  .recommended-feed {
+    padding: 16px;
+  }
+
+  .recommended-feed__items {
+    grid-template-columns: 1fr;
+  }
+}

--- a/src/app/components/recommended-feed/recommended-feed.component.ts
+++ b/src/app/components/recommended-feed/recommended-feed.component.ts
@@ -1,0 +1,72 @@
+import { Component, OnDestroy, OnInit, computed, signal } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { Subject } from 'rxjs';
+import { debounceTime, distinctUntilChanged, skip, takeUntil } from 'rxjs/operators';
+import { RecommendationService } from '../../services/recommendation.service';
+import { AnalyticsService } from '../../services/analytics.service';
+import { UserIdentityService } from '../../services/user-identity.service';
+import { NewsItem } from '../../models/news.model';
+import { RecommendationFeed } from '../../models/recommendation.model';
+import { NewsItemComponent } from '../news-item/news-item.component';
+
+@Component({
+  selector: 'app-recommended-feed',
+  standalone: true,
+  imports: [CommonModule, NewsItemComponent],
+  templateUrl: './recommended-feed.component.html',
+  styleUrls: ['./recommended-feed.component.scss']
+})
+export class RecommendedFeedComponent implements OnInit, OnDestroy {
+  protected feed = signal<RecommendationFeed | null>(null);
+  protected loading = signal<boolean>(true);
+  protected errorMessage = signal<string | null>(null);
+
+  protected readonly items = computed<NewsItem[]>(() => this.feed()?.items ?? []);
+  protected readonly strategy = computed(() => this.feed()?.strategy ?? 'fallback');
+  protected readonly cohort = computed(() => this.feed()?.cohort);
+
+  private destroy$ = new Subject<void>();
+
+  constructor(
+    private recommendationService: RecommendationService,
+    private analyticsService: AnalyticsService,
+    private userIdentityService: UserIdentityService
+  ) {}
+
+  ngOnInit(): void {
+    this.recommendationService.recommendations$().pipe(
+      takeUntil(this.destroy$)
+    ).subscribe({
+      next: feed => {
+        this.feed.set(feed);
+        this.loading.set(false);
+        this.errorMessage.set(null);
+      },
+      error: () => {
+        this.loading.set(false);
+        this.errorMessage.set('Unable to load recommendations right now.');
+      }
+    });
+
+    this.analyticsService.events$.pipe(
+      takeUntil(this.destroy$),
+      debounceTime(1500)
+    ).subscribe(() => this.refresh());
+
+    this.userIdentityService.userId$.pipe(
+      takeUntil(this.destroy$),
+      distinctUntilChanged(),
+      skip(1)
+    ).subscribe(() => this.refresh());
+  }
+
+  ngOnDestroy(): void {
+    this.destroy$.next();
+    this.destroy$.complete();
+  }
+
+  refresh(): void {
+    this.loading.set(true);
+    this.recommendationService.refresh();
+  }
+}

--- a/src/app/models/news.model.ts
+++ b/src/app/models/news.model.ts
@@ -7,6 +7,21 @@ export interface NewsItem {
   source: string;
   category?: string;
   imageUrl?: string;
+  summary?: string;
+  metrics?: NewsMetrics;
+}
+
+export interface RecommendationBreakdown {
+  contentScore?: number;
+  collaborativeScore?: number;
+  popularityBoost?: number;
+}
+
+export interface NewsMetrics {
+  recommendationScore?: number;
+  breakdown?: RecommendationBreakdown;
+  strategy?: 'personalized' | 'fallback';
+  cohortLabel?: string;
 }
 
 export interface NewsState {

--- a/src/app/models/recommendation.model.ts
+++ b/src/app/models/recommendation.model.ts
@@ -1,0 +1,40 @@
+import { NewsItem } from './news.model';
+
+export interface RecommendationCohort {
+  id: string;
+  label: string;
+  description: string;
+}
+
+export interface RecommendationApiItem {
+  id: string;
+  title: string;
+  summary: string;
+  url: string;
+  source: string;
+  category?: string;
+  imageUrl?: string;
+  publishedAt: string;
+  recommendationScore?: number;
+  breakdown?: {
+    contentScore?: number;
+    collaborativeScore?: number;
+    popularityBoost?: number;
+  };
+}
+
+export interface RecommendationApiResponse {
+  requestedAt: string;
+  userId: string | null;
+  strategy: 'personalized' | 'fallback';
+  cohort?: RecommendationCohort;
+  items: RecommendationApiItem[];
+}
+
+export interface RecommendationFeed {
+  requestedAt: string;
+  userId: string | null;
+  strategy: 'personalized' | 'fallback';
+  cohort?: RecommendationCohort;
+  items: NewsItem[];
+}

--- a/src/app/services/analytics.service.ts
+++ b/src/app/services/analytics.service.ts
@@ -1,0 +1,82 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { of, Subject } from 'rxjs';
+import { catchError, tap } from 'rxjs/operators';
+import { NewsItem } from '../models/news.model';
+import { UserIdentityService } from './user-identity.service';
+
+interface AnalyticsPayload {
+  type: 'click' | 'save' | 'dwell';
+  itemId: string;
+  dwellTimeMs?: number;
+  metadata?: Record<string, unknown>;
+}
+
+@Injectable({
+  providedIn: 'root'
+})
+export class AnalyticsService {
+  private dwellTimers = new Map<string, number>();
+  private eventsSubject = new Subject<AnalyticsPayload>();
+
+  readonly events$ = this.eventsSubject.asObservable();
+
+  constructor(
+    private http: HttpClient,
+    private userIdentity: UserIdentityService
+  ) {}
+
+  trackClick(item: NewsItem, metadata: Record<string, unknown> = {}): void {
+    this.dispatch({ type: 'click', itemId: item.id, metadata }, item);
+  }
+
+  trackSave(item: NewsItem, saved: boolean, metadata: Record<string, unknown> = {}): void {
+    this.dispatch({ type: 'save', itemId: item.id, metadata: { ...metadata, saved } }, item);
+  }
+
+  startDwell(item: NewsItem): void {
+    this.dwellTimers.set(item.id, this.now());
+  }
+
+  endDwell(item: NewsItem, metadata: Record<string, unknown> = {}): void {
+    const start = this.dwellTimers.get(item.id);
+    if (!start) {
+      return;
+    }
+    this.dwellTimers.delete(item.id);
+    const dwellTimeMs = Math.round(this.now() - start);
+    if (dwellTimeMs < 250) {
+      return;
+    }
+    this.dispatch({ type: 'dwell', itemId: item.id, dwellTimeMs, metadata }, item);
+  }
+
+  private dispatch(payload: AnalyticsPayload, item: NewsItem): void {
+    const userId = this.userIdentity.ensureUserId();
+    const body = {
+      ...payload,
+      userId,
+      metadata: {
+        title: item.title,
+        source: item.source,
+        category: item.category,
+        ...payload.metadata
+      }
+    };
+
+    this.http.post<unknown>('/api/analytics/events', body).pipe(
+      tap(() => this.eventsSubject.next(payload)),
+      catchError(() => {
+        // Intentionally swallow analytics errors so they never interrupt UX
+        return of(null);
+      })
+    ).subscribe();
+  }
+
+  private now(): number {
+    if (typeof performance !== 'undefined' && performance.now) {
+      return performance.now();
+    }
+    return Date.now();
+  }
+}

--- a/src/app/services/recommendation.service.ts
+++ b/src/app/services/recommendation.service.ts
@@ -1,0 +1,71 @@
+import { Injectable } from '@angular/core';
+import { HttpClient, HttpParams } from '@angular/common/http';
+import { Observable, Subject } from 'rxjs';
+import { map, shareReplay, switchMap, startWith } from 'rxjs/operators';
+import { NewsItem } from '../models/news.model';
+import { RecommendationFeed, RecommendationApiResponse } from '../models/recommendation.model';
+import { UserIdentityService } from './user-identity.service';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class RecommendationService {
+  private refreshTrigger$ = new Subject<void>();
+
+  constructor(
+    private http: HttpClient,
+    private userIdentity: UserIdentityService
+  ) {}
+
+  recommendations$(limit = 6): Observable<RecommendationFeed> {
+    return this.refreshTrigger$.pipe(
+      startWith(void 0),
+      switchMap(() => this.fetchRecommendations(limit)),
+      shareReplay(1)
+    );
+  }
+
+  refresh(): void {
+    this.refreshTrigger$.next();
+  }
+
+  private fetchRecommendations(limit: number): Observable<RecommendationFeed> {
+    const userId = this.userIdentity.getUserId();
+    let params = new HttpParams().set('limit', limit);
+    if (userId) {
+      params = params.set('userId', userId);
+    }
+
+    return this.http.get<RecommendationApiResponse>('/api/news/recommended', { params }).pipe(
+      map(response => this.mapResponse(response))
+    );
+  }
+
+  private mapResponse(response: RecommendationApiResponse): RecommendationFeed {
+    const items: NewsItem[] = response.items.map(item => ({
+      id: item.id,
+      title: item.title,
+      link: item.url,
+      pubDate: new Date(item.publishedAt),
+      content: item.summary,
+      source: item.source,
+      category: item.category,
+      imageUrl: item.imageUrl,
+      summary: item.summary,
+      metrics: {
+        recommendationScore: item.recommendationScore,
+        breakdown: item.breakdown,
+        strategy: response.strategy,
+        cohortLabel: response.cohort?.label
+      }
+    }));
+
+    return {
+      requestedAt: response.requestedAt,
+      userId: response.userId,
+      strategy: response.strategy,
+      cohort: response.cohort,
+      items
+    };
+  }
+}

--- a/src/app/services/user-identity.service.ts
+++ b/src/app/services/user-identity.service.ts
@@ -1,0 +1,56 @@
+import { Injectable } from '@angular/core';
+import { BehaviorSubject } from 'rxjs';
+
+const STORAGE_KEY = 'tracker-user-id';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class UserIdentityService {
+  private userIdSubject = new BehaviorSubject<string | null>(this.loadUserId());
+  readonly userId$ = this.userIdSubject.asObservable();
+
+  getUserId(): string | null {
+    return this.userIdSubject.getValue();
+  }
+
+  ensureUserId(): string {
+    const existing = this.getUserId();
+    if (existing) {
+      return existing;
+    }
+
+    const newId = this.generateId();
+    this.persist(newId);
+    this.userIdSubject.next(newId);
+    return newId;
+  }
+
+  clearUserId(): void {
+    localStorage.removeItem(STORAGE_KEY);
+    this.userIdSubject.next(null);
+  }
+
+  private loadUserId(): string | null {
+    try {
+      return localStorage.getItem(STORAGE_KEY);
+    } catch {
+      return null;
+    }
+  }
+
+  private persist(id: string): void {
+    try {
+      localStorage.setItem(STORAGE_KEY, id);
+    } catch {
+      // Swallow persistence errors silently to avoid breaking UX in private mode
+    }
+  }
+
+  private generateId(): string {
+    if (typeof crypto !== 'undefined' && 'randomUUID' in crypto) {
+      return crypto.randomUUID();
+    }
+    return 'user-' + Math.random().toString(36).slice(2, 11);
+  }
+}


### PR DESCRIPTION
## Summary
- add an Express-based analytics and recommendation service with content-based and collaborative scoring plus cohort fallbacks
- capture client-side interaction telemetry and surface a dedicated recommended news panel that refreshes as signals arrive
- update layout and shared item component to expose personalization context, saving, and analytics metadata

## Testing
- npm test -- --watch=false

------
https://chatgpt.com/codex/tasks/task_e_68ea80f4cd48832688979562e2758db2