### PR TITLE
feat: rebrand site around australian cricket

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-# TrumpTracker
+# AussieCricketPulse
+
+Australian cricket news and analytics hub built with Angular and a NestJS-backed aggregation service.
 
 This project was generated with [Angular CLI](https://github.com/angular/angular-cli) version 18.0.3.
 
@@ -60,7 +62,7 @@ Pushing to the `main` branch automatically builds and publishes the static site 
 
 1. Installs dependencies with `npm ci` using Node.js 20.
 2. Builds the Angular app with a repository-aware `base-href` so assets resolve correctly at `https://<user>.github.io/<repo>/`.
-3. Uploads `dist/trump-tracker/browser` as the static artifact and deploys it to GitHub Pages.
+3. Uploads `dist/aussie-cricket-pulse/browser` as the static artifact and deploys it to GitHub Pages.
 
 After the first successful run, enable GitHub Pages in the repository settings and choose the "GitHub Actions" source. Subsequent pushes to `main` will update the live site automatically.
 

--- a/angular.json
+++ b/angular.json
@@ -17,7 +17,7 @@
         "build": {
           "builder": "@angular-devkit/build-angular:application",
           "options": {
-            "outputPath": "dist/trump-tracker",
+            "outputPath": "dist/aussie-cricket-pulse",
             "index": "src/index.html",
             "browser": "src/main.ts",
             "polyfills": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "trump-tracker",
+  "name": "aussie-cricket-pulse",
   "version": "0.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "trump-tracker",
+      "name": "aussie-cricket-pulse",
       "version": "0.0.0",
       "dependencies": {
         "@angular/animations": "^18.0.0",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "trump-tracker",
+  "name": "aussie-cricket-pulse",
   "version": "0.0.0",
   "scripts": {
     "ng": "ng",

--- a/server/data/news-topics.json
+++ b/server/data/news-topics.json
@@ -1,137 +1,145 @@
 {
-  "lastUpdated": "2024-09-30T18:30:00.000Z",
+  "lastUpdated": "2024-02-20T08:00:00.000Z",
   "topics": [
     {
-      "slug": "legal-battles",
-      "title": "Legal Battles and Court Strategy",
-      "summary": "Tracking how Trump's campaign weaponizes ongoing court fights to energize supporters and drive fundraising.",
-      "curatedCopy": "## Courtroom vs. Campaign\nThe campaign treats every filing and hearing as a two-for-one opportunity: legal defense by day, campaign rallying cry by night. Fundraising texts reference each development within minutes, and surrogates translate legal jargon into a persecution narrative built for cable hits.\n\n### Messaging pillars\n- Portray restrictions as election interference.\n- Tie prosecutors to Democratic leaders by name.\n- Pledge to overhaul the justice system on day one.",
+      "slug": "black-caps-tour",
+      "title": "Trans-Tasman Test Tour",
+      "summary": "Australia finalises plans for the two-Test swing through Wellington and Christchurch with selection intrigue across the pace ranks.",
+      "curatedCopy": "## Selection calls and conditions\nSelectors have opted to rest Josh Hazlewood for the opener, elevating Lance Morris after his Shield heroics. Scott Boland stays on standby as conditions at the Basin Reserve hint at seam movement early before flattening out.\n\n### Key talking points\n- Who partners Marnus Labuschagne at first drop if Steven Smith remains as makeshift opener.\n- Balance of the attack with Nathan Lyon backed for long spells.\n- Cameron Green's dual role covering middle-order stability and fourth seamer duties.",
       "callouts": [
         {
-          "title": "Why it matters",
-          "markdown": "- Legal updates regularly spike small-dollar donations.\n- Base voters cite legal fights as proof the movement is under attack."
+          "title": "Weather watch",
+          "markdown": "Wellington forecast suggests showers on days two and three — reserve day contingencies already flagged."
         },
         {
-          "title": "Watch the calendar",
-          "markdown": "Sentencing and pre-trial hearings align with key fundraising deadlines, giving the campaign recurring content moments."
+          "title": "Broadcast guide",
+          "markdown": "Fox Cricket and Kayo to simulcast from 9:30am AEDT with SEN radio syndicating ball-by-ball commentary."
         }
       ],
       "spotlightIds": ["article-1"],
       "momentumSeries": [
-        { "date": "2024-09-18", "value": 38 },
-        { "date": "2024-09-22", "value": 47 },
-        { "date": "2024-09-25", "value": 56 },
-        { "date": "2024-09-27", "value": 59 },
-        { "date": "2024-09-30", "value": 61 }
+        { "date": "2024-02-12", "value": 42 },
+        { "date": "2024-02-15", "value": 48 },
+        { "date": "2024-02-17", "value": 55 },
+        { "date": "2024-02-18", "value": 58 },
+        { "date": "2024-02-20", "value": 62 }
       ],
       "events": [
         {
-          "slug": "georgia-ruling",
-          "title": "Georgia racketeering ruling resets the clock",
-          "date": "2024-09-23T10:00:00.000Z",
-          "description": "A Fulton County judge delays proceedings into 2025. The campaign frames the pause as proof the case is collapsing and uses the reprieve to claim momentum in swing states.",
-          "momentum": 58,
+          "slug": "warm-up-clash",
+          "title": "Aussies dominate Lincoln warm-up",
+          "date": "2024-02-18T01:00:00.000Z",
+          "description": "Practice match sees Lance Morris clock 150kph while Cameron Bancroft posts a rapid 80, nudging selection conversations.",
+          "momentum": 60,
           "relatedItemIds": ["article-1", "article-2"]
         },
         {
-          "slug": "gag-order-fight",
-          "title": "New York gag order fight becomes a censorship narrative",
-          "date": "2024-09-27T18:00:00.000Z",
-          "description": "Surrogates argue that limits on Trump's speech are an attack on supporters, driving sympathetic coverage and op-eds from allies.",
-          "momentum": 62,
+          "slug": "hazlewood-rested",
+          "title": "Hazlewood rested, Boland flies in",
+          "date": "2024-02-19T06:00:00.000Z",
+          "description": "Australia shuffle the pace stocks with workload management in mind ahead of a packed winter schedule.",
+          "momentum": 63,
           "relatedItemIds": ["article-3"]
         },
         {
-          "slug": "immunity-appeal",
-          "title": "Supreme Court appeal teasers revive immunity storyline",
-          "date": "2024-09-29T14:30:00.000Z",
-          "description": "Campaign lawyers preview new filings that they say will shield Trump from future prosecutions, reinforcing the promise of a second-term crackdown on DOJ critics.",
+          "slug": "smith-opening-call",
+          "title": "Smith to continue as Test opener",
+          "date": "2024-02-20T04:30:00.000Z",
+          "description": "Head coach Andrew McDonald backs Steven Smith to open alongside Usman Khawaja with Labuschagne locked at three.",
           "momentum": 64,
           "relatedItemIds": ["article-4"]
         }
       ]
     },
     {
-      "slug": "ground-game",
-      "title": "Swing-State Ground Game",
-      "summary": "Field organizing pushes in the Rust Belt and Sun Belt aimed at closing the early-vote gap.",
-      "curatedCopy": "## Organizing Infrastructure\nField staff are leaning on county GOP offices, faith leaders, and a revived \"Trump Force 47\" volunteer portal. The campaign highlights door-knocking stats at every rally to signal professionalization while maintaining the outsider vibe.\n\n### Key tactics\n1. Overlapping bus tours in Pennsylvania, Michigan, and Georgia.\n2. Micro-targeted radio ads focused on energy costs and border security.\n3. Faith outreach breakfasts that double as data collection events.",
+      "slug": "wncl-championship",
+      "title": "WNCL Final Countdown",
+      "summary": "Breakers and Tigers renew their rivalry in a North Sydney Oval finale with star-studded line-ups and sell-out momentum.",
+      "curatedCopy": "## Finals fever\nNSW regain Alyssa Healy while Elyse Villani returns for Tasmania after hamstring tightness. Both camps emphasise powerplay match-ups with cross-breeze expected to favour attacking stroke-play.\n\n### Tactical trends\n1. How Belinda Vakarewa and Lauren Cheatle manage new-ball overs.\n2. Middle-order acceleration with Phoebe Litchfield floating to exploit match-ups.\n3. Fielding units rehearsing aerial catching under lights for a twilight finish.",
       "callouts": [
         {
-          "title": "Staffing snapshot",
-          "markdown": "- 48 paid staffers announced across four battleground states.\n- County captains recruited from 2020 stop-the-steal networks."
+          "title": "Ticket pulse",
+          "markdown": "Only 1,200 general admission seats remain with family bays nearly exhausted."
         }
       ],
       "spotlightIds": ["article-5"],
       "momentumSeries": [
-        { "date": "2024-09-18", "value": 32 },
-        { "date": "2024-09-22", "value": 36 },
-        { "date": "2024-09-25", "value": 40 },
-        { "date": "2024-09-27", "value": 44 },
-        { "date": "2024-09-30", "value": 49 }
+        { "date": "2024-02-12", "value": 34 },
+        { "date": "2024-02-15", "value": 37 },
+        { "date": "2024-02-17", "value": 41 },
+        { "date": "2024-02-19", "value": 47 },
+        { "date": "2024-02-20", "value": 52 }
       ],
       "events": [
         {
-          "slug": "pennsylvania-field-offices",
-          "title": "Six new Pennsylvania field offices open ahead of mail voting",
-          "date": "2024-09-24T15:00:00.000Z",
-          "description": "Campaign claims 8,000 volunteers signed up after the openings, using live streams from each ribbon cutting.",
-          "momentum": 46,
-          "relatedItemIds": ["article-5", "article-6"]
-        },
-        {
-          "slug": "rural-bus-tour",
-          "title": "Rural bus tour spotlights energy message",
-          "date": "2024-09-26T20:00:00.000Z",
-          "description": "Surrogates barnstorm rural Ohio and Michigan touting drilling permits and farmers' fuel costs, capturing local TV coverage.",
-          "momentum": 48,
-          "relatedItemIds": ["article-7"]
-        },
-        {
-          "slug": "latino-faith-outreach",
-          "title": "Latino faith outreach adds bilingual voter guides",
-          "date": "2024-09-28T17:00:00.000Z",
-          "description": "Church partnerships distribute Spanish-language voter packets, part of a broader move to chip into Biden's coalition.",
+          "slug": "healy-cleared",
+          "title": "Healy cleared for WNCL decider",
+          "date": "2024-02-18T21:00:00.000Z",
+          "description": "NSW medical staff confirm Healy's return, giving the Breakers a top-order boost.",
           "momentum": 50,
-          "relatedItemIds": ["article-8"]
+          "relatedItemIds": ["article-5"]
+        },
+        {
+          "slug": "villani-fitness-test",
+          "title": "Villani passes late fitness test",
+          "date": "2024-02-19T08:30:00.000Z",
+          "description": "Tasmania's skipper declared ready after clearing match-eve mobility drills.",
+          "momentum": 52,
+          "relatedItemIds": ["article-6"]
+        },
+        {
+          "slug": "broadcast-upgrade",
+          "title": "Broadcast upgrade adds spidercam",
+          "date": "2024-02-20T02:15:00.000Z",
+          "description": "Cricket Australia and Fox confirm enhanced coverage elements including spidercam and player mic-ups.",
+          "momentum": 54,
+          "relatedItemIds": ["article-7"]
         }
       ]
     },
     {
-      "slug": "issue-messaging",
-      "title": "Issue Messaging & Narrative Testing",
-      "summary": "Rapid-response talking points on immigration, inflation, and foreign policy tested across conservative media.",
-      "curatedCopy": "## Narrative Testing\nCampaign pollsters feed nightly findings into surrogate briefings. Messaging pivots quickly to keep the news cycle on favorable terrain, often marrying immigration with inflation to hold focus.\n\n#### Channels\n- Late-night Truth Social posts.\n- Podcast blitzes hosted by allied influencers.\n- Geo-targeted pre-roll ads that shift by state.",
+      "slug": "big-bash-retool",
+      "title": "Big Bash List Shuffle",
+      "summary": "BBL and WBBL clubs begin list management with marquee targets, trade whispers, and coaching moves shaping the off-season.",
+      "curatedCopy": "## Contract window opens\nClubs have two weeks to finalise retentions before marquee offers to overseas stars go live. Brisbane Heat and Hobart Hurricanes head the queue for top-order finishers, while Melbourne Stars search for a frontline spinner.\n\n### Moves to monitor\n- Heat plotting a multi-year offer to English powerhouse Liam Livingstone.\n- Hurricanes sounding out South African quick Shabnim Ismail for dual WBBL duties.\n- Cricket Australia canvassing fans on expanded regional festival rounds.",
       "callouts": [
         {
-          "title": "Rapid-response cadence",
-          "markdown": "Clip packages are cut within 45 minutes of any major Biden gaffe and sent to a 2,000-person surrogate list."
+          "title": "Regulation refresh",
+          "markdown": "Revised contracting rules allow one additional overseas replacement slot subject to CA approval."
         }
       ],
-      "spotlightIds": ["article-9"],
+      "spotlightIds": ["article-8"],
       "momentumSeries": [
-        { "date": "2024-09-18", "value": 41 },
-        { "date": "2024-09-22", "value": 43 },
-        { "date": "2024-09-25", "value": 47 },
-        { "date": "2024-09-27", "value": 52 },
-        { "date": "2024-09-30", "value": 55 }
+        { "date": "2024-02-12", "value": 29 },
+        { "date": "2024-02-15", "value": 33 },
+        { "date": "2024-02-17", "value": 38 },
+        { "date": "2024-02-19", "value": 44 },
+        { "date": "2024-02-20", "value": 49 }
       ],
       "events": [
         {
-          "slug": "immigration-ad-blitz",
-          "title": "Immigration ad blitz ties border to inflation",
-          "date": "2024-09-25T12:00:00.000Z",
-          "description": "A wave of digital ads claims rising grocery prices stem from federal spending on migrants, a talking point echoed by surrogates on radio.",
-          "momentum": 53,
-          "relatedItemIds": ["article-9", "article-10"]
+          "slug": "heat-coaching-call",
+          "title": "Heat confirm Wade Seccombe extension",
+          "date": "2024-02-17T05:00:00.000Z",
+          "description": "Brisbane extend their coach through BBL|15, reinforcing stability ahead of contracting announcements.",
+          "momentum": 45,
+          "relatedItemIds": ["article-8"]
         },
         {
-          "slug": "debate-prep-messaging",
-          "title": "Debate prep memos leak to conservative outlets",
-          "date": "2024-09-29T11:00:00.000Z",
-          "description": "Selective leaks preview attacks on Biden's foreign policy, keeping the focus on Afghanistan while framing Trump as steady on world affairs.",
-          "momentum": 57,
-          "relatedItemIds": ["article-11"]
+          "slug": "hurricanes-targets",
+          "title": "Hurricanes narrow marquee shortlist",
+          "date": "2024-02-19T09:45:00.000Z",
+          "description": "Hobart open talks with two overseas finishers while eyeing a local quick through trade mechanisms.",
+          "momentum": 47,
+          "relatedItemIds": ["article-9"]
+        },
+        {
+          "slug": "festival-round-pilot",
+          "title": "Regional festival round pitched",
+          "date": "2024-02-20T07:20:00.000Z",
+          "description": "Cricket Australia surveys fans on taking WBBL double-headers to Launceston and Cairns.",
+          "momentum": 50,
+          "relatedItemIds": ["article-10"]
         }
       ]
     }
@@ -139,157 +147,143 @@
   "items": [
     {
       "id": "article-1",
-      "title": "Trump campaign blasts Georgia prosecutors after trial delay",
-      "link": "https://example.com/trump-georgia-delay",
-      "pubDate": "2024-09-23T15:45:00.000Z",
-      "content": "Senior aides told reporters the delay proves the case is political, urging supporters to donate to \"finish the fight\".",
-      "source": "Politico",
-      "category": "Legal",
-      "imageUrl": "https://images.example.com/trump-court.jpg",
-      "topics": ["legal-battles"],
-      "eventSlug": "georgia-ruling",
+      "title": "Morris and Bancroft star in Lincoln tour match",
+      "link": "https://www.cricket.com.au/news/morris-bancroft-tour-match-lincoln/",
+      "pubDate": "2024-02-18T05:45:00.000Z",
+      "content": "Fast bowler Lance Morris and opener Cameron Bancroft press their claims as Australia cruise through their New Zealand hit-out.",
+      "source": "cricket.com.au",
+      "category": "International",
+      "imageUrl": "https://images.cricket.com.au/morris-lincoln.jpg",
+      "topics": ["black-caps-tour"],
+      "eventSlug": "warm-up-clash",
+      "sentiment": "positive",
+      "momentumScore": 60
+    },
+    {
+      "id": "article-2",
+      "title": "Bancroft firms for Test recall after NZ warm-up",
+      "link": "https://www.foxsports.com.au/cricket/bancroft-test-recall-new-zealand/",
+      "pubDate": "2024-02-18T08:30:00.000Z",
+      "content": "Selectors hint that Bancroft could slot in should Australia reshuffle the top order in Wellington.",
+      "source": "Fox Sports",
+      "category": "Analysis",
+      "imageUrl": "https://images.foxsports.com.au/bancroft-celebrate.jpg",
+      "topics": ["black-caps-tour"],
+      "eventSlug": "warm-up-clash",
       "sentiment": "positive",
       "momentumScore": 58
     },
     {
-      "id": "article-2",
-      "title": "Fundraising text blitz follows Georgia ruling",
-      "link": "https://example.com/fundraising-texts",
-      "pubDate": "2024-09-24T02:30:00.000Z",
-      "content": "Within hours of the judge's order, the campaign sent seven fundraising texts referencing \"witch hunt delays\".",
-      "source": "Axios",
-      "category": "Campaign Finance",
-      "imageUrl": "https://images.example.com/text-blitz.jpg",
-      "topics": ["legal-battles", "ground-game"],
-      "eventSlug": "georgia-ruling",
-      "sentiment": "positive",
-      "momentumScore": 57
-    },
-    {
       "id": "article-3",
-      "title": "Trump allies decry gag order on conservative media",
-      "link": "https://example.com/gag-order-response",
-      "pubDate": "2024-09-27T22:10:00.000Z",
-      "content": "Surrogates lined up on talk radio to argue that the gag order is really aimed at silencing supporters.",
-      "source": "Fox News",
-      "category": "Media",
-      "imageUrl": "https://images.example.com/gag-order.jpg",
-      "topics": ["legal-battles", "issue-messaging"],
-      "eventSlug": "gag-order-fight",
-      "sentiment": "positive",
-      "momentumScore": 62
+      "title": "Hazlewood rested for opener as Boland called in",
+      "link": "https://www.smh.com.au/sport/cricket/hazlewood-rested-boland-flies-in-20240219-p5f2z7.html",
+      "pubDate": "2024-02-19T06:30:00.000Z",
+      "content": "Workload management sees Hazlewood miss Wellington with Boland linking with the squad as cover.",
+      "source": "Sydney Morning Herald",
+      "category": "Team News",
+      "imageUrl": "https://images.smh.com.au/hazlewood-rest.jpg",
+      "topics": ["black-caps-tour"],
+      "eventSlug": "hazlewood-rested",
+      "sentiment": "neutral",
+      "momentumScore": 63
     },
     {
       "id": "article-4",
-      "title": "Campaign previews Supreme Court immunity appeal",
-      "link": "https://example.com/immunity-appeal",
-      "pubDate": "2024-09-29T16:05:00.000Z",
-      "content": "Advisers say a conservative majority will rein in the Department of Justice, promising day-one reforms.",
-      "source": "Wall Street Journal",
-      "category": "Legal",
-      "imageUrl": "https://images.example.com/supreme-court.jpg",
-      "topics": ["legal-battles", "issue-messaging"],
-      "eventSlug": "immunity-appeal",
+      "title": "Smith to persist as opener for Kiwi Tests",
+      "link": "https://www.espncricinfo.com/story/australia-commit-to-steven-smith-as-test-opener-1423456",
+      "pubDate": "2024-02-20T05:10:00.000Z",
+      "content": "Coach Andrew McDonald says the Smith-Khawaja partnership will open in Wellington with Labuschagne anchored at three.",
+      "source": "ESPNcricinfo",
+      "category": "Strategy",
+      "imageUrl": "https://img.espncricinfo.com/smith-training.jpg",
+      "topics": ["black-caps-tour"],
+      "eventSlug": "smith-opening-call",
       "sentiment": "positive",
       "momentumScore": 64
     },
     {
       "id": "article-5",
-      "title": "Trump opens six field offices across Pennsylvania",
-      "link": "https://example.com/pennsylvania-field",
-      "pubDate": "2024-09-24T18:30:00.000Z",
-      "content": "Ribbon cuttings featured local lawmakers and targeted messages about energy prices.",
-      "source": "Philadelphia Inquirer",
-      "category": "Ground Game",
-      "imageUrl": "https://images.example.com/field-office.jpg",
-      "topics": ["ground-game"],
-      "eventSlug": "pennsylvania-field-offices",
-      "sentiment": "positive",
-      "momentumScore": 46
-    },
-    {
-      "id": "article-6",
-      "title": "Volunteer sign-ups surge after field office blitz",
-      "link": "https://example.com/volunteer-surge",
-      "pubDate": "2024-09-25T14:20:00.000Z",
-      "content": "Campaign claims 8,000 new volunteers, though Democrats dispute the number.",
-      "source": "NBC News",
-      "category": "Ground Game",
-      "imageUrl": "https://images.example.com/volunteers.jpg",
-      "topics": ["ground-game"],
-      "eventSlug": "pennsylvania-field-offices",
-      "sentiment": "neutral",
-      "momentumScore": 44
-    },
-    {
-      "id": "article-7",
-      "title": "Rural bus tour amplifies energy message",
-      "link": "https://example.com/rural-bus",
-      "pubDate": "2024-09-26T22:40:00.000Z",
-      "content": "The bus tour stops at small-town diners with local radio hits about drilling and inflation.",
-      "source": "Cleveland Plain Dealer",
-      "category": "Ground Game",
-      "imageUrl": "https://images.example.com/bus-tour.jpg",
-      "topics": ["ground-game", "issue-messaging"],
-      "eventSlug": "rural-bus-tour",
-      "sentiment": "positive",
-      "momentumScore": 48
-    },
-    {
-      "id": "article-8",
-      "title": "Latino pastors partner with Trump team on voter guides",
-      "link": "https://example.com/latino-voter-guides",
-      "pubDate": "2024-09-28T19:15:00.000Z",
-      "content": "Spanish-language voter packets are distributed alongside food drives in Phoenix and Orlando.",
-      "source": "Univision",
-      "category": "Outreach",
-      "imageUrl": "https://images.example.com/latino-outreach.jpg",
-      "topics": ["ground-game"],
-      "eventSlug": "latino-faith-outreach",
+      "title": "Healy cleared to lead Breakers in WNCL final",
+      "link": "https://www.cricket.com.au/news/healy-returns-wncl-final-breakers-tigers/",
+      "pubDate": "2024-02-18T22:00:00.000Z",
+      "content": "NSW confirm Alyssa Healy will take the gloves after clearing concussion protocols ahead of the decider.",
+      "source": "cricket.com.au",
+      "category": "WNCL",
+      "imageUrl": "https://images.cricket.com.au/healy-return.jpg",
+      "topics": ["wncl-championship"],
+      "eventSlug": "healy-cleared",
       "sentiment": "positive",
       "momentumScore": 50
     },
     {
-      "id": "article-9",
-      "title": "Immigration ad blitz links border to inflation",
-      "link": "https://example.com/immigration-ads",
-      "pubDate": "2024-09-25T13:10:00.000Z",
-      "content": "Ads feature grocery carts and Border Patrol footage, testing a new hybrid message.",
-      "source": "Washington Post",
-      "category": "Advertising",
-      "imageUrl": "https://images.example.com/immigration-ads.jpg",
-      "topics": ["issue-messaging"],
-      "eventSlug": "immigration-ad-blitz",
+      "id": "article-6",
+      "title": "Villani fitness tick boosts Tigers hopes",
+      "link": "https://www.themercury.com.au/sport/cricket/villani-cleared-for-wncl-final/news-story",
+      "pubDate": "2024-02-19T09:00:00.000Z",
+      "content": "Tasmania captain Elyse Villani wins her race against time to feature in Saturday's showdown.",
+      "source": "The Mercury",
+      "category": "WNCL",
+      "imageUrl": "https://images.themercury.com.au/villani-training.jpg",
+      "topics": ["wncl-championship"],
+      "eventSlug": "villani-fitness-test",
       "sentiment": "positive",
-      "momentumScore": 53
+      "momentumScore": 52
+    },
+    {
+      "id": "article-7",
+      "title": "Spidercam to debut for women's domestic final",
+      "link": "https://www.abc.net.au/news/spidercam-wncl-final-broadcast-upgrade/",
+      "pubDate": "2024-02-20T02:45:00.000Z",
+      "content": "Enhanced broadcast coverage promised as Cricket Australia invests in elevated production for the women's final.",
+      "source": "ABC News",
+      "category": "Broadcast",
+      "imageUrl": "https://live-production.wcms.abc-cdn.net.au/spidercam.jpg",
+      "topics": ["wncl-championship", "big-bash-retool"],
+      "eventSlug": "broadcast-upgrade",
+      "sentiment": "positive",
+      "momentumScore": 54
+    },
+    {
+      "id": "article-8",
+      "title": "Heat lock in coach Wade Seccombe through 2026",
+      "link": "https://www.brisbaneheat.com.au/news/heat-coach-extension/",
+      "pubDate": "2024-02-17T05:30:00.000Z",
+      "content": "Brisbane Heat extend their head coach as they eye marquee signings in the opening of the contracting window.",
+      "source": "Brisbane Heat",
+      "category": "BBL",
+      "imageUrl": "https://images.brisbaneheat.com.au/seccombe.jpg",
+      "topics": ["big-bash-retool"],
+      "eventSlug": "heat-coaching-call",
+      "sentiment": "positive",
+      "momentumScore": 45
+    },
+    {
+      "id": "article-9",
+      "title": "Hurricanes hunt finisher as contracting window opens",
+      "link": "https://www.theage.com.au/sport/cricket/hurricanes-marquee-targets-20240219-p5f30a.html",
+      "pubDate": "2024-02-19T10:00:00.000Z",
+      "content": "Hobart Hurricanes zero in on overseas finisher options while canvassing a local quick via trade.",
+      "source": "The Age",
+      "category": "BBL",
+      "imageUrl": "https://images.theage.com.au/hurricanes-coach.jpg",
+      "topics": ["big-bash-retool"],
+      "eventSlug": "hurricanes-targets",
+      "sentiment": "neutral",
+      "momentumScore": 47
     },
     {
       "id": "article-10",
-      "title": "Fact-checkers push back on ad claims about migrant spending",
-      "link": "https://example.com/fact-check",
-      "pubDate": "2024-09-26T09:00:00.000Z",
-      "content": "Independent fact-checkers say the numbers are exaggerated, but the campaign doubles down in response videos.",
-      "source": "AP",
-      "category": "Fact Check",
-      "imageUrl": "https://images.example.com/fact-check.jpg",
-      "topics": ["issue-messaging", "legal-battles"],
-      "eventSlug": "immigration-ad-blitz",
-      "sentiment": "negative",
-      "momentumScore": 48
-    },
-    {
-      "id": "article-11",
-      "title": "Debate prep memo outlines foreign policy attacks",
-      "link": "https://example.com/debate-memo",
-      "pubDate": "2024-09-29T13:55:00.000Z",
-      "content": "Leaked slides suggest a focus on Afghanistan, arguing Biden cannot handle crises abroad.",
-      "source": "Bloomberg",
-      "category": "Debate",
-      "imageUrl": "https://images.example.com/debate-prep.jpg",
-      "topics": ["issue-messaging", "legal-battles"],
-      "eventSlug": "debate-prep-messaging",
+      "title": "Fans asked to vote on WBBL festival rounds",
+      "link": "https://www.cricket.com.au/news/wbbl-festival-rounds-survey/",
+      "pubDate": "2024-02-20T07:30:00.000Z",
+      "content": "Cricket Australia surveys supporters on potential regional festival weekends in Launceston and Cairns.",
+      "source": "cricket.com.au",
+      "category": "WBBL",
+      "imageUrl": "https://images.cricket.com.au/wbbl-fans.jpg",
+      "topics": ["big-bash-retool", "wncl-championship"],
+      "eventSlug": "festival-round-pilot",
       "sentiment": "positive",
-      "momentumScore": 57
+      "momentumScore": 50
     }
   ]
 }

--- a/server/package.json
+++ b/server/package.json
@@ -1,7 +1,7 @@
 {
   "name": "news-aggregator-server",
   "version": "1.0.0",
-  "description": "Aggregated news backend for 47presangular",
+  "description": "Aggregated news backend for Aussie Cricket Pulse",
   "scripts": {
     "start": "node dist/main.js",
     "start:dev": "ts-node-dev --respawn --transpile-only src/main.ts",

--- a/server/src/news/news.service.ts
+++ b/server/src/news/news.service.ts
@@ -107,9 +107,9 @@ export class NewsService {
   }
 
   private async fetchReddit(): Promise<NewsItemDto[]> {
-    const subredditQuery = 'politics+news+worldnews';
+    const subredditQuery = 'Cricket+CricketAustralia+BigBashLeague';
     const searchParams = new URLSearchParams({
-      q: 'trump 2024 campaign',
+      q: 'Australian cricket',
       restrict_sr: '1',
       sort: 'new',
       limit: '100'
@@ -147,7 +147,7 @@ export class NewsService {
     }
 
     const params = new URLSearchParams({
-      q: 'Trump AND (campaign OR election OR 2024)',
+      q: 'Australia AND cricket',
       language: 'en',
       sortBy: 'publishedAt',
       apiKey
@@ -182,7 +182,7 @@ export class NewsService {
     }
 
     const params = new URLSearchParams({
-      q: 'Trump presidential campaign 2024',
+      q: 'Australian cricket',
       sort: 'newest',
       'api-key': apiKey
     });

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -1,5 +1,6 @@
 import { TestBed } from '@angular/core/testing';
 import { provideRouter } from '@angular/router';
+
 import { AppComponent } from './app.component';
 import { ExperimentService, ExperimentVariant } from './services/experiment.service';
 import { ReferralService } from './services/referral.service';
@@ -12,20 +13,19 @@ class ExperimentServiceStub {
 
 class ReferralServiceStub {
   getReferralCode(): string {
-    return 'T47-TEST';
+    return 'ACP-TEST';
   }
 }
 
 describe('AppComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [AppComponent]
       imports: [AppComponent],
-      providers: [provideRouter([])]
       providers: [
+        provideRouter([]),
         { provide: ExperimentService, useClass: ExperimentServiceStub },
-        { provide: ReferralService, useClass: ReferralServiceStub },
-      ],
+        { provide: ReferralService, useClass: ReferralServiceStub }
+      ]
     }).compileComponents();
   });
 
@@ -35,23 +35,17 @@ describe('AppComponent', () => {
     expect(app).toBeTruthy();
   });
 
-  it('should have the campaign tracker title', () => {
-  it('should have the tracker title', () => {
-    const fixture = TestBed.createComponent(AppComponent);
-    const app = fixture.componentInstance;
-    expect(app.title).toEqual('Trump 47 Campaign Tracker');
-  });
-
   it('should render a skip link for accessibility', () => {
     const fixture = TestBed.createComponent(AppComponent);
     fixture.detectChanges();
     const compiled = fixture.nativeElement as HTMLElement;
     expect(compiled.querySelector('.skip-link')?.textContent?.trim()).toBe('Skip to main content');
-  it('should render the layout header title', () => {
+  });
+
+  it('should render the Aussie Cricket Pulse title', () => {
     const fixture = TestBed.createComponent(AppComponent);
     fixture.detectChanges();
     const compiled = fixture.nativeElement as HTMLElement;
-    expect(compiled.querySelector('h1')?.textContent).toContain('Trump 47 Campaign Tracker');
-    expect(compiled.querySelector('.brand')?.textContent).toContain('Trump 47 Campaign Tracker');
+    expect(compiled.querySelector('h1')?.textContent).toContain('Aussie Cricket Pulse');
   });
 });

--- a/src/app/components/community/community.component.html
+++ b/src/app/components/community/community.component.html
@@ -1,7 +1,7 @@
 <section class="community" aria-labelledby="community-title">
   <header>
-    <h1 id="community-title">Community War Room</h1>
-    <p>Official forums plus the best conversations from Reddit, all moderated for actionability.</p>
+    <h1 id="community-title">Fan clubhouse</h1>
+    <p>Official forums and the liveliest threads from Aussie cricket communities.</p>
   </header>
 
   <div class="thread-grid">

--- a/src/app/components/community/community.component.ts
+++ b/src/app/components/community/community.component.ts
@@ -7,7 +7,7 @@ interface CommunityThread {
   description: string;
   link: string;
   platform: 'reddit' | 'official';
-  moderationLevel: 'community' | 'campaign';
+  moderationLevel: 'community' | 'official';
 }
 
 @Component({
@@ -20,25 +20,25 @@ interface CommunityThread {
 export class CommunityComponent {
   readonly featuredThreads: CommunityThread[] = [
     {
-      title: 'Strategy AMA with campaign leadership',
-      description: 'Bring your questions for the digital, field, and finance directors. Moderated by the official campaign team.',
-      link: 'https://community.trump47.com/threads/strategy-ama',
+      title: 'Selector Q&A with national panel',
+      description: 'Submit your Test summer questions for George Bailey and national selectors in a moderated live chat.',
+      link: 'https://community.cricket.com.au/forums/selectors-ama',
       platform: 'official',
-      moderationLevel: 'campaign',
+      moderationLevel: 'official',
     },
     {
-      title: 'Grassroots organizing toolkit',
-      description: 'Volunteer leaders share the scripts and materials that are working in their counties.',
-      link: 'https://www.reddit.com/r/Conservative/comments/toolkit',
+      title: 'Grade cricket tactics thread',
+      description: 'Coaches swap net session drills, fitness plans, and captaincy tips from premier competitions.',
+      link: 'https://www.reddit.com/r/Cricket/comments/grade_cricket_tactics',
       platform: 'reddit',
       moderationLevel: 'community',
     },
     {
-      title: 'Digital rapid response room',
-      description: 'Coordinate social media pushes in real time. Official moderators surface priority narratives.',
-      link: 'https://community.trump47.com/threads/digital-war-room',
+      title: 'WBBL fantasy coaches corner',
+      description: 'Track lineup news and share trades before the next double-header weekend.',
+      link: 'https://community.cricket.com.au/forums/wbbl-fantasy',
       platform: 'official',
-      moderationLevel: 'campaign',
+      moderationLevel: 'official',
     },
   ];
 

--- a/src/app/components/featured-stories/featured-stories.component.html
+++ b/src/app/components/featured-stories/featured-stories.component.html
@@ -1,7 +1,7 @@
 <section class="featured-stories" aria-labelledby="featured-heading" id="stories">
   <div class="featured-stories__header">
     <h2 id="featured-heading">Featured stories</h2>
-    <p class="featured-stories__description">Curated highlights from the campaign trail.</p>
+    <p class="featured-stories__description">Curated highlights from across Australian cricket.</p>
   </div>
 
   <ul class="featured-stories__list">

--- a/src/app/components/featured-stories/featured-stories.component.ts
+++ b/src/app/components/featured-stories/featured-stories.component.ts
@@ -19,22 +19,22 @@ type FeaturedStory = {
 export class FeaturedStoriesComponent {
   readonly stories: FeaturedStory[] = [
     {
-      title: 'Ground Game Intensifies in Swing States',
-      excerpt: 'Organizers ramp up door-to-door outreach in Pennsylvania and Arizona as polling margins tighten.',
-      topic: 'Field Operations',
-      url: 'https://www.donaldjtrump.com/news/'
+      title: 'Aussies lock in New Zealand tour squad',
+      excerpt: 'Selectors reward Shield form as Lance Morris and Aaron Hardie headline the travelling party.',
+      topic: 'International',
+      url: 'https://www.cricket.com.au/news/australia-squad-new-zealand-tour/'
     },
     {
-      title: 'Fundraising Push Sets New Monthly Record',
-      excerpt: 'Digital campaigns and grassroots donations combine for a historic funding surge across small-dollar donors.',
-      topic: 'Fundraising',
-      url: 'https://www.donaldjtrump.com/news/'
+      title: 'WNCL final set for North Sydney Oval',
+      excerpt: 'NSW Breakers and Tasmania Tigers prepare for a rematch with star-studded line-ups.',
+      topic: 'Domestic',
+      url: 'https://www.cricket.com.au/news/wncl-final-preview/'
     },
     {
-      title: 'Policy Rollout Focuses on Energy Independence',
-      excerpt: 'The campaign outlines a renewed strategy for domestic energy production aimed at lowering costs for families.',
-      topic: 'Policy',
-      url: 'https://www.donaldjtrump.com/news/'
+      title: 'BBL clubs chase marquee deals',
+      excerpt: 'Franchises eye overseas signatures as contracting window opens ahead of summer.',
+      topic: 'Big Bash',
+      url: 'https://www.cricket.com.au/news/bbl-signings-window/'
     }
   ];
 }

--- a/src/app/components/insights-sidebar/insights-sidebar.component.html
+++ b/src/app/components/insights-sidebar/insights-sidebar.component.html
@@ -1,7 +1,7 @@
 <aside class="insights" aria-labelledby="insights-heading" id="insights">
   <div class="insights__header">
-    <h2 id="insights-heading">Campaign insights</h2>
-    <p class="insights__description">Key performance signals updated throughout the day.</p>
+    <h2 id="insights-heading">Cricket insights</h2>
+    <p class="insights__description">Key performance signals across Aussie internationals and leagues.</p>
   </div>
 
   <ul class="insights__metrics" role="list">

--- a/src/app/components/insights-sidebar/insights-sidebar.component.ts
+++ b/src/app/components/insights-sidebar/insights-sidebar.component.ts
@@ -19,28 +19,28 @@ type Insight = {
 export class InsightsSidebarComponent {
   readonly insights: Insight[] = [
     {
-      label: 'Digital reach',
-      value: '2.1M',
+      label: 'WTC standings',
+      value: '66 pts',
       trend: 'up',
-      description: 'Impressions across official channels in the last 48 hours'
+      description: 'Australia extend their lead after the SCG Test win'
     },
     {
-      label: 'Grassroots events',
-      value: '38',
+      label: 'BBL net run rate',
+      value: '+0.923',
       trend: 'steady',
-      description: 'Scheduled rallies and town halls this week'
+      description: 'Scorchers hold top spot with consistent margin victories'
     },
     {
-      label: 'Volunteer signups',
-      value: '+14%',
+      label: 'WBBL ladder climb',
+      value: '+2',
       trend: 'up',
-      description: 'Week-over-week increase in new volunteers'
+      description: 'Sydney Sixers jump two places following back-to-back wins'
     }
   ];
 
   readonly keyActions: string[] = [
-    'Track upcoming debate preparation milestones',
-    'Highlight localized policy rollouts for supporters',
-    'Coordinate regional press availability with rapid response team'
+    'Monitor Marsh Cup squad announcements due Friday',
+    'Track injury updates for the New Zealand tour',
+    'Compile broadcast changes for regional WBBL viewers'
   ];
 }

--- a/src/app/components/news-feed/news-feed.component.html
+++ b/src/app/components/news-feed/news-feed.component.html
@@ -1,6 +1,6 @@
 <div class="news-feed" role="region" aria-labelledby="news-feed-heading">
   <header>
-    <h1 id="news-feed-heading">Trump 2024 Campaign News</h1>
+    <h1 id="news-feed-heading">Australian Cricket Newswire</h1>
 
     <div class="controls">
       <div class="filters" role="search">

--- a/src/app/components/news-item/news-item.component.html
+++ b/src/app/components/news-item/news-item.component.html
@@ -36,7 +36,7 @@
       <a
         [routerLink]="detailRoute"
         class="view-story"
-        [attr.aria-label]="'Read campaign context for: ' + item.title"
+        [attr.aria-label]="'Read extended coverage for: ' + item.title"
       >
         View story
       </a>
@@ -45,9 +45,9 @@
         target="_blank"
         rel="noopener noreferrer"
         class="read-more"
-        [attr.aria-label]="'Read full post on Reddit: ' + item.title"
+        [attr.aria-label]="'Read full article: ' + item.title"
       >
-        <span>Read on Reddit</span>
+        <span>Read full article</span>
         <svg
           xmlns="http://www.w3.org/2000/svg"
           width="16"
@@ -66,7 +66,7 @@
       </a>
 
       <div class="share">
-        <span>Amplify:</span>
+        <span>Share:</span>
         <a
           *ngFor="let share of shareLinks"
           class="share-link"

--- a/src/app/components/shell/shell.component.html
+++ b/src/app/components/shell/shell.component.html
@@ -2,10 +2,10 @@
 <div class="shell">
   <header class="shell__header" role="banner">
     <div class="shell__branding">
-      <span class="shell__logo" aria-hidden="true">47</span>
+      <span class="shell__logo" aria-hidden="true">AC</span>
       <div>
-        <p class="shell__title">Trump 47 Campaign Tracker</p>
-        <p class="shell__subtitle">Real-time updates from across the campaign trail</p>
+        <p class="shell__title">Aussie Cricket Pulse</p>
+        <p class="shell__subtitle">Real-time updates across every Australian competition</p>
       </div>
     </div>
 
@@ -39,11 +39,11 @@
           [routerLinkActiveOptions]="{ exact: true }"
           [attr.aria-current]="rla.isActive ? 'page' : null"
         >
-          Campaign Feed
+          News Feed
         </a>
       </li>
       <li>
-        <a href="#insights">Insights</a>
+        <a href="#insights">Form guide</a>
       </li>
       <li>
         <a href="#stories">Featured stories</a>
@@ -52,9 +52,9 @@
   </nav>
 
   <main id="main-content" class="shell__main" role="main" tabindex="-1">
-    <div class="shell__grid" aria-label="Campaign dashboard layout">
-      <section class="shell__content" aria-labelledby="campaign-feed-heading">
-        <h2 id="campaign-feed-heading" class="visually-hidden">Campaign news feed</h2>
+    <div class="shell__grid" aria-label="Cricket newsroom layout">
+      <section class="shell__content" aria-labelledby="news-feed-heading">
+        <h2 id="news-feed-heading" class="visually-hidden">Australian cricket news feed</h2>
         <router-outlet></router-outlet>
       </section>
       <app-featured-stories class="shell__featured"></app-featured-stories>
@@ -63,7 +63,7 @@
   </main>
 
   <footer class="shell__footer" role="contentinfo">
-    <p>Built for accessibility and real-time insight into the 2024 campaign.</p>
-    <a class="footer__feedback" href="mailto:feedback@trump47tracker.com">Share feedback</a>
+    <p>Built for accessibility and real-time insight into Australian cricket.</p>
+    <a class="footer__feedback" href="mailto:feedback@aussiecricketpulse.com">Share feedback</a>
   </footer>
 </div>

--- a/src/app/components/story/story-detail/story-detail.component.html
+++ b/src/app/components/story/story-detail/story-detail.component.html
@@ -1,6 +1,6 @@
 <section class="story-detail" *ngIf="!loading && story; else loadingOrError">
   <nav class="breadcrumb">
-    <a routerLink="/" aria-label="Back to campaign news">← Back to news feed</a>
+    <a routerLink="/" aria-label="Back to cricket news">← Back to news feed</a>
   </nav>
 
   <header class="story-header">
@@ -17,7 +17,7 @@
       target="_blank"
       rel="noopener noreferrer"
     >
-      Read on Reddit
+      Read full article
     </a>
   </header>
 

--- a/src/app/components/story/story-detail/story-detail.component.ts
+++ b/src/app/components/story/story-detail/story-detail.component.ts
@@ -72,7 +72,7 @@ export class StoryDetailComponent implements OnInit, OnDestroy {
 
   private updateMeta(detail: StoryDetail): void {
     const summary = detail.summary?.[0] ?? detail.content;
-    const pageTitle = `${detail.title} | Trump 47 Campaign Tracker`;
+    const pageTitle = `${detail.title} | Aussie Cricket Pulse`;
 
     this.title.setTitle(pageTitle);
     this.meta.updateTag({ name: 'description', content: summary });

--- a/src/app/layout/components/footer/layout-footer.component.html
+++ b/src/app/layout/components/footer/layout-footer.component.html
@@ -1,6 +1,6 @@
 <footer class="footer">
   <div class="footer__inner">
-    <p>&copy; {{ updated | date:'yyyy' }} Trump 47 Campaign Tracker. Data aggregated from national outlets.</p>
-    <a href="/media" class="footer__cta" routerLink="/media">Explore campaign media</a>
+    <p>&copy; {{ updated | date:'yyyy' }} Aussie Cricket Pulse. Scores &amp; analysis sourced from trusted cricket outlets.</p>
+    <a href="/media" class="footer__cta" routerLink="/media">Explore cricket media</a>
   </div>
 </footer>

--- a/src/app/layout/components/header/layout-header.component.ts
+++ b/src/app/layout/components/header/layout-header.component.ts
@@ -6,6 +6,6 @@ import { Component } from '@angular/core';
   styleUrls: ['./layout-header.component.scss']
 })
 export class LayoutHeaderComponent {
-  readonly title = 'Trump 47 Campaign Tracker';
-  readonly subtitle = 'Real-time intelligence on the 2024 campaign trail';
+  readonly title = 'Aussie Cricket Pulse';
+  readonly subtitle = 'Real-time intelligence across Australian cricket';
 }

--- a/src/app/layout/components/hero-metrics/hero-metrics.component.html
+++ b/src/app/layout/components/hero-metrics/hero-metrics.component.html
@@ -7,8 +7,8 @@
 
   <ng-template #emptyState>
     <div class="hero__headline">
-      <p class="hero__eyebrow">Campaign insights</p>
-      <h2 class="hero__title">Tracking breaking news, policy shifts, and campaign moments</h2>
+      <p class="hero__eyebrow">Cricket insights</p>
+      <h2 class="hero__title">Tracking breaking news, squad changes, and match-day storylines</h2>
     </div>
   </ng-template>
 
@@ -30,7 +30,7 @@
     </article>
 
     <article class="metric" *ngIf="metrics.trendingIssues.length">
-      <h3 class="metric__value">Trending issues</h3>
+      <h3 class="metric__value">Trending topics</h3>
       <ul class="metric__list">
         <li *ngFor="let issue of metrics.trendingIssues">{{ issue | titlecase }}</li>
       </ul>

--- a/src/app/layout/footer/footer.component.html
+++ b/src/app/layout/footer/footer.component.html
@@ -1,8 +1,8 @@
 <footer class="site-footer" role="contentinfo">
   <div class="site-footer__inner">
     <div class="site-footer__brand">
-      <p class="site-footer__title">Trump 47 Campaign Tracker</p>
-      <p class="site-footer__tagline">Monitoring news, policy, and movement energy on the road to November.</p>
+      <p class="site-footer__title">Aussie Cricket Pulse</p>
+      <p class="site-footer__tagline">Daily intelligence across Australian internationals and domestic leagues.</p>
     </div>
     <nav class="site-footer__nav" aria-label="Footer">
       <ul>
@@ -13,7 +13,7 @@
     </nav>
   </div>
   <div class="site-footer__meta">
-    <p>&copy; {{ currentYear }} Grassroots Briefing Collective.</p>
-    <a href="mailto:tips&#64;campaigntracker.org">tips&#64;campaigntracker.org</a>
+    <p>&copy; {{ currentYear }} Southern Wicket Media.</p>
+    <a href="mailto:desk&#64;aussiecricketpulse.com">desk&#64;aussiecricketpulse.com</a>
   </div>
 </footer>

--- a/src/app/layout/footer/footer.component.ts
+++ b/src/app/layout/footer/footer.component.ts
@@ -13,9 +13,9 @@ export class FooterComponent {
   readonly navLinks = [
     { label: 'News', route: '/news' },
     { label: 'Dashboard', route: '/dashboard' },
-    { label: 'Issues', route: '/issues' },
-    { label: 'Events', route: '/events' },
-    { label: 'Get Involved', route: '/get-involved' }
+    { label: 'Coverage', route: '/issues' },
+    { label: 'Fixtures', route: '/events' },
+    { label: 'Fan Hub', route: '/get-involved' }
   ];
 
   currentYear = new Date().getFullYear();

--- a/src/app/layout/header/header.component.html
+++ b/src/app/layout/header/header.component.html
@@ -1,11 +1,11 @@
 <header class="site-header" role="banner">
   <div class="site-header__inner">
     <div class="site-header__branding">
-      <a class="site-header__logo" routerLink="/news" aria-label="Trump 47 Tracker home">
-        <span class="site-header__logo-mark" aria-hidden="true">47</span>
+      <a class="site-header__logo" routerLink="/news" aria-label="Aussie Cricket Pulse home">
+        <span class="site-header__logo-mark" aria-hidden="true">AC</span>
         <span class="site-header__logo-text">
-          <span class="site-header__logo-primary">Trump 47</span>
-          <span class="site-header__logo-secondary">Campaign Tracker</span>
+          <span class="site-header__logo-primary">Aussie Cricket</span>
+          <span class="site-header__logo-secondary">Pulse Network</span>
         </span>
       </a>
     </div>
@@ -20,11 +20,11 @@
         </li>
         <li class="primary-nav__item primary-nav__item--mega">
           <button class="primary-nav__link mega-trigger" type="button" aria-haspopup="true"
-            [attr.aria-expanded]="megaMenuOpen" aria-controls="issues-mega" (click)="toggleMegaMenu()">
-            Issues
+            [attr.aria-expanded]="megaMenuOpen" aria-controls="coverage-mega" (click)="toggleMegaMenu()">
+            Coverage
             <span class="chevron" [class.is-open]="megaMenuOpen" aria-hidden="true"></span>
           </button>
-          <div id="issues-mega" class="mega-menu" [class.is-open]="megaMenuOpen" [attr.aria-hidden]="!megaMenuOpen">
+          <div id="coverage-mega" class="mega-menu" [class.is-open]="megaMenuOpen" [attr.aria-hidden]="!megaMenuOpen">
             <div class="mega-menu__inner">
               <div class="mega-menu__section" *ngFor="let section of megaMenuSections">
                 <p class="mega-menu__heading">{{ section.heading }}</p>
@@ -76,7 +76,7 @@
           <li *ngFor="let link of navLinks">
             <a [routerLink]="link.route" routerLinkActive="is-active" (click)="closeMobileMenu()">{{ link.label }}</a>
           </li>
-          <li class="mobile-drawer__section-label">Issues</li>
+          <li class="mobile-drawer__section-label">Coverage</li>
           <li class="mobile-drawer__mega" *ngFor="let section of megaMenuSections">
             <p class="mobile-drawer__heading">{{ section.heading }}</p>
             <ul>

--- a/src/app/layout/header/header.component.ts
+++ b/src/app/layout/header/header.component.ts
@@ -40,59 +40,59 @@ export class HeaderComponent {
   readonly navLinks: NavLink[] = [
     { label: 'News', route: '/news' },
     { label: 'Dashboard', route: '/dashboard' },
-    { label: 'Events', route: '/events' },
-    { label: 'Get Involved', route: '/get-involved' }
+    { label: 'Fixtures', route: '/events' },
+    { label: 'Fan Hub', route: '/get-involved' }
   ];
 
   readonly megaMenuSections: MegaMenuSection[] = [
     {
-      heading: 'Top Priorities',
+      heading: 'National Teams',
       items: [
         {
-          label: 'Economic Agenda',
-          description: 'Jobs, inflation, and trade policy priorities.',
+          label: "Men's internationals",
+          description: 'Test, ODI, and T20 focus for the Baggy Greens.',
           route: '/issues',
-          fragment: 'economy'
+          fragment: 'international-men'
         },
         {
-          label: 'Border & Security',
-          description: 'Immigration, national defense, and public safety.',
+          label: "Women's internationals",
+          description: 'Southern Stars tour news and form guide.',
           route: '/issues',
-          fragment: 'security'
+          fragment: 'international-women'
         }
       ]
     },
     {
-      heading: 'Policy Pillars',
+      heading: 'Domestic Leagues',
       items: [
         {
-          label: 'Healthcare & Social',
-          description: 'Healthcare access, veteran services, and family support.',
+          label: 'Sheffield Shield & Marsh Cup',
+          description: 'Red-ball updates and one-day cup storylines.',
           route: '/issues',
-          fragment: 'healthcare'
+          fragment: 'domestic-red-ball'
         },
         {
-          label: 'Election Integrity',
-          description: 'Voting reforms and oversight initiatives.',
+          label: 'Big Bash spotlight',
+          description: 'BBL & WBBL squads, trades, and table watch.',
           route: '/issues',
-          fragment: 'elections'
+          fragment: 'big-bash'
         }
       ]
     },
     {
-      heading: 'Movement Voices',
+      heading: 'Pathways & Culture',
       items: [
         {
-          label: 'Grassroots Spotlights',
-          description: 'Community stories and volunteer organizing.',
+          label: 'Emerging talent',
+          description: 'Academy prospects and Australia A tours.',
           route: '/issues',
-          fragment: 'grassroots'
+          fragment: 'pathways'
         },
         {
-          label: 'Media Statements',
-          description: 'Campaign press releases and official responses.',
+          label: 'Community & media',
+          description: 'Grassroots stories and broadcast developments.',
           route: '/issues',
-          fragment: 'media'
+          fragment: 'community-media'
         }
       ]
     }
@@ -100,21 +100,21 @@ export class HeaderComponent {
 
   readonly ctas: CtaLink[] = [
     {
-      label: 'Donate',
-      description: 'Power the movement with a contribution.',
-      href: 'https://www.donaldjtrump.com/',
+      label: 'Stream matches',
+      description: 'Watch live cricket on Kayo & Foxtel.',
+      href: 'https://kayosports.com.au/',
       style: 'primary'
     },
     {
-      label: 'Volunteer',
-      description: 'Host events or knock doors in your community.',
-      href: 'https://www.donaldjtrump.com/join/',
+      label: 'Join 12th Man',
+      description: 'Become a Cricket Australia supporter member.',
+      href: 'https://www.cricket.com.au/12thman',
       style: 'outline'
     },
     {
-      label: 'Subscribe',
-      description: 'Get rapid response alerts from campaign HQ.',
-      href: 'https://www.donaldjtrump.com/subscribe/',
+      label: 'Shop jerseys',
+      description: 'Grab the latest green and gold kits.',
+      href: 'https://shop.cricket.com.au/',
       style: 'ghost'
     }
   ];

--- a/src/app/layout/sidebar/sidebar.component.html
+++ b/src/app/layout/sidebar/sidebar.component.html
@@ -1,25 +1,25 @@
-<aside class="campaign-sidebar" aria-labelledby="sidebar-title">
-  <div class="campaign-sidebar__section">
+<aside class="cricket-sidebar" aria-labelledby="sidebar-title">
+  <div class="cricket-sidebar__section">
     <h2 id="sidebar-title">Stay engaged</h2>
-    <p>Key actions and resources to keep the campaign momentum moving.</p>
-    <ul class="campaign-sidebar__list">
+    <p>Support Aussie cricket pathways with official programs and fan perks.</p>
+    <ul class="cricket-sidebar__list">
       <li *ngFor="let cta of takeActionCtas">
-        <a class="campaign-sidebar__card" [href]="cta.href" target="_blank" rel="noopener noreferrer"
+        <a class="cricket-sidebar__card" [href]="cta.href" target="_blank" rel="noopener noreferrer"
           [attr.aria-label]="cta.ariaLabel">
-          <span class="campaign-sidebar__card-label">{{ cta.label }}</span>
-          <span class="campaign-sidebar__card-description">{{ cta.description }}</span>
+          <span class="cricket-sidebar__card-label">{{ cta.label }}</span>
+          <span class="cricket-sidebar__card-description">{{ cta.description }}</span>
         </a>
       </li>
     </ul>
   </div>
-  <div class="campaign-sidebar__section">
+  <div class="cricket-sidebar__section">
     <h3>Additional resources</h3>
-    <ul class="campaign-sidebar__list campaign-sidebar__list--compact">
+    <ul class="cricket-sidebar__list cricket-sidebar__list--compact">
       <li *ngFor="let link of resourceLinks">
-        <a class="campaign-sidebar__link" [href]="link.href" target="_blank" rel="noopener noreferrer"
+        <a class="cricket-sidebar__link" [href]="link.href" target="_blank" rel="noopener noreferrer"
           [attr.aria-label]="link.ariaLabel">
-          <span class="campaign-sidebar__card-label">{{ link.label }}</span>
-          <span class="campaign-sidebar__card-description">{{ link.description }}</span>
+          <span class="cricket-sidebar__card-label">{{ link.label }}</span>
+          <span class="cricket-sidebar__card-description">{{ link.description }}</span>
         </a>
       </li>
     </ul>

--- a/src/app/layout/sidebar/sidebar.component.scss
+++ b/src/app/layout/sidebar/sidebar.component.scss
@@ -1,7 +1,7 @@
 @use '../../shared/styles/tokens';
 @use '../../shared/styles/mixins';
 
-.campaign-sidebar {
+.cricket-sidebar {
   position: sticky;
   top: var(--space-9);
   display: grid;
@@ -61,7 +61,7 @@
 }
 
 @include mixins.respond('lg') {
-  .campaign-sidebar {
+  .cricket-sidebar {
     position: static;
     top: auto;
     padding: var(--space-4);
@@ -70,7 +70,7 @@
 }
 
 @include mixins.respond('md') {
-  .campaign-sidebar {
+  .cricket-sidebar {
     gap: var(--space-4);
   }
 }

--- a/src/app/layout/sidebar/sidebar.component.ts
+++ b/src/app/layout/sidebar/sidebar.component.ts
@@ -18,37 +18,37 @@ interface SidebarCta {
 export class SidebarComponent {
   readonly takeActionCtas: SidebarCta[] = [
     {
-      label: 'Chip in $20.24',
-      description: 'Donate to accelerate key battleground operations.',
-      href: 'https://www.donaldjtrump.com/',
-      ariaLabel: 'Donate twenty dollars and twenty four cents'
+      label: 'Join 12th Man',
+      description: 'Support the national teams with exclusive member perks.',
+      href: 'https://www.cricket.com.au/12thman',
+      ariaLabel: 'Join the Cricket Australia 12th Man supporters club'
     },
     {
-      label: 'Become a Captain',
-      description: 'Lead local volunteer teams and coordinate canvasses.',
-      href: 'https://www.donaldjtrump.com/join/',
-      ariaLabel: 'Sign up to become a neighborhood captain'
+      label: 'Club cricket hub',
+      description: 'Register your local side and find club resources.',
+      href: 'https://play.cricket.com.au/',
+      ariaLabel: 'Open the community club cricket registration hub'
     },
     {
-      label: 'Rapid Response List',
-      description: 'Get SMS alerts for breaking news and key votes.',
-      href: 'https://www.donaldjtrump.com/subscribe/',
-      ariaLabel: 'Subscribe to the Trump rapid response list'
+      label: 'Match alerts',
+      description: 'Sign up for email and push alerts on Aussie fixtures.',
+      href: 'https://www.cricket.com.au/newsletters',
+      ariaLabel: 'Subscribe to Australian cricket match alerts'
     }
   ];
 
   readonly resourceLinks: SidebarCta[] = [
     {
-      label: 'State Leadership',
-      description: 'Find your state director and field staff.',
-      href: 'https://www.donaldjtrump.com/states/',
-      ariaLabel: 'Explore state leadership contacts'
+      label: 'Domestic fixtures',
+      description: 'Sheffield Shield, WNCL, and premier cricket schedules.',
+      href: 'https://www.cricket.com.au/fixtures',
+      ariaLabel: 'Browse Australian domestic cricket fixtures'
     },
     {
-      label: 'Events Calendar',
-      description: 'See rallies, town halls, and digital events near you.',
-      href: 'https://www.donaldjtrump.com/events/',
-      ariaLabel: 'Open the campaign events calendar'
+      label: 'Broadcast guide',
+      description: 'Find streaming and radio options for every league.',
+      href: 'https://www.cricket.com.au/broadcast-guide',
+      ariaLabel: 'Open the Australian cricket broadcast guide'
     }
   ];
 }

--- a/src/app/pages/dashboard/dashboard.component.html
+++ b/src/app/pages/dashboard/dashboard.component.html
@@ -1,9 +1,9 @@
 <section class="dashboard" aria-labelledby="dashboard-heading">
   <header class="dashboard__header">
-    <p class="dashboard__eyebrow">Campaign intelligence</p>
-    <h1 id="dashboard-heading">Tracker dashboard</h1>
+    <p class="dashboard__eyebrow">National coverage</p>
+    <h1 id="dashboard-heading">Cricket pulse dashboard</h1>
     <p class="dashboard__lede">
-      Real-time organizing metrics and earned media snapshots to keep rapid response teams aligned.
+      Quick-glance metrics on the Australian sides and domestic competitions to guide your week of coverage.
     </p>
   </header>
   <div class="dashboard__metrics" role="list">
@@ -15,18 +15,18 @@
   </div>
   <section class="dashboard__updates" aria-label="Latest updates">
     <article class="dashboard__card">
-      <h2>War room brief</h2>
+      <h2>High performance brief</h2>
       <p>
-        State directors report strong volunteer sign-ups following the Phoenix town hall. Digital ads are
-        outperforming benchmarks in Wisconsin and Pennsylvania.
+        Pat Cummins confirms the pace trio for Wellington with Hazlewood rested and Scott Boland on standby. Nathan Lyon
+        stays with the squad as subcontinental prep ramps up.
       </p>
     </article>
     <article class="dashboard__card">
-      <h2>Field priorities</h2>
+      <h2>Domestic watchlist</h2>
       <ul>
-        <li>Expand Hispanic media buys in Las Vegas and Miami.</li>
-        <li>Coordinate door-to-door weekend of action with national surrogates.</li>
-        <li>Drive early vote education in Sun Belt metros.</li>
+        <li>Shield leaders WA meet Victoria at the WACA — streaming from 10:00 AWST.</li>
+        <li>WNCL final tickets now limited; coverage on ABC Grandstand and Kayo.</li>
+        <li>Hobart Hurricanes targeting marquee overseas signing before list deadline.</li>
       </ul>
     </article>
   </section>

--- a/src/app/pages/dashboard/dashboard.component.ts
+++ b/src/app/pages/dashboard/dashboard.component.ts
@@ -11,19 +11,19 @@ import { CommonModule } from '@angular/common';
 export class DashboardComponent {
   readonly metrics = [
     {
-      label: 'Battleground events this week',
-      value: 18,
-      change: '+4 vs. last week'
+      label: 'World Test Championship points',
+      value: 66,
+      change: '+12 after Sydney victory'
     },
     {
-      label: 'Grassroots captains onboarded',
-      value: 312,
-      change: '+28 in the last 24 hours'
+      label: 'BBL wins this fortnight',
+      value: 9,
+      change: 'Scorchers & Heat lead the ladder'
     },
     {
-      label: 'Digital impressions YTD',
-      value: '47M',
-      change: '+8% month over month'
+      label: 'WBBL run rate trend',
+      value: '+0.37',
+      change: 'Sixers surge over past 3 matches'
     }
   ];
 }

--- a/src/app/pages/events/events.component.html
+++ b/src/app/pages/events/events.component.html
@@ -1,8 +1,8 @@
 <section class="events" aria-labelledby="events-heading">
   <header class="events__intro">
-    <p class="events__eyebrow">On the road</p>
-    <h1 id="events-heading">Upcoming events</h1>
-    <p>Find campaign stops and grassroots meetups to plug into the movement.</p>
+    <p class="events__eyebrow">Around the grounds</p>
+    <h1 id="events-heading">Upcoming fixtures &amp; moments</h1>
+    <p>Bookmark the key matches, finals, and milestone announcements across Australian cricket.</p>
   </header>
   <div class="events__list" role="list">
     <article class="events__card" role="listitem" *ngFor="let event of events">

--- a/src/app/pages/events/events.component.ts
+++ b/src/app/pages/events/events.component.ts
@@ -19,25 +19,25 @@ interface CampaignEvent {
 export class EventsComponent {
   readonly events: CampaignEvent[] = [
     {
-      title: 'Rust Belt Jobs Rally',
-      location: 'Erie, Pennsylvania',
-      date: 'June 22, 2024',
-      description: 'Manufacturing workers and small business owners share testimonies on economic revival.',
-      rsvpUrl: 'https://www.donaldjtrump.com/events/'
+      title: 'Australia vs New Zealand – 1st Test',
+      location: 'Basin Reserve, Wellington',
+      date: 'February 29, 2024',
+      description: 'Baggy Greens return across the ditch with a day-one start at 10:00am NZDT.',
+      rsvpUrl: 'https://www.cricket.com.au/series/australia-tour-of-new-zealand-2024'
     },
     {
-      title: 'Border Security Town Hall',
-      location: 'Yuma, Arizona',
-      date: 'June 24, 2024',
-      description: 'Policy roundtable featuring sheriffs, border agents, and Angel families.',
-      rsvpUrl: 'https://www.donaldjtrump.com/events/'
+      title: 'Women’s National Cricket League Final',
+      location: 'North Sydney Oval, Sydney',
+      date: 'March 2, 2024',
+      description: 'Breakers meet the Tigers in a rematch streamed live on Kayo and ABC Grandstand.',
+      rsvpUrl: 'https://www.cricket.com.au/news/wncl-final-preview/'
     },
     {
-      title: 'Faith & Freedom Summit',
-      location: 'Greenville, South Carolina',
-      date: 'June 27, 2024',
-      description: 'Pastors, faith leaders, and youth ministries coordinating voter outreach.',
-      rsvpUrl: 'https://www.donaldjtrump.com/events/'
+      title: 'BBL|14 Contracting Window Opens',
+      location: 'Cricket Australia HQ & digital stream',
+      date: 'March 15, 2024',
+      description: 'Clubs begin lodging marquee signings; watch the live recap with team list analysts.',
+      rsvpUrl: 'https://www.cricket.com.au/news/bbl-signings-window/'
     }
   ];
 }

--- a/src/app/pages/get-involved/get-involved.component.html
+++ b/src/app/pages/get-involved/get-involved.component.html
@@ -1,8 +1,8 @@
 <section class="get-involved" aria-labelledby="get-involved-heading">
   <header class="get-involved__intro">
-    <p class="get-involved__eyebrow">Take action</p>
-    <h1 id="get-involved-heading">Get involved today</h1>
-    <p>Choose a pathway to contribute your time, talent, or resources to the movement.</p>
+    <p class="get-involved__eyebrow">Fan engagement</p>
+    <h1 id="get-involved-heading">Stay connected to Aussie cricket</h1>
+    <p>Pick a pathway to keep pace with squads, fixtures, and the community fueling Australian cricket.</p>
   </header>
   <div class="get-involved__grid">
     <article class="get-involved__card" *ngFor="let step of steps">
@@ -13,8 +13,8 @@
   </div>
   <section class="get-involved__newsletter" aria-label="Newsletter signup">
     <h2>Stay informed</h2>
-    <p>Subscribe to get the daily briefing and volunteer opportunities in your inbox.</p>
-    <form class="get-involved__form" aria-label="Subscribe to campaign updates" (submit)="onSubmit($event)" novalidate>
+    <p>Subscribe for the Aussie Cricket Pulse daily wrap with squad news and streaming guides.</p>
+    <form class="get-involved__form" aria-label="Subscribe to cricket updates" (submit)="onSubmit($event)" novalidate>
       <label class="visually-hidden" for="newsletter-email">Email address</label>
       <input id="newsletter-email" type="email" placeholder="you@example.com" required />
       <button type="submit">Subscribe</button>

--- a/src/app/pages/get-involved/get-involved.component.ts
+++ b/src/app/pages/get-involved/get-involved.component.ts
@@ -17,19 +17,19 @@ interface ActionStep {
 export class GetInvolvedComponent {
   readonly steps: ActionStep[] = [
     {
-      title: 'Join the grassroots team',
-      description: 'Become a neighborhood captain to coordinate phone banks and canvasses.',
-      link: 'https://www.donaldjtrump.com/join/'
+      title: 'Subscribe to match alerts',
+      description: 'Get team lists, weather calls, and score updates for every Aussie XI.',
+      link: 'https://www.cricket.com.au/newsletters'
     },
     {
-      title: 'Host a house meeting',
-      description: 'Download our toolkit and invite supporters for a rapid response briefing.',
-      link: 'https://www.donaldjtrump.com/get-involved/'
+      title: 'Join a supporter club',
+      description: 'Find your local fan base and official watch party partners.',
+      link: 'https://www.cricket.com.au/fans/club-registrations'
     },
     {
-      title: 'Digital rapid responders',
-      description: 'Amplify campaign messaging with social media share kits and daily talking points.',
-      link: 'https://www.donaldjtrump.com/subscribe/'
+      title: 'Volunteer at community cricket',
+      description: 'Help coach, score, or umpire through Cricket Australia pathway programs.',
+      link: 'https://www.community.cricket.com.au/clubs/volunteers'
     }
   ];
 

--- a/src/app/pages/issues/issues.component.html
+++ b/src/app/pages/issues/issues.component.html
@@ -1,9 +1,9 @@
 <section class="issues" aria-labelledby="issues-heading">
   <header class="issues__intro">
-    <p class="issues__eyebrow">Policy agenda</p>
-    <h1 id="issues-heading">Where the campaign is focused</h1>
+    <p class="issues__eyebrow">Coverage pillars</p>
+    <h1 id="issues-heading">What we're tracking across Australian cricket</h1>
     <p class="issues__lede">
-      Explore core priorities shaping the movement and dive into highlight reels pulled from the campaign trail.
+      Deep dives into national teams, domestic leagues, and the pathways powering the next wave of Australian stars.
     </p>
   </header>
   <div class="issues__grid">

--- a/src/app/pages/issues/issues.component.ts
+++ b/src/app/pages/issues/issues.component.ts
@@ -18,63 +18,63 @@ interface IssueSection {
 export class IssuesComponent {
   readonly sections: IssueSection[] = [
     {
-      id: 'economy',
-      title: 'Economy first agenda',
-      summary: 'Tax relief for working families, energy dominance, and small business expansion.',
+      id: 'international-men',
+      title: "Men's internationals",
+      summary: 'Tour news, selection calls, and form lines for the Baggy Greens across Test, ODI, and T20 formats.',
       bullets: [
-        'Pledge to extend middle-class tax cuts and expand opportunity zones.',
-        'Reinvest in American energy with new drilling permits and refining capacity.',
-        'Launch apprenticeship partnerships with community colleges.'
+        'Monitor the New Zealand Test tour with focus on the pace attack rotation.',
+        'Track ODI squad refresh ahead of the Champions Trophy qualification window.',
+        'Analyse David Warner succession planning for the next home summer.'
       ]
     },
     {
-      id: 'security',
-      title: 'Border & national security',
-      summary: 'Finish the wall, restore remain-in-Mexico, and boost law enforcement resources.',
+      id: 'international-women',
+      title: "Women's internationals",
+      summary: 'Southern Stars scheduling, squad depth, and World Cup defence storylines.',
       bullets: [
-        'Deploy additional border agents and accelerate asylum processing reforms.',
-        'Block fentanyl trafficking with new technology at ports of entry.',
-        'Back the blue with federal support for local task forces.'
+        'Selection squeeze with Kim Garth, Darcie Brown, and Tayla Vlaeminck returning from injury.',
+        'Spin tandem of Alana King and Ash Gardner prepping for subcontinental tours.',
+        'Multi-format captaincy balance for Meg Lanning successors and leadership group.'
       ]
     },
     {
-      id: 'healthcare',
-      title: 'Healthcare & social supports',
-      summary: 'Lower costs, protect seniors, and expand rural care access.',
+      id: 'domestic-red-ball',
+      title: 'Sheffield Shield & Marsh Cup',
+      summary: 'State cricket trends that influence national call-ups and contract decisions.',
       bullets: [
-        'Drive price transparency across hospitals and insurers.',
-        'Expand telehealth waivers for rural clinics and veteran care.',
-        'Protect Medicare and Social Security with fiscal discipline.'
+        'Western Australia pushing for a three-peat with Cameron Bancroft in prolific form.',
+        'Victorian quicks vying for Australia A selection through strong Shield returns.',
+        'Marsh Cup final permutations as Queensland chase net run rate boosts.'
       ]
     },
     {
-      id: 'elections',
-      title: 'Election integrity',
-      summary: 'Secure ballots, clean voter rolls, and restore confidence in elections.',
+      id: 'big-bash',
+      title: 'Big Bash spotlight',
+      summary: 'BBL and WBBL recruitment moves, tactical shifts, and broadcast innovations.',
       bullets: [
-        'Advance voter ID standards with state partners.',
-        'Invest in poll watcher training and legal rapid response teams.',
-        'Modernize election systems with paper backups and audits.'
+        'Hurricanes and Renegades in market for marquee overseas finishers.',
+        'New power surge strategies and analytics-led fielding alignments.',
+        'Negotiations underway for expanded WBBL regional festival rounds.'
       ]
     },
     {
-      id: 'grassroots',
-      title: 'Grassroots spotlights',
-      summary: 'Stories from volunteers building the movement at the local level.',
+      id: 'pathways',
+      title: 'Emerging talent pipeline',
+      summary: 'Pathway programs fueling the next generation of Australian stars.',
       bullets: [
-        'Faith coalition in Georgia registering new voters weekly.',
-        'Small business owners hosting roundtables on regulatory reform.',
-        'College chapters leading campus debate nights.'
+        'National Performance Squad camp at Allan Border Field focused on fast bowling loads.',
+        'Australia A to tour England in July with an eye on Ashes depth.',
+        'Under-19 world cup recap spotlighting MVP Kate Pelle and Harry Dixon.'
       ]
     },
     {
-      id: 'media',
-      title: 'Media statements',
-      summary: 'Official campaign messaging and fact checks in response to breaking news.',
+      id: 'community-media',
+      title: 'Community & media',
+      summary: 'Grassroots initiatives and coverage shifts keeping fans connected.',
       bullets: [
-        'Weekly talking points for surrogate interviews.',
-        'Shareable graphics for social platforms.',
-        'Rapid rebuttal briefs for newsroom outreach.'
+        'Cricket Australia rolling out PlayHQ upgrades for live scoring at grade level.',
+        'ABC confirms expanded digital radio rights for WBBL and WNCL.',
+        'Indigenous cricket programs delivering combined youth carnivals in Alice Springs.'
       ]
     }
   ];

--- a/src/app/routes/timeline/timeline.component.html
+++ b/src/app/routes/timeline/timeline.component.html
@@ -11,9 +11,9 @@
   <ng-container *ngIf="state.state === 'loaded'">
     <header class="timeline__header">
       <div>
-        <h1>Campaign Timeline</h1>
+        <h1>Cricket Timeline</h1>
         <p class="timeline__subhead">
-          Curated moments and news grouped by topic, with a quick read on how momentum is shifting.
+          Curated moments across Australian internationals and leagues, with a quick read on how momentum is shifting.
         </p>
       </div>
       <div class="timeline__meta">

--- a/src/assets/data/news-topics.json
+++ b/src/assets/data/news-topics.json
@@ -1,137 +1,145 @@
 {
-  "lastUpdated": "2024-09-30T18:30:00.000Z",
+  "lastUpdated": "2024-02-20T08:00:00.000Z",
   "topics": [
     {
-      "slug": "legal-battles",
-      "title": "Legal Battles and Court Strategy",
-      "summary": "Tracking how Trump's campaign weaponizes ongoing court fights to energize supporters and drive fundraising.",
-      "curatedCopy": "## Courtroom vs. Campaign\nThe campaign treats every filing and hearing as a two-for-one opportunity: legal defense by day, campaign rallying cry by night. Fundraising texts reference each development within minutes, and surrogates translate legal jargon into a persecution narrative built for cable hits.\n\n### Messaging pillars\n- Portray restrictions as election interference.\n- Tie prosecutors to Democratic leaders by name.\n- Pledge to overhaul the justice system on day one.",
+      "slug": "black-caps-tour",
+      "title": "Trans-Tasman Test Tour",
+      "summary": "Australia finalises plans for the two-Test swing through Wellington and Christchurch with selection intrigue across the pace ranks.",
+      "curatedCopy": "## Selection calls and conditions\nSelectors have opted to rest Josh Hazlewood for the opener, elevating Lance Morris after his Shield heroics. Scott Boland stays on standby as conditions at the Basin Reserve hint at seam movement early before flattening out.\n\n### Key talking points\n- Who partners Marnus Labuschagne at first drop if Steven Smith remains as makeshift opener.\n- Balance of the attack with Nathan Lyon backed for long spells.\n- Cameron Green's dual role covering middle-order stability and fourth seamer duties.",
       "callouts": [
         {
-          "title": "Why it matters",
-          "markdown": "- Legal updates regularly spike small-dollar donations.\n- Base voters cite legal fights as proof the movement is under attack."
+          "title": "Weather watch",
+          "markdown": "Wellington forecast suggests showers on days two and three — reserve day contingencies already flagged."
         },
         {
-          "title": "Watch the calendar",
-          "markdown": "Sentencing and pre-trial hearings align with key fundraising deadlines, giving the campaign recurring content moments."
+          "title": "Broadcast guide",
+          "markdown": "Fox Cricket and Kayo to simulcast from 9:30am AEDT with SEN radio syndicating ball-by-ball commentary."
         }
       ],
       "spotlightIds": ["article-1"],
       "momentumSeries": [
-        { "date": "2024-09-18", "value": 38 },
-        { "date": "2024-09-22", "value": 47 },
-        { "date": "2024-09-25", "value": 56 },
-        { "date": "2024-09-27", "value": 59 },
-        { "date": "2024-09-30", "value": 61 }
+        { "date": "2024-02-12", "value": 42 },
+        { "date": "2024-02-15", "value": 48 },
+        { "date": "2024-02-17", "value": 55 },
+        { "date": "2024-02-18", "value": 58 },
+        { "date": "2024-02-20", "value": 62 }
       ],
       "events": [
         {
-          "slug": "georgia-ruling",
-          "title": "Georgia racketeering ruling resets the clock",
-          "date": "2024-09-23T10:00:00.000Z",
-          "description": "A Fulton County judge delays proceedings into 2025. The campaign frames the pause as proof the case is collapsing and uses the reprieve to claim momentum in swing states.",
-          "momentum": 58,
+          "slug": "warm-up-clash",
+          "title": "Aussies dominate Lincoln warm-up",
+          "date": "2024-02-18T01:00:00.000Z",
+          "description": "Practice match sees Lance Morris clock 150kph while Cameron Bancroft posts a rapid 80, nudging selection conversations.",
+          "momentum": 60,
           "relatedItemIds": ["article-1", "article-2"]
         },
         {
-          "slug": "gag-order-fight",
-          "title": "New York gag order fight becomes a censorship narrative",
-          "date": "2024-09-27T18:00:00.000Z",
-          "description": "Surrogates argue that limits on Trump's speech are an attack on supporters, driving sympathetic coverage and op-eds from allies.",
-          "momentum": 62,
+          "slug": "hazlewood-rested",
+          "title": "Hazlewood rested, Boland flies in",
+          "date": "2024-02-19T06:00:00.000Z",
+          "description": "Australia shuffle the pace stocks with workload management in mind ahead of a packed winter schedule.",
+          "momentum": 63,
           "relatedItemIds": ["article-3"]
         },
         {
-          "slug": "immunity-appeal",
-          "title": "Supreme Court appeal teasers revive immunity storyline",
-          "date": "2024-09-29T14:30:00.000Z",
-          "description": "Campaign lawyers preview new filings that they say will shield Trump from future prosecutions, reinforcing the promise of a second-term crackdown on DOJ critics.",
+          "slug": "smith-opening-call",
+          "title": "Smith to continue as Test opener",
+          "date": "2024-02-20T04:30:00.000Z",
+          "description": "Head coach Andrew McDonald backs Steven Smith to open alongside Usman Khawaja with Labuschagne locked at three.",
           "momentum": 64,
           "relatedItemIds": ["article-4"]
         }
       ]
     },
     {
-      "slug": "ground-game",
-      "title": "Swing-State Ground Game",
-      "summary": "Field organizing pushes in the Rust Belt and Sun Belt aimed at closing the early-vote gap.",
-      "curatedCopy": "## Organizing Infrastructure\nField staff are leaning on county GOP offices, faith leaders, and a revived \"Trump Force 47\" volunteer portal. The campaign highlights door-knocking stats at every rally to signal professionalization while maintaining the outsider vibe.\n\n### Key tactics\n1. Overlapping bus tours in Pennsylvania, Michigan, and Georgia.\n2. Micro-targeted radio ads focused on energy costs and border security.\n3. Faith outreach breakfasts that double as data collection events.",
+      "slug": "wncl-championship",
+      "title": "WNCL Final Countdown",
+      "summary": "Breakers and Tigers renew their rivalry in a North Sydney Oval finale with star-studded line-ups and sell-out momentum.",
+      "curatedCopy": "## Finals fever\nNSW regain Alyssa Healy while Elyse Villani returns for Tasmania after hamstring tightness. Both camps emphasise powerplay match-ups with cross-breeze expected to favour attacking stroke-play.\n\n### Tactical trends\n1. How Belinda Vakarewa and Lauren Cheatle manage new-ball overs.\n2. Middle-order acceleration with Phoebe Litchfield floating to exploit match-ups.\n3. Fielding units rehearsing aerial catching under lights for a twilight finish.",
       "callouts": [
         {
-          "title": "Staffing snapshot",
-          "markdown": "- 48 paid staffers announced across four battleground states.\n- County captains recruited from 2020 stop-the-steal networks."
+          "title": "Ticket pulse",
+          "markdown": "Only 1,200 general admission seats remain with family bays nearly exhausted."
         }
       ],
       "spotlightIds": ["article-5"],
       "momentumSeries": [
-        { "date": "2024-09-18", "value": 32 },
-        { "date": "2024-09-22", "value": 36 },
-        { "date": "2024-09-25", "value": 40 },
-        { "date": "2024-09-27", "value": 44 },
-        { "date": "2024-09-30", "value": 49 }
+        { "date": "2024-02-12", "value": 34 },
+        { "date": "2024-02-15", "value": 37 },
+        { "date": "2024-02-17", "value": 41 },
+        { "date": "2024-02-19", "value": 47 },
+        { "date": "2024-02-20", "value": 52 }
       ],
       "events": [
         {
-          "slug": "pennsylvania-field-offices",
-          "title": "Six new Pennsylvania field offices open ahead of mail voting",
-          "date": "2024-09-24T15:00:00.000Z",
-          "description": "Campaign claims 8,000 volunteers signed up after the openings, using live streams from each ribbon cutting.",
-          "momentum": 46,
-          "relatedItemIds": ["article-5", "article-6"]
-        },
-        {
-          "slug": "rural-bus-tour",
-          "title": "Rural bus tour spotlights energy message",
-          "date": "2024-09-26T20:00:00.000Z",
-          "description": "Surrogates barnstorm rural Ohio and Michigan touting drilling permits and farmers' fuel costs, capturing local TV coverage.",
-          "momentum": 48,
-          "relatedItemIds": ["article-7"]
-        },
-        {
-          "slug": "latino-faith-outreach",
-          "title": "Latino faith outreach adds bilingual voter guides",
-          "date": "2024-09-28T17:00:00.000Z",
-          "description": "Church partnerships distribute Spanish-language voter packets, part of a broader move to chip into Biden's coalition.",
+          "slug": "healy-cleared",
+          "title": "Healy cleared for WNCL decider",
+          "date": "2024-02-18T21:00:00.000Z",
+          "description": "NSW medical staff confirm Healy's return, giving the Breakers a top-order boost.",
           "momentum": 50,
-          "relatedItemIds": ["article-8"]
+          "relatedItemIds": ["article-5"]
+        },
+        {
+          "slug": "villani-fitness-test",
+          "title": "Villani passes late fitness test",
+          "date": "2024-02-19T08:30:00.000Z",
+          "description": "Tasmania's skipper declared ready after clearing match-eve mobility drills.",
+          "momentum": 52,
+          "relatedItemIds": ["article-6"]
+        },
+        {
+          "slug": "broadcast-upgrade",
+          "title": "Broadcast upgrade adds spidercam",
+          "date": "2024-02-20T02:15:00.000Z",
+          "description": "Cricket Australia and Fox confirm enhanced coverage elements including spidercam and player mic-ups.",
+          "momentum": 54,
+          "relatedItemIds": ["article-7"]
         }
       ]
     },
     {
-      "slug": "issue-messaging",
-      "title": "Issue Messaging & Narrative Testing",
-      "summary": "Rapid-response talking points on immigration, inflation, and foreign policy tested across conservative media.",
-      "curatedCopy": "## Narrative Testing\nCampaign pollsters feed nightly findings into surrogate briefings. Messaging pivots quickly to keep the news cycle on favorable terrain, often marrying immigration with inflation to hold focus.\n\n#### Channels\n- Late-night Truth Social posts.\n- Podcast blitzes hosted by allied influencers.\n- Geo-targeted pre-roll ads that shift by state.",
+      "slug": "big-bash-retool",
+      "title": "Big Bash List Shuffle",
+      "summary": "BBL and WBBL clubs begin list management with marquee targets, trade whispers, and coaching moves shaping the off-season.",
+      "curatedCopy": "## Contract window opens\nClubs have two weeks to finalise retentions before marquee offers to overseas stars go live. Brisbane Heat and Hobart Hurricanes head the queue for top-order finishers, while Melbourne Stars search for a frontline spinner.\n\n### Moves to monitor\n- Heat plotting a multi-year offer to English powerhouse Liam Livingstone.\n- Hurricanes sounding out South African quick Shabnim Ismail for dual WBBL duties.\n- Cricket Australia canvassing fans on expanded regional festival rounds.",
       "callouts": [
         {
-          "title": "Rapid-response cadence",
-          "markdown": "Clip packages are cut within 45 minutes of any major Biden gaffe and sent to a 2,000-person surrogate list."
+          "title": "Regulation refresh",
+          "markdown": "Revised contracting rules allow one additional overseas replacement slot subject to CA approval."
         }
       ],
-      "spotlightIds": ["article-9"],
+      "spotlightIds": ["article-8"],
       "momentumSeries": [
-        { "date": "2024-09-18", "value": 41 },
-        { "date": "2024-09-22", "value": 43 },
-        { "date": "2024-09-25", "value": 47 },
-        { "date": "2024-09-27", "value": 52 },
-        { "date": "2024-09-30", "value": 55 }
+        { "date": "2024-02-12", "value": 29 },
+        { "date": "2024-02-15", "value": 33 },
+        { "date": "2024-02-17", "value": 38 },
+        { "date": "2024-02-19", "value": 44 },
+        { "date": "2024-02-20", "value": 49 }
       ],
       "events": [
         {
-          "slug": "immigration-ad-blitz",
-          "title": "Immigration ad blitz ties border to inflation",
-          "date": "2024-09-25T12:00:00.000Z",
-          "description": "A wave of digital ads claims rising grocery prices stem from federal spending on migrants, a talking point echoed by surrogates on radio.",
-          "momentum": 53,
-          "relatedItemIds": ["article-9", "article-10"]
+          "slug": "heat-coaching-call",
+          "title": "Heat confirm Wade Seccombe extension",
+          "date": "2024-02-17T05:00:00.000Z",
+          "description": "Brisbane extend their coach through BBL|15, reinforcing stability ahead of contracting announcements.",
+          "momentum": 45,
+          "relatedItemIds": ["article-8"]
         },
         {
-          "slug": "debate-prep-messaging",
-          "title": "Debate prep memos leak to conservative outlets",
-          "date": "2024-09-29T11:00:00.000Z",
-          "description": "Selective leaks preview attacks on Biden's foreign policy, keeping the focus on Afghanistan while framing Trump as steady on world affairs.",
-          "momentum": 57,
-          "relatedItemIds": ["article-11"]
+          "slug": "hurricanes-targets",
+          "title": "Hurricanes narrow marquee shortlist",
+          "date": "2024-02-19T09:45:00.000Z",
+          "description": "Hobart open talks with two overseas finishers while eyeing a local quick through trade mechanisms.",
+          "momentum": 47,
+          "relatedItemIds": ["article-9"]
+        },
+        {
+          "slug": "festival-round-pilot",
+          "title": "Regional festival round pitched",
+          "date": "2024-02-20T07:20:00.000Z",
+          "description": "Cricket Australia surveys fans on taking WBBL double-headers to Launceston and Cairns.",
+          "momentum": 50,
+          "relatedItemIds": ["article-10"]
         }
       ]
     }
@@ -139,157 +147,143 @@
   "items": [
     {
       "id": "article-1",
-      "title": "Trump campaign blasts Georgia prosecutors after trial delay",
-      "link": "https://example.com/trump-georgia-delay",
-      "pubDate": "2024-09-23T15:45:00.000Z",
-      "content": "Senior aides told reporters the delay proves the case is political, urging supporters to donate to \"finish the fight\".",
-      "source": "Politico",
-      "category": "Legal",
-      "imageUrl": "https://images.example.com/trump-court.jpg",
-      "topics": ["legal-battles"],
-      "eventSlug": "georgia-ruling",
+      "title": "Morris and Bancroft star in Lincoln tour match",
+      "link": "https://www.cricket.com.au/news/morris-bancroft-tour-match-lincoln/",
+      "pubDate": "2024-02-18T05:45:00.000Z",
+      "content": "Fast bowler Lance Morris and opener Cameron Bancroft press their claims as Australia cruise through their New Zealand hit-out.",
+      "source": "cricket.com.au",
+      "category": "International",
+      "imageUrl": "https://images.cricket.com.au/morris-lincoln.jpg",
+      "topics": ["black-caps-tour"],
+      "eventSlug": "warm-up-clash",
+      "sentiment": "positive",
+      "momentumScore": 60
+    },
+    {
+      "id": "article-2",
+      "title": "Bancroft firms for Test recall after NZ warm-up",
+      "link": "https://www.foxsports.com.au/cricket/bancroft-test-recall-new-zealand/",
+      "pubDate": "2024-02-18T08:30:00.000Z",
+      "content": "Selectors hint that Bancroft could slot in should Australia reshuffle the top order in Wellington.",
+      "source": "Fox Sports",
+      "category": "Analysis",
+      "imageUrl": "https://images.foxsports.com.au/bancroft-celebrate.jpg",
+      "topics": ["black-caps-tour"],
+      "eventSlug": "warm-up-clash",
       "sentiment": "positive",
       "momentumScore": 58
     },
     {
-      "id": "article-2",
-      "title": "Fundraising text blitz follows Georgia ruling",
-      "link": "https://example.com/fundraising-texts",
-      "pubDate": "2024-09-24T02:30:00.000Z",
-      "content": "Within hours of the judge's order, the campaign sent seven fundraising texts referencing \"witch hunt delays\".",
-      "source": "Axios",
-      "category": "Campaign Finance",
-      "imageUrl": "https://images.example.com/text-blitz.jpg",
-      "topics": ["legal-battles", "ground-game"],
-      "eventSlug": "georgia-ruling",
-      "sentiment": "positive",
-      "momentumScore": 57
-    },
-    {
       "id": "article-3",
-      "title": "Trump allies decry gag order on conservative media",
-      "link": "https://example.com/gag-order-response",
-      "pubDate": "2024-09-27T22:10:00.000Z",
-      "content": "Surrogates lined up on talk radio to argue that the gag order is really aimed at silencing supporters.",
-      "source": "Fox News",
-      "category": "Media",
-      "imageUrl": "https://images.example.com/gag-order.jpg",
-      "topics": ["legal-battles", "issue-messaging"],
-      "eventSlug": "gag-order-fight",
-      "sentiment": "positive",
-      "momentumScore": 62
+      "title": "Hazlewood rested for opener as Boland called in",
+      "link": "https://www.smh.com.au/sport/cricket/hazlewood-rested-boland-flies-in-20240219-p5f2z7.html",
+      "pubDate": "2024-02-19T06:30:00.000Z",
+      "content": "Workload management sees Hazlewood miss Wellington with Boland linking with the squad as cover.",
+      "source": "Sydney Morning Herald",
+      "category": "Team News",
+      "imageUrl": "https://images.smh.com.au/hazlewood-rest.jpg",
+      "topics": ["black-caps-tour"],
+      "eventSlug": "hazlewood-rested",
+      "sentiment": "neutral",
+      "momentumScore": 63
     },
     {
       "id": "article-4",
-      "title": "Campaign previews Supreme Court immunity appeal",
-      "link": "https://example.com/immunity-appeal",
-      "pubDate": "2024-09-29T16:05:00.000Z",
-      "content": "Advisers say a conservative majority will rein in the Department of Justice, promising day-one reforms.",
-      "source": "Wall Street Journal",
-      "category": "Legal",
-      "imageUrl": "https://images.example.com/supreme-court.jpg",
-      "topics": ["legal-battles", "issue-messaging"],
-      "eventSlug": "immunity-appeal",
+      "title": "Smith to persist as opener for Kiwi Tests",
+      "link": "https://www.espncricinfo.com/story/australia-commit-to-steven-smith-as-test-opener-1423456",
+      "pubDate": "2024-02-20T05:10:00.000Z",
+      "content": "Coach Andrew McDonald says the Smith-Khawaja partnership will open in Wellington with Labuschagne anchored at three.",
+      "source": "ESPNcricinfo",
+      "category": "Strategy",
+      "imageUrl": "https://img.espncricinfo.com/smith-training.jpg",
+      "topics": ["black-caps-tour"],
+      "eventSlug": "smith-opening-call",
       "sentiment": "positive",
       "momentumScore": 64
     },
     {
       "id": "article-5",
-      "title": "Trump opens six field offices across Pennsylvania",
-      "link": "https://example.com/pennsylvania-field",
-      "pubDate": "2024-09-24T18:30:00.000Z",
-      "content": "Ribbon cuttings featured local lawmakers and targeted messages about energy prices.",
-      "source": "Philadelphia Inquirer",
-      "category": "Ground Game",
-      "imageUrl": "https://images.example.com/field-office.jpg",
-      "topics": ["ground-game"],
-      "eventSlug": "pennsylvania-field-offices",
-      "sentiment": "positive",
-      "momentumScore": 46
-    },
-    {
-      "id": "article-6",
-      "title": "Volunteer sign-ups surge after field office blitz",
-      "link": "https://example.com/volunteer-surge",
-      "pubDate": "2024-09-25T14:20:00.000Z",
-      "content": "Campaign claims 8,000 new volunteers, though Democrats dispute the number.",
-      "source": "NBC News",
-      "category": "Ground Game",
-      "imageUrl": "https://images.example.com/volunteers.jpg",
-      "topics": ["ground-game"],
-      "eventSlug": "pennsylvania-field-offices",
-      "sentiment": "neutral",
-      "momentumScore": 44
-    },
-    {
-      "id": "article-7",
-      "title": "Rural bus tour amplifies energy message",
-      "link": "https://example.com/rural-bus",
-      "pubDate": "2024-09-26T22:40:00.000Z",
-      "content": "The bus tour stops at small-town diners with local radio hits about drilling and inflation.",
-      "source": "Cleveland Plain Dealer",
-      "category": "Ground Game",
-      "imageUrl": "https://images.example.com/bus-tour.jpg",
-      "topics": ["ground-game", "issue-messaging"],
-      "eventSlug": "rural-bus-tour",
-      "sentiment": "positive",
-      "momentumScore": 48
-    },
-    {
-      "id": "article-8",
-      "title": "Latino pastors partner with Trump team on voter guides",
-      "link": "https://example.com/latino-voter-guides",
-      "pubDate": "2024-09-28T19:15:00.000Z",
-      "content": "Spanish-language voter packets are distributed alongside food drives in Phoenix and Orlando.",
-      "source": "Univision",
-      "category": "Outreach",
-      "imageUrl": "https://images.example.com/latino-outreach.jpg",
-      "topics": ["ground-game"],
-      "eventSlug": "latino-faith-outreach",
+      "title": "Healy cleared to lead Breakers in WNCL final",
+      "link": "https://www.cricket.com.au/news/healy-returns-wncl-final-breakers-tigers/",
+      "pubDate": "2024-02-18T22:00:00.000Z",
+      "content": "NSW confirm Alyssa Healy will take the gloves after clearing concussion protocols ahead of the decider.",
+      "source": "cricket.com.au",
+      "category": "WNCL",
+      "imageUrl": "https://images.cricket.com.au/healy-return.jpg",
+      "topics": ["wncl-championship"],
+      "eventSlug": "healy-cleared",
       "sentiment": "positive",
       "momentumScore": 50
     },
     {
-      "id": "article-9",
-      "title": "Immigration ad blitz links border to inflation",
-      "link": "https://example.com/immigration-ads",
-      "pubDate": "2024-09-25T13:10:00.000Z",
-      "content": "Ads feature grocery carts and Border Patrol footage, testing a new hybrid message.",
-      "source": "Washington Post",
-      "category": "Advertising",
-      "imageUrl": "https://images.example.com/immigration-ads.jpg",
-      "topics": ["issue-messaging"],
-      "eventSlug": "immigration-ad-blitz",
+      "id": "article-6",
+      "title": "Villani fitness tick boosts Tigers hopes",
+      "link": "https://www.themercury.com.au/sport/cricket/villani-cleared-for-wncl-final/news-story",
+      "pubDate": "2024-02-19T09:00:00.000Z",
+      "content": "Tasmania captain Elyse Villani wins her race against time to feature in Saturday's showdown.",
+      "source": "The Mercury",
+      "category": "WNCL",
+      "imageUrl": "https://images.themercury.com.au/villani-training.jpg",
+      "topics": ["wncl-championship"],
+      "eventSlug": "villani-fitness-test",
       "sentiment": "positive",
-      "momentumScore": 53
+      "momentumScore": 52
+    },
+    {
+      "id": "article-7",
+      "title": "Spidercam to debut for women's domestic final",
+      "link": "https://www.abc.net.au/news/spidercam-wncl-final-broadcast-upgrade/",
+      "pubDate": "2024-02-20T02:45:00.000Z",
+      "content": "Enhanced broadcast coverage promised as Cricket Australia invests in elevated production for the women's final.",
+      "source": "ABC News",
+      "category": "Broadcast",
+      "imageUrl": "https://live-production.wcms.abc-cdn.net.au/spidercam.jpg",
+      "topics": ["wncl-championship", "big-bash-retool"],
+      "eventSlug": "broadcast-upgrade",
+      "sentiment": "positive",
+      "momentumScore": 54
+    },
+    {
+      "id": "article-8",
+      "title": "Heat lock in coach Wade Seccombe through 2026",
+      "link": "https://www.brisbaneheat.com.au/news/heat-coach-extension/",
+      "pubDate": "2024-02-17T05:30:00.000Z",
+      "content": "Brisbane Heat extend their head coach as they eye marquee signings in the opening of the contracting window.",
+      "source": "Brisbane Heat",
+      "category": "BBL",
+      "imageUrl": "https://images.brisbaneheat.com.au/seccombe.jpg",
+      "topics": ["big-bash-retool"],
+      "eventSlug": "heat-coaching-call",
+      "sentiment": "positive",
+      "momentumScore": 45
+    },
+    {
+      "id": "article-9",
+      "title": "Hurricanes hunt finisher as contracting window opens",
+      "link": "https://www.theage.com.au/sport/cricket/hurricanes-marquee-targets-20240219-p5f30a.html",
+      "pubDate": "2024-02-19T10:00:00.000Z",
+      "content": "Hobart Hurricanes zero in on overseas finisher options while canvassing a local quick via trade.",
+      "source": "The Age",
+      "category": "BBL",
+      "imageUrl": "https://images.theage.com.au/hurricanes-coach.jpg",
+      "topics": ["big-bash-retool"],
+      "eventSlug": "hurricanes-targets",
+      "sentiment": "neutral",
+      "momentumScore": 47
     },
     {
       "id": "article-10",
-      "title": "Fact-checkers push back on ad claims about migrant spending",
-      "link": "https://example.com/fact-check",
-      "pubDate": "2024-09-26T09:00:00.000Z",
-      "content": "Independent fact-checkers say the numbers are exaggerated, but the campaign doubles down in response videos.",
-      "source": "AP",
-      "category": "Fact Check",
-      "imageUrl": "https://images.example.com/fact-check.jpg",
-      "topics": ["issue-messaging", "legal-battles"],
-      "eventSlug": "immigration-ad-blitz",
-      "sentiment": "negative",
-      "momentumScore": 48
-    },
-    {
-      "id": "article-11",
-      "title": "Debate prep memo outlines foreign policy attacks",
-      "link": "https://example.com/debate-memo",
-      "pubDate": "2024-09-29T13:55:00.000Z",
-      "content": "Leaked slides suggest a focus on Afghanistan, arguing Biden cannot handle crises abroad.",
-      "source": "Bloomberg",
-      "category": "Debate",
-      "imageUrl": "https://images.example.com/debate-prep.jpg",
-      "topics": ["issue-messaging", "legal-battles"],
-      "eventSlug": "debate-prep-messaging",
+      "title": "Fans asked to vote on WBBL festival rounds",
+      "link": "https://www.cricket.com.au/news/wbbl-festival-rounds-survey/",
+      "pubDate": "2024-02-20T07:30:00.000Z",
+      "content": "Cricket Australia surveys supporters on potential regional festival weekends in Launceston and Cairns.",
+      "source": "cricket.com.au",
+      "category": "WBBL",
+      "imageUrl": "https://images.cricket.com.au/wbbl-fans.jpg",
+      "topics": ["big-bash-retool", "wncl-championship"],
+      "eventSlug": "festival-round-pilot",
       "sentiment": "positive",
-      "momentumScore": 57
+      "momentumScore": 50
     }
   ]
 }

--- a/src/index.html
+++ b/src/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="utf-8">
-  <title>TrumpTracker</title>
+  <title>Aussie Cricket Pulse</title>
   <base href="/">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="icon" type="image/x-icon" href="favicon.ico">

--- a/trump47-tracker/README.md
+++ b/trump47-tracker/README.md
@@ -1,4 +1,4 @@
-# Trump47Tracker
+# AussieCricketPulse Legacy Shell
 
 This project was generated with [Angular CLI](https://github.com/angular/angular-cli) version 18.0.3.
 

--- a/trump47-tracker/src/index.html
+++ b/trump47-tracker/src/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="utf-8">
-  <title>Trump47Tracker</title>
+  <title>AussieCricketPulse</title>
   <base href="/">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="icon" type="image/x-icon" href="favicon.ico">


### PR DESCRIPTION
## Summary
- Rebrand the header, shell, and footer to the Aussie Cricket Pulse identity with refreshed navigation and calls to action
- Replace dashboard, events, issues, and fan hub content with Australian cricket metrics, fixtures, and engagement paths
- Update datasets, backend news queries, and project metadata to target Australian cricket coverage

## Testing
- `npm run test -- --watch=false --browsers=ChromeHeadless` *(fails: ChromeHeadless binary missing in container)*

------
https://chatgpt.com/codex/tasks/task_e_68eab9a7cbb08326a89a77ffd6a73e50