### PR TITLE
Add multi-source news aggregation pipeline

### DIFF
--- a/src/app/config/news-source.config.ts
+++ b/src/app/config/news-source.config.ts
@@ -1,0 +1,114 @@
+import type { HttpHeaders, HttpParams } from '@angular/common/http';
+
+export interface ProxyEndpointConfig {
+  url: string;
+  headers?: HttpHeaders;
+  params?: HttpParams | Record<string, string | number | boolean>;
+}
+
+export interface NewsSourceProxyConfig {
+  newsApi: ProxyEndpointConfig;
+  nyTimes: ProxyEndpointConfig;
+  fecFilings: ProxyEndpointConfig;
+  campaignRss: ProxyEndpointConfig;
+  twitter: ProxyEndpointConfig;
+}
+
+export interface NewsAggregationConfig {
+  proxies: NewsSourceProxyConfig;
+  cacheTtlMs: number;
+  relevance: {
+    recencyHalfLifeHours: number;
+    keywordBoost: Record<string, number>;
+  };
+  defaultQuery: string;
+}
+
+const defaultConfig: NewsAggregationConfig = {
+  proxies: {
+    newsApi: {
+      url: '/api/news/newsapi',
+      params: {
+        language: 'en',
+        pageSize: 50
+      }
+    },
+    nyTimes: {
+      url: '/api/news/nytimes',
+      params: {
+        sort: 'newest'
+      }
+    },
+    fecFilings: {
+      url: '/api/news/fec',
+      params: {
+        per_page: 50
+      }
+    },
+    campaignRss: {
+      url: '/api/news/rss'
+    },
+    twitter: {
+      url: '/api/news/twitter',
+      params: {
+        limit: 50
+      }
+    }
+  },
+  cacheTtlMs: 10 * 60 * 1000,
+  relevance: {
+    recencyHalfLifeHours: 6,
+    keywordBoost: {
+      election: 2,
+      fundraising: 1.5,
+      polling: 1.25,
+      rally: 1.15
+    }
+  },
+  defaultQuery: 'trump 2024 campaign'
+};
+
+function readRuntimeConfig(): Partial<NewsAggregationConfig> | undefined {
+  if (typeof globalThis === 'undefined') {
+    return undefined;
+  }
+  const runtimeConfig = (globalThis as any).__NEWS_AGGREGATION_CONFIG__;
+  if (!runtimeConfig || typeof runtimeConfig !== 'object') {
+    return undefined;
+  }
+  return runtimeConfig as Partial<NewsAggregationConfig>;
+}
+
+function mergeProxyConfig(defaultProxy: ProxyEndpointConfig, override?: Partial<ProxyEndpointConfig>): ProxyEndpointConfig {
+  if (!override) {
+    return defaultProxy;
+  }
+  const params = override.params
+    ? { ...((defaultProxy.params as Record<string, any>) ?? {}), ...(override.params as Record<string, any>) }
+    : defaultProxy.params;
+
+  return {
+    ...defaultProxy,
+    ...override,
+    params
+  };
+}
+
+export const newsAggregationConfig: NewsAggregationConfig = (() => {
+  const runtimeConfig = readRuntimeConfig();
+  if (!runtimeConfig) {
+    return defaultConfig;
+  }
+
+  return {
+    ...defaultConfig,
+    ...runtimeConfig,
+    proxies: {
+      newsApi: mergeProxyConfig(defaultConfig.proxies.newsApi, runtimeConfig.proxies?.newsApi),
+      nyTimes: mergeProxyConfig(defaultConfig.proxies.nyTimes, runtimeConfig.proxies?.nyTimes),
+      fecFilings: mergeProxyConfig(defaultConfig.proxies.fecFilings, runtimeConfig.proxies?.fecFilings),
+      campaignRss: mergeProxyConfig(defaultConfig.proxies.campaignRss, runtimeConfig.proxies?.campaignRss),
+      twitter: mergeProxyConfig(defaultConfig.proxies.twitter, runtimeConfig.proxies?.twitter)
+    }
+  };
+})();

