### PR TITLE
Fix AppComponent to host router outlet directly

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,12 +1,12 @@
 import { Component } from '@angular/core';
-import { LayoutModule } from './layout/layout.module';
+import { RouterOutlet } from '@angular/router';
 
 @Component({
   selector: 'app-root',
   standalone: true,
-  imports: [LayoutModule],
+  imports: [RouterOutlet],
   template: `
-    <app-layout></app-layout>
+    <router-outlet></router-outlet>
   `,
   styles: [`
     :host {

--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -1,11 +1,13 @@
-import { ApplicationConfig } from '@angular/core';
+import { ApplicationConfig, importProvidersFrom } from '@angular/core';
 import { provideRouter } from '@angular/router';
 import { provideHttpClient } from '@angular/common/http';
 
 import { routes } from './app.routes';
+import { LayoutModule } from './layout/layout.module';
 
 export const appConfig: ApplicationConfig = {
   providers: [
+    importProvidersFrom(LayoutModule),
     provideRouter(routes),
     provideHttpClient()
   ]


### PR DESCRIPTION
## Summary
- import RouterOutlet in AppComponent and remove the embedded Layout component
- render the router outlet from the root component to prevent duplicate layout chrome

## Testing
- npm run build *(hangs at "Building..." in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ea8aaabe548326829e4db6b4bf4ec6