### PR TITLE
Fix double shell rendering regression

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,1 +1,1 @@
-<app-shell></app-shell>
+<router-outlet></router-outlet>

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,10 +1,10 @@
 import { Component } from '@angular/core';
-import { ShellComponent } from './layout/shell/shell.component';
+import { RouterOutlet } from '@angular/router';
 
 @Component({
   selector: 'app-root',
   standalone: true,
-  imports: [ShellComponent],
+  imports: [RouterOutlet],
   templateUrl: './app.component.html',
   styleUrls: ['./app.component.scss']
 })


### PR DESCRIPTION
## Summary
- switch AppComponent to host the router outlet so the Shell layout only renders once
- replace the ShellComponent import with RouterOutlet to match the routing configuration

## Testing
- npm run build *(fails: missing @swimlane/ngx-charts and marked dependencies in existing setup)*

------
https://chatgpt.com/codex/tasks/task_e_68eabad094888326a2e54a0f32632f9e