--- a/src/app/models/news.model.ts
+++ b/src/app/models/news.model.ts
@@ -7,6 +7,9 @@ export interface NewsItem {
   source: string;
   category?: string;
   imageUrl?: string;
+  topics?: string[];
+  relevanceScore?: number;
+  rawSource?: string;
 }
 
 export interface NewsState {

--- a/src/app/services/aggregation/news-aggregation.service.ts
+++ b/src/app/services/aggregation/news-aggregation.service.ts
@@ -1,0 +1,297 @@
+import { Injectable } from '@angular/core';
+import { HttpClient, HttpHeaders, HttpParams } from '@angular/common/http';
+import { Observable, concat, defer, from, merge, of } from 'rxjs';
+import { catchError, filter, map, mergeMap, tap } from 'rxjs/operators';
+
+import { NewsItem } from '../../models/news.model';
+import { LoadingState } from '../../models/loading-state.model';
+import { newsAggregationConfig, ProxyEndpointConfig } from '../../config/news-source.config';
+import { NewsCacheService } from '../news-cache.service';
+import { TelemetryService } from '../telemetry.service';
+
+interface SourceResult {
+  source: string;
+  items: NewsItem[];
+}
+
+@Injectable({
+  providedIn: 'root'
+})
+export class NewsAggregationService {
+  private readonly config = newsAggregationConfig;
+
+  constructor(
+    private readonly http: HttpClient,
+    private readonly cacheService: NewsCacheService,
+    private readonly telemetry: TelemetryService
+  ) {}
+
+  aggregate(): Observable<LoadingState<NewsItem[]>> {
+    return defer(() => {
+      this.telemetry.logEvent('news.ingestion.started', {
+        cacheTtlMs: this.config.cacheTtlMs
+      });
+
+      const cached$ = from(this.cacheService.getCachedNews()).pipe(
+        map((cached) => {
+          if (!cached) {
+            return null;
+          }
+          this.telemetry.logEvent('news.ingestion.cache_hit', {
+            itemCount: cached.length
+          });
+          return { state: 'loaded', data: cached } as LoadingState<NewsItem[]>;
+        }),
+        catchError((error) => {
+          this.telemetry.logError(error, { stage: 'cache-read' });
+          return of(null);
+        })
+      );
+
+      const network$ = this.fetchAndNormalize().pipe(
+        tap((items) => {
+          this.cacheService.setCachedNews(items).catch((error) =>
+            this.telemetry.logError(error, { stage: 'cache-write' })
+          );
+        }),
+        map((items) => ({ state: 'loaded', data: items } as LoadingState<NewsItem[]>)),
+        catchError((error) => {
+          const normalizedError = error instanceof Error ? error : new Error('Failed to aggregate news');
+          this.telemetry.logError(normalizedError, { stage: 'network' });
+          return of({ state: 'error', error: normalizedError } as LoadingState<NewsItem[]>);
+        })
+      );
+
+      return concat(
+        of({ state: 'loading' } as LoadingState<NewsItem[]>),
+        cached$.pipe(filter((value): value is LoadingState<NewsItem[]> => value !== null)),
+        network$
+      );
+    });
+  }
+
+  private fetchAndNormalize(): Observable<NewsItem[]> {
+    const requests = [
+      this.fetchNewsApi(),
+      this.fetchNyTimes(),
+      this.fetchFecFilings(),
+      this.fetchCampaignRss(),
+      this.fetchTwitter()
+    ];
+
+    return merge(...requests).pipe(
+      map((result) => result.items),
+      map((items) => this.enrich(items)),
+      mergeMap((items) => of(...items)),
+      // Deduplicate by canonical URL/hash
+      this.cacheService.dedupeByUrl(),
+      map((item) => ({ ...item, relevanceScore: this.scoreItem(item) })),
+      this.telemetry.collectMetrics(),
+      // Recombine into array sorted by relevance and recency
+      this.cacheService.recombineSorted()
+    );
+  }
+
+  private fetchNewsApi(): Observable<SourceResult> {
+    return this.fetchFromProxy('NewsAPI', this.config.proxies.newsApi).pipe(
+      map((response: any) => {
+        const articles = Array.isArray(response?.articles) ? response.articles : [];
+        const items = articles.map((article: any): NewsItem => ({
+          id: article.url,
+          title: article.title,
+          link: article.url,
+          pubDate: article.publishedAt ? new Date(article.publishedAt) : new Date(),
+          content: article.description || article.content || '',
+          source: article.source?.name || 'NewsAPI',
+          category: article.category,
+          imageUrl: article.urlToImage,
+          topics: this.extractTopics(article.title, article.description),
+          rawSource: 'newsapi'
+        }));
+        return { source: 'newsapi', items };
+      })
+    );
+  }
+
+  private fetchNyTimes(): Observable<SourceResult> {
+    return this.fetchFromProxy('New York Times', this.config.proxies.nyTimes).pipe(
+      map((response: any) => {
+        const docs = Array.isArray(response?.response?.docs) ? response.response.docs : [];
+        const items = docs.map((doc: any): NewsItem => ({
+          id: doc._id,
+          title: doc.headline?.main ?? 'Untitled',
+          link: doc.web_url,
+          pubDate: doc.pub_date ? new Date(doc.pub_date) : new Date(),
+          content: doc.abstract || doc.lead_paragraph || '',
+          source: 'The New York Times',
+          category: doc.section_name,
+          imageUrl: doc.multimedia?.[0]?.url,
+          topics: this.extractTopics(doc.headline?.main, doc.abstract),
+          rawSource: 'nytimes'
+        }));
+        return { source: 'nytimes', items };
+      })
+    );
+  }
+
+  private fetchFecFilings(): Observable<SourceResult> {
+    return this.fetchFromProxy('Federal Election Commission', this.config.proxies.fecFilings).pipe(
+      map((response: any) => {
+        const results = Array.isArray(response?.results) ? response.results : [];
+        const items = results.map((filing: any, index: number): NewsItem => ({
+          id: filing.filing_id?.toString() ?? `fec-${index}`,
+          title: `${filing.committee_name ?? 'Committee'} filed ${filing.document_type_full ?? 'a report'}`,
+          link: filing.document_url || filing.filing_url || '#',
+          pubDate: filing.receipt_date ? new Date(filing.receipt_date) : new Date(),
+          content: filing.amended ? 'Amended filing' : 'New filing',
+          source: 'Federal Election Commission',
+          category: 'Compliance',
+          topics: this.extractTopics(filing.document_type_full, filing.committee_name),
+          rawSource: 'fec'
+        }));
+        return { source: 'fec', items };
+      })
+    );
+  }
+
+  private fetchCampaignRss(): Observable<SourceResult> {
+    return this.fetchFromProxy('Campaign RSS', this.config.proxies.campaignRss).pipe(
+      map((response: any) => {
+        const feedItems = Array.isArray(response?.items) ? response.items : [];
+        const items = feedItems.map((item: any, index: number): NewsItem => ({
+          id: item.guid || item.id || `rss-${index}`,
+          title: item.title ?? 'Campaign update',
+          link: item.link || item.url,
+          pubDate: item.pubDate ? new Date(item.pubDate) : new Date(),
+          content: item.contentSnippet || item.content || '',
+          source: item.source || 'Campaign RSS',
+          category: item.categories?.[0],
+          imageUrl: item.enclosure?.url,
+          topics: this.extractTopics(item.title, item.contentSnippet),
+          rawSource: 'campaign-rss'
+        }));
+        return { source: 'campaign-rss', items };
+      })
+    );
+  }
+
+  private fetchTwitter(): Observable<SourceResult> {
+    return this.fetchFromProxy('Twitter', this.config.proxies.twitter).pipe(
+      map((response: any) => {
+        const tweets = Array.isArray(response?.data) ? response.data : [];
+        const items = tweets.map((tweet: any): NewsItem => ({
+          id: tweet.id,
+          title: tweet.text?.slice(0, 120) ?? 'Campaign tweet',
+          link: tweet.url || `https://twitter.com/i/web/status/${tweet.id}`,
+          pubDate: tweet.created_at ? new Date(tweet.created_at) : new Date(),
+          content: tweet.text ?? '',
+          source: tweet.author_id ?? 'Campaign Twitter',
+          category: 'Social',
+          topics: this.extractTopics(tweet.text),
+          rawSource: 'twitter'
+        }));
+        return { source: 'twitter', items };
+      })
+    );
+  }
+
+  private fetchFromProxy(sourceLabel: string, config: ProxyEndpointConfig): Observable<any> {
+    const headers = config.headers instanceof HttpHeaders ? config.headers : new HttpHeaders(config.headers ?? {});
+    let params: HttpParams | undefined;
+    if (config.params instanceof HttpParams) {
+      params = config.params;
+    } else if (config.params) {
+      params = new HttpParams({ fromObject: this.convertParams(config.params) });
+    }
+
+    let queryParams = params ?? new HttpParams();
+    if (!queryParams.has('q')) {
+      queryParams = queryParams.set('q', this.config.defaultQuery);
+    }
+
+    const request$ = this.http.get(config.url, {
+      headers: headers.set('x-cache-ttl', String(this.config.cacheTtlMs)),
+      params: queryParams
+    });
+
+    return request$.pipe(
+      tap((response) =>
+        this.telemetry.logEvent('news.ingestion.source_success', {
+          source: sourceLabel,
+          items: Array.isArray((response as any)?.items)
+            ? (response as any).items.length
+            : Array.isArray((response as any)?.articles)
+            ? (response as any).articles.length
+            : Array.isArray((response as any)?.data)
+            ? (response as any).data.length
+            : Array.isArray((response as any)?.results)
+            ? (response as any).results.length
+            : 0
+        })
+      ),
+      catchError((error) => {
+        const normalizedError = error instanceof Error ? error : new Error(`Failed to load ${sourceLabel}`);
+        this.telemetry.logError(normalizedError, { source: sourceLabel });
+        return of({});
+      })
+    );
+  }
+
+  private convertParams(params: Record<string, string | number | boolean>): Record<string, string> {
+    return Object.entries(params).reduce<Record<string, string>>((acc, [key, value]) => {
+      acc[key] = String(value);
+      return acc;
+    }, {});
+  }
+
+  private enrich(items: NewsItem[]): NewsItem[] {
+    return items.map((item) => ({
+      ...item,
+      topics: Array.from(new Set([...(item.topics ?? []), ...this.extractTopics(item.title, item.content)])),
+      category: item.category ?? this.deriveCategory(item)
+    }));
+  }
+
+  private deriveCategory(item: NewsItem): string {
+    const content = `${item.title} ${item.content}`.toLowerCase();
+    if (/(poll|survey|approval)/.test(content)) {
+      return 'Polling';
+    }
+    if (/(rally|event|appearance|speech)/.test(content)) {
+      return 'Events';
+    }
+    if (/(fundraising|donation|finance|fec)/.test(content)) {
+      return 'Fundraising';
+    }
+    if (/(endorsement|coalition|surrogate)/.test(content)) {
+      return 'Endorsements';
+    }
+    return 'General';
+  }
+
+  private extractTopics(...inputs: Array<string | undefined>): string[] {
+    const keywords = new Set<string>();
+    const tokens = inputs
+      .filter((value): value is string => typeof value === 'string')
+      .flatMap((value) => value.split(/[^a-zA-Z0-9]+/))
+      .map((token) => token.trim())
+      .filter((token) => token.length > 3);
+
+    tokens.forEach((token) => keywords.add(token.toLowerCase()));
+
+    return Array.from(keywords).slice(0, 8);
+  }
+
+  private scoreItem(item: NewsItem): number {
+    const now = Date.now();
+    const ageHours = Math.max(1, (now - new Date(item.pubDate).getTime()) / (1000 * 60 * 60));
+    const recencyScore = Math.pow(0.5, ageHours / this.config.relevance.recencyHalfLifeHours);
+
+    const topics = (item.topics ?? []).join(' ');
+    const keywordScore = Object.entries(this.config.relevance.keywordBoost).reduce((acc, [keyword, weight]) => {
+      return acc + (topics.includes(keyword) ? weight : 0);
+    }, 0);
+
+    return Number((recencyScore * (1 + keywordScore)).toFixed(3));
+  }
+}

--- a/src/app/services/news-cache.service.ts
+++ b/src/app/services/news-cache.service.ts
@@ -1,0 +1,234 @@
+import { Injectable } from '@angular/core';
+import { MonoTypeOperatorFunction, Observable, OperatorFunction, reduce } from 'rxjs';
+import { map } from 'rxjs/operators';
+
+import { NewsItem } from '../models/news.model';
+import { newsAggregationConfig } from '../config/news-source.config';
+
+interface CachedEntry {
+  timestamp: number;
+  items: CachedNewsItem[];
+}
+
+interface CachedNewsItem extends Omit<NewsItem, 'pubDate'> {
+  pubDate: string;
+}
+
+@Injectable({
+  providedIn: 'root'
+})
+export class NewsCacheService {
+  private readonly DB_NAME = 'news-aggregation-cache';
+  private readonly STORE_NAME = 'news-items';
+  private readonly CACHE_KEY = 'aggregated';
+  private readonly TTL = newsAggregationConfig.cacheTtlMs;
+  private dbPromise: Promise<IDBDatabase> | null = null;
+
+  async getCachedNews(): Promise<NewsItem[] | null> {
+    try {
+      const entry = await this.readFromIndexedDb();
+      if (!entry) {
+        return this.readFromLocalStorage();
+      }
+      if (Date.now() - entry.timestamp > this.TTL) {
+        await this.clearInternal();
+        return null;
+      }
+      return entry.items.map((item) => ({
+        ...item,
+        pubDate: new Date(item.pubDate)
+      }));
+    } catch {
+      return this.readFromLocalStorage();
+    }
+  }
+
+  async setCachedNews(items: NewsItem[]): Promise<void> {
+    const entry: CachedEntry = {
+      timestamp: Date.now(),
+      items: items.map((item) => ({
+        ...item,
+        pubDate: item.pubDate.toISOString()
+      }))
+    };
+
+    try {
+      await this.writeToIndexedDb(entry);
+    } catch {
+      this.writeToLocalStorage(entry);
+    }
+  }
+
+  dedupeByUrl(): MonoTypeOperatorFunction<NewsItem> {
+    const seen = new Map<string, string>();
+    return (source$) => source$.pipe(
+      filterUnique((item) => {
+        const urlKey = this.normalizeUrl(item.link);
+        const existingHash = seen.get(urlKey);
+        const hash = this.hashItem(item);
+        if (existingHash && existingHash === hash) {
+          return false;
+        }
+        seen.set(urlKey, hash);
+        return true;
+      })
+    );
+  }
+
+  recombineSorted(): OperatorFunction<NewsItem, NewsItem[]> {
+    return (source$) =>
+      source$.pipe(
+        reduce((acc, item) => {
+          acc.push(item);
+          return acc;
+        }, [] as NewsItem[]),
+        map((items) =>
+          items.sort((a, b) => (b.relevanceScore ?? 0) - (a.relevanceScore ?? 0) ||
+            new Date(b.pubDate).getTime() - new Date(a.pubDate).getTime())
+        )
+      );
+  }
+
+  private normalizeUrl(url: string): string {
+    try {
+      const normalized = new URL(url);
+      normalized.hash = '';
+      normalized.searchParams.sort();
+      return normalized.toString();
+    } catch {
+      return url;
+    }
+  }
+
+  private hashItem(item: NewsItem): string {
+    const data = `${item.title}|${item.link}|${item.pubDate.toISOString()}`;
+    let hash = 0;
+    for (let i = 0; i < data.length; i++) {
+      hash = (hash << 5) - hash + data.charCodeAt(i);
+      hash |= 0;
+    }
+    return hash.toString();
+  }
+
+  private async readFromIndexedDb(): Promise<CachedEntry | null> {
+    if (!this.supportsIndexedDb()) {
+      return null;
+    }
+    const db = await this.getDb();
+    return new Promise((resolve, reject) => {
+      const transaction = db.transaction(this.STORE_NAME, 'readonly');
+      const store = transaction.objectStore(this.STORE_NAME);
+      const request = store.get(this.CACHE_KEY);
+      request.onsuccess = () => resolve((request.result as CachedEntry) ?? null);
+      request.onerror = () => reject(request.error);
+    });
+  }
+
+  private async writeToIndexedDb(entry: CachedEntry): Promise<void> {
+    if (!this.supportsIndexedDb()) {
+      throw new Error('IndexedDB unavailable');
+    }
+    const db = await this.getDb();
+    await new Promise<void>((resolve, reject) => {
+      const transaction = db.transaction(this.STORE_NAME, 'readwrite');
+      const store = transaction.objectStore(this.STORE_NAME);
+      const request = store.put(entry, this.CACHE_KEY);
+      request.onsuccess = () => resolve();
+      request.onerror = () => reject(request.error);
+    });
+  }
+
+  private readFromLocalStorage(): NewsItem[] | null {
+    if (typeof localStorage === 'undefined') {
+      return null;
+    }
+    const raw = localStorage.getItem(this.localStorageKey());
+    if (!raw) {
+      return null;
+    }
+    try {
+      const entry = JSON.parse(raw) as CachedEntry;
+      if (Date.now() - entry.timestamp > this.TTL) {
+        localStorage.removeItem(this.localStorageKey());
+        return null;
+      }
+      return entry.items.map((item) => ({
+        ...item,
+        pubDate: new Date(item.pubDate)
+      }));
+    } catch {
+      localStorage.removeItem(this.localStorageKey());
+      return null;
+    }
+  }
+
+  private writeToLocalStorage(entry: CachedEntry): void {
+    if (typeof localStorage === 'undefined') {
+      return;
+    }
+    localStorage.setItem(this.localStorageKey(), JSON.stringify(entry));
+  }
+
+  async clearCache(): Promise<void> {
+    await this.clearInternal();
+  }
+
+  private async clearInternal(): Promise<void> {
+    if (this.supportsIndexedDb()) {
+      const db = await this.getDb();
+      await new Promise<void>((resolve, reject) => {
+        const transaction = db.transaction(this.STORE_NAME, 'readwrite');
+        const store = transaction.objectStore(this.STORE_NAME);
+        const request = store.delete(this.CACHE_KEY);
+        request.onsuccess = () => resolve();
+        request.onerror = () => reject(request.error);
+      });
+    }
+    if (typeof localStorage !== 'undefined') {
+      localStorage.removeItem(this.localStorageKey());
+    }
+  }
+
+  private supportsIndexedDb(): boolean {
+    return typeof indexedDB !== 'undefined';
+  }
+
+  private getDb(): Promise<IDBDatabase> {
+    if (!this.dbPromise) {
+      this.dbPromise = new Promise((resolve, reject) => {
+        const request = indexedDB.open(this.DB_NAME, 1);
+        request.onupgradeneeded = () => {
+          const db = request.result;
+          if (!db.objectStoreNames.contains(this.STORE_NAME)) {
+            db.createObjectStore(this.STORE_NAME);
+          }
+        };
+        request.onsuccess = () => resolve(request.result);
+        request.onerror = () => reject(request.error);
+      });
+    }
+    return this.dbPromise;
+  }
+
+  private localStorageKey(): string {
+    return `${this.DB_NAME}:${this.STORE_NAME}:${this.CACHE_KEY}`;
+  }
+}
+
+function filterUnique<T>(predicate: (value: T) => boolean): MonoTypeOperatorFunction<T> {
+  return (source$) => new Observable<T>((subscriber) =>
+    source$.subscribe({
+      next: (value) => {
+        try {
+          if (predicate(value)) {
+            subscriber.next(value);
+          }
+        } catch (error) {
+          subscriber.error(error);
+        }
+      },
+      error: (error) => subscriber.error(error),
+      complete: () => subscriber.complete()
+    })
+  );
+}

--- a/src/app/services/news-state.service.ts
+++ b/src/app/services/news-state.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@angular/core';
 import { BehaviorSubject, Observable, timer, Subscription } from 'rxjs';
 import { NewsState, NewsItem, NewsFilter } from '../models/news.model';
-import { NewsApiService } from './news-api.service';
+import { NewsService } from './news.service';
 
 const initialState: NewsState = {
   items: [],
@@ -19,7 +19,7 @@ export class NewsStateService {
   private refreshSubscription?: Subscription;
   private readonly REFRESH_INTERVAL = 5 * 60 * 1000; // 5 minutes
 
-  constructor(private newsApiService: NewsApiService) {
+  constructor(private newsService: NewsService) {
     this.setupAutoRefresh();
   }
 
@@ -71,7 +71,7 @@ export class NewsStateService {
 
   // Data Operations
   fetchNews(): void {
-    this.newsApiService.getNews().subscribe({
+    this.newsService.fetchNews().subscribe({
       next: (loadingState) => {
         switch (loadingState.state) {
           case 'loading':

--- a/src/app/services/news.service.spec.ts
+++ b/src/app/services/news.service.spec.ts
@@ -1,12 +1,36 @@
 import { TestBed } from '@angular/core/testing';
+import { of } from 'rxjs';
 
 import { NewsService } from './news.service';
+import { NewsAggregationService } from './aggregation/news-aggregation.service';
+import { NewsCacheService } from './news-cache.service';
+import { TelemetryService } from './telemetry.service';
+
+class MockAggregationService {
+  aggregate = jasmine.createSpy('aggregate').and.returnValue(of({ state: 'loading' } as any));
+}
+
+class MockCacheService {
+  clearCache = jasmine.createSpy('clearCache').and.returnValue(Promise.resolve());
+}
+
+class MockTelemetryService {
+  logEvent = jasmine.createSpy('logEvent');
+  logError = jasmine.createSpy('logError');
+}
 
 describe('NewsService', () => {
   let service: NewsService;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({});
+    TestBed.configureTestingModule({
+      providers: [
+        NewsService,
+        { provide: NewsAggregationService, useClass: MockAggregationService },
+        { provide: NewsCacheService, useClass: MockCacheService },
+        { provide: TelemetryService, useClass: MockTelemetryService }
+      ]
+    });
     service = TestBed.inject(NewsService);
   });
 

--- a/src/app/services/news.service.ts
+++ b/src/app/services/news.service.ts
@@ -1,135 +1,40 @@
 import { Injectable } from '@angular/core';
-import { HttpClient, HttpErrorResponse } from '@angular/common/http';
-import { Observable, throwError, timer, forkJoin } from 'rxjs';
-import { catchError, map, retryWhen, delay, take, tap } from 'rxjs/operators';
+import { Observable } from 'rxjs';
+import { tap } from 'rxjs/operators';
+
 import { NewsItem } from '../models/news.model';
-import { NewsStateService } from './news-state.service';
+import { LoadingState } from '../models/loading-state.model';
+import { NewsAggregationService } from './aggregation/news-aggregation.service';
+import { NewsCacheService } from './news-cache.service';
+import { TelemetryService } from './telemetry.service';
 
 @Injectable({
   providedIn: 'root'
 })
 export class NewsService {
-  private readonly CACHE_TIME = 5 * 60 * 1000; // 5 minutes
-  private readonly MAX_RETRIES = 3;
-  private readonly RETRY_DELAY = 2000; // 2 seconds
-
-  private newsApis = [
-    {
-      url: 'https://newsapi.org/v2/everything',
-      params: {
-        q: 'Trump AND (campaign OR election OR 2024)',
-        language: 'en',
-        sortBy: 'publishedAt',
-        apiKey: 'YOUR_API_KEY' // Replace with your NewsAPI key
-      }
-    },
-    {
-      url: 'https://api.nytimes.com/svc/search/v2/articlesearch.json',
-      params: {
-        q: 'Trump presidential campaign 2024',
-        sort: 'newest',
-        'api-key': 'YOUR_API_KEY' // Replace with your NYTimes API key
-      }
-    }
-  ];
-
   constructor(
-    private http: HttpClient,
-    private stateService: NewsStateService
-  ) {
-    // Auto-refresh data periodically
-    this.setupAutoRefresh();
-  }
+    private readonly aggregationService: NewsAggregationService,
+    private readonly cacheService: NewsCacheService,
+    private readonly telemetry: TelemetryService
+  ) {}
 
-  fetchNews(): Observable<NewsItem[]> {
-    this.stateService.setLoading(true);
-
-    const requests = this.newsApis.map(api =>
-      this.fetchFromApi(api.url, api.params)
-    );
-
-    return forkJoin(requests).pipe(
-      map((responses: any[]) => this.processResponses(responses)),
-      tap(items => {
-        this.stateService.setItems(items);
-        this.stateService.setLoading(false);
-      }),
-      catchError(error => this.handleError(error))
+  fetchNews(): Observable<LoadingState<NewsItem[]>> {
+    return this.aggregationService.aggregate().pipe(
+      tap((state) => {
+        if (state.state === 'loaded') {
+          this.telemetry.logEvent('news.service.loaded', {
+            items: state.data.length,
+            topRelevance: state.data[0]?.relevanceScore ?? null
+          });
+        }
+        if (state.state === 'error') {
+          this.telemetry.logError(state.error, { scope: 'news-service' });
+        }
+      })
     );
   }
 
-  private fetchFromApi(url: string, params: any): Observable<any> {
-    return this.http.get(url, { params }).pipe(
-      retryWhen(errors =>
-        errors.pipe(
-          delay(this.RETRY_DELAY),
-          take(this.MAX_RETRIES),
-          tap(() => console.log('Retrying API request...'))
-        )
-      ),
-      catchError(error => this.handleError(error))
-    );
-  }
-
-  private processResponses(responses: any[]): NewsItem[] {
-    const items: NewsItem[] = [];
-
-    responses.forEach((response, index) => {
-      const source = this.newsApis[index].url;
-      const processedItems = this.processApiResponse(response, source);
-      items.push(...processedItems);
-    });
-
-    return items.sort((a, b) => b.pubDate.getTime() - a.pubDate.getTime());
-  }
-
-  private processApiResponse(response: any, source: string): NewsItem[] {
-    // Process based on the API source
-    if (source.includes('newsapi.org')) {
-      return response.articles.map((article: any) => ({
-        id: article.url,
-        title: article.title,
-        link: article.url,
-        pubDate: new Date(article.publishedAt),
-        content: article.description,
-        source: article.source.name,
-        imageUrl: article.urlToImage
-      }));
-    } else if (source.includes('nytimes.com')) {
-      return response.response.docs.map((doc: any) => ({
-        id: doc._id,
-        title: doc.headline.main,
-        link: doc.web_url,
-        pubDate: new Date(doc.pub_date),
-        content: doc.abstract,
-        source: 'The New York Times',
-        category: doc.section_name
-      }));
-    }
-    return [];
-  }
-
-  private handleError(error: HttpErrorResponse): Observable<never> {
-    let errorMessage = 'An error occurred';
-
-    if (error.error instanceof ErrorEvent) {
-      // Client-side error
-      errorMessage = error.error.message;
-    } else {
-      // Server-side error
-      errorMessage = `Error Code: ${error.status}\nMessage: ${error.message}`;
-    }
-
-    this.stateService.setError(errorMessage);
-    this.stateService.setLoading(false);
-    return throwError(() => new Error(errorMessage));
-  }
-
-  private setupAutoRefresh(): void {
-    timer(this.CACHE_TIME, this.CACHE_TIME).subscribe(() => {
-      if (!this.stateService.currentState.loading) {
-        this.fetchNews().subscribe();
-      }
-    });
+  async clearCache(): Promise<void> {
+    await this.cacheService.clearCache();
   }
 }

--- a/src/app/services/telemetry.service.ts
+++ b/src/app/services/telemetry.service.ts
@@ -1,0 +1,74 @@
+import { Injectable } from '@angular/core';
+import { MonoTypeOperatorFunction, Observable } from 'rxjs';
+
+import { NewsItem } from '../models/news.model';
+
+interface TelemetryClient {
+  captureMessage?(message: string, context?: Record<string, unknown>): void;
+  captureException?(error: unknown, context?: Record<string, unknown>): void;
+  trackEvent?(name: string, properties?: Record<string, unknown>): void;
+}
+
+@Injectable({
+  providedIn: 'root'
+})
+export class TelemetryService {
+  private readonly client: TelemetryClient | null;
+
+  constructor() {
+    this.client = this.resolveClient();
+  }
+
+  logEvent(name: string, properties?: Record<string, unknown>): void {
+    if (this.client?.trackEvent) {
+      this.client.trackEvent(name, properties);
+    } else if (this.client?.captureMessage) {
+      this.client.captureMessage(name, properties);
+    } else {
+      console.debug(`[telemetry] ${name}`, properties);
+    }
+  }
+
+  logError(error: unknown, context?: Record<string, unknown>): void {
+    if (this.client?.captureException) {
+      this.client.captureException(error, context);
+    } else {
+      console.error('[telemetry] error', error, context);
+    }
+  }
+
+  collectMetrics(): MonoTypeOperatorFunction<NewsItem> {
+    const start = typeof performance !== 'undefined' ? performance.now() : Date.now();
+    let count = 0;
+    return (source$) =>
+      new Observable<NewsItem>((subscriber) =>
+        source$.subscribe({
+          next: (item) => {
+            count += 1;
+            subscriber.next(item);
+          },
+          error: (error) => subscriber.error(error),
+          complete: () => {
+            const end = typeof performance !== 'undefined' ? performance.now() : Date.now();
+            const duration = end - start;
+            this.logEvent('news.ingestion.normalized', {
+              itemCount: count,
+              durationMs: Number(duration.toFixed(2))
+            });
+            subscriber.complete();
+          }
+        })
+      );
+  }
+
+  private resolveClient(): TelemetryClient | null {
+    const globalObject = globalThis as any;
+    if (globalObject.Sentry) {
+      return globalObject.Sentry as TelemetryClient;
+    }
+    if (globalObject.__OTEL_EXPORTER__) {
+      return globalObject.__OTEL_EXPORTER__ as TelemetryClient;
+    }
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary
- introduce a configurable aggregation layer that calls proxy-backed NewsAPI, NYTimes, FEC, RSS, and Twitter sources and normalizes their payloads
- enrich news items with deduplication, topic/category tagging, relevance scoring, and persist them through IndexedDB/localStorage caching plus server cache hints
- update the news state/service orchestration to consume the aggregated loading stream and emit telemetry metrics/errors for observability

## Testing
- npm run build -- --configuration development

------
https://chatgpt.com/codex/tasks/task_e_68ea80fbf268832690617380558a6d7c