### PR TITLE
Rebrand site for Australian cricket coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# TrumpTracker
+# AussieCricketPulse
 
 This project was generated with [Angular CLI](https://github.com/angular/angular-cli) version 18.0.3.
 

--- a/server/data/news-topics.json
+++ b/server/data/news-topics.json
@@ -1,295 +1,281 @@
 {
-  "lastUpdated": "2024-09-30T18:30:00.000Z",
+  "lastUpdated": "2024-11-10T08:00:00.000Z",
   "topics": [
     {
-      "slug": "legal-battles",
-      "title": "Legal Battles and Court Strategy",
-      "summary": "Tracking how Trump's campaign weaponizes ongoing court fights to energize supporters and drive fundraising.",
-      "curatedCopy": "## Courtroom vs. Campaign\nThe campaign treats every filing and hearing as a two-for-one opportunity: legal defense by day, campaign rallying cry by night. Fundraising texts reference each development within minutes, and surrogates translate legal jargon into a persecution narrative built for cable hits.\n\n### Messaging pillars\n- Portray restrictions as election interference.\n- Tie prosecutors to Democratic leaders by name.\n- Pledge to overhaul the justice system on day one.",
+      "slug": "international-season",
+      "title": "Australian International Summer",
+      "summary": "Tracking squads, injuries, and momentum as Australia hosts India and Pakistan across formats.",
+      "curatedCopy": "## Summer storyline\nAustralia opens the Border-Gavaskar Trophy under lights in Perth before a quick-turnaround ODI series. Selectors are balancing Shield form, player workloads, and an expanded bowling group ahead of the New Zealand tour.\n\n### What we're watching\n- Mitchell Marsh's captaincy cadence with Cummins rotating.\n- Cameron Green's Shield form compared to Matt Renshaw and Marcus Harris.\n- How Alyssa Healy's return shapes dual men's and women's Test preparations.",
       "callouts": [
         {
           "title": "Why it matters",
-          "markdown": "- Legal updates regularly spike small-dollar donations.\n- Base voters cite legal fights as proof the movement is under attack."
+          "markdown": "- India arrive with a near full-strength attack, demanding fresh plans for Australian batters.\n- Dual men's and women's Tests at Optus Stadium require careful pitch preparation and squad balance."
         },
         {
-          "title": "Watch the calendar",
-          "markdown": "Sentencing and pre-trial hearings align with key fundraising deadlines, giving the campaign recurring content moments."
+          "title": "Injury watch",
+          "markdown": "Mitchell Starc is being managed through groin soreness while Ellyse Perry completes modified training after back spasms."
         }
       ],
-      "spotlightIds": ["article-1"],
+      "spotlightIds": ["story-1"],
       "momentumSeries": [
-        { "date": "2024-09-18", "value": 38 },
-        { "date": "2024-09-22", "value": 47 },
-        { "date": "2024-09-25", "value": 56 },
-        { "date": "2024-09-27", "value": 59 },
-        { "date": "2024-09-30", "value": 61 }
+        { "date": "2024-11-02", "value": 45 },
+        { "date": "2024-11-05", "value": 52 },
+        { "date": "2024-11-07", "value": 58 },
+        { "date": "2024-11-09", "value": 63 },
+        { "date": "2024-11-10", "value": 67 }
       ],
       "events": [
         {
-          "slug": "georgia-ruling",
-          "title": "Georgia racketeering ruling resets the clock",
-          "date": "2024-09-23T10:00:00.000Z",
-          "description": "A Fulton County judge delays proceedings into 2025. The campaign frames the pause as proof the case is collapsing and uses the reprieve to claim momentum in swing states.",
-          "momentum": 58,
-          "relatedItemIds": ["article-1", "article-2"]
+          "slug": "perth-test-squad",
+          "title": "Australia confirms Perth Test squad",
+          "date": "2024-11-04T00:00:00.000Z",
+          "description": "Selectors back Marcus Harris to open with Khawaja while Cameron Green is earmarked for No. 4 after blistering Shield form.",
+          "momentum": 61,
+          "relatedItemIds": ["story-1", "story-2"]
         },
         {
-          "slug": "gag-order-fight",
-          "title": "New York gag order fight becomes a censorship narrative",
-          "date": "2024-09-27T18:00:00.000Z",
-          "description": "Surrogates argue that limits on Trump's speech are an attack on supporters, driving sympathetic coverage and op-eds from allies.",
-          "momentum": 62,
-          "relatedItemIds": ["article-3"]
-        },
-        {
-          "slug": "immunity-appeal",
-          "title": "Supreme Court appeal teasers revive immunity storyline",
-          "date": "2024-09-29T14:30:00.000Z",
-          "description": "Campaign lawyers preview new filings that they say will shield Trump from future prosecutions, reinforcing the promise of a second-term crackdown on DOJ critics.",
+          "slug": "healy-return",
+          "title": "Healy cleared for day-night Test",
+          "date": "2024-11-07T08:30:00.000Z",
+          "description": "Alyssa Healy passes fitness tests to lead the Southern Stars, freeing Phoebe Litchfield to bat in her preferred role.",
           "momentum": 64,
-          "relatedItemIds": ["article-4"]
+          "relatedItemIds": ["story-3"]
+        },
+        {
+          "slug": "gabba-odi-shift",
+          "title": "Gabba ODI moved to twilight slot",
+          "date": "2024-11-09T05:15:00.000Z",
+          "description": "Cricket Australia adjusts start times to maximise prime-time coverage after ticket demand surges above 35,000.",
+          "momentum": 66,
+          "relatedItemIds": ["story-4"]
         }
       ]
     },
     {
-      "slug": "ground-game",
-      "title": "Swing-State Ground Game",
-      "summary": "Field organizing pushes in the Rust Belt and Sun Belt aimed at closing the early-vote gap.",
-      "curatedCopy": "## Organizing Infrastructure\nField staff are leaning on county GOP offices, faith leaders, and a revived \"Trump Force 47\" volunteer portal. The campaign highlights door-knocking stats at every rally to signal professionalization while maintaining the outsider vibe.\n\n### Key tactics\n1. Overlapping bus tours in Pennsylvania, Michigan, and Georgia.\n2. Micro-targeted radio ads focused on energy costs and border security.\n3. Faith outreach breakfasts that double as data collection events.",
+      "slug": "big-bash-leagues",
+      "title": "Big Bash League Watch",
+      "summary": "Roster shuffles, draft picks, and tactical tweaks as BBL|14 and WBBL|10 hit full stride.",
+      "curatedCopy": "## League pulse\nClubs are finalising marquee signings while trialling rule tweaks in practice matches. Expect more power-surge gambles, floating finishers, and aggressive use of local replacement players as international windows tighten.\n\n### Key talking points\n1. Brisbane Heat prioritising pace depth with Spencer Johnson on managed loads.\n2. Melbourne Stars banking on Glenn Maxwell's fitness and a rookie wicketkeeper rotation.\n3. Sydney Sixers launching community hubs alongside every home game.",
       "callouts": [
         {
-          "title": "Staffing snapshot",
-          "markdown": "- 48 paid staffers announced across four battleground states.\n- County captains recruited from 2020 stop-the-steal networks."
+          "title": "Fan experience",
+          "markdown": "Member upgrades now include behind-the-scenes streaming from changerooms and mic'd-up warm-ups."
         }
       ],
-      "spotlightIds": ["article-5"],
+      "spotlightIds": ["story-5"],
       "momentumSeries": [
-        { "date": "2024-09-18", "value": 32 },
-        { "date": "2024-09-22", "value": 36 },
-        { "date": "2024-09-25", "value": 40 },
-        { "date": "2024-09-27", "value": 44 },
-        { "date": "2024-09-30", "value": 49 }
+        { "date": "2024-11-01", "value": 38 },
+        { "date": "2024-11-04", "value": 44 },
+        { "date": "2024-11-07", "value": 49 },
+        { "date": "2024-11-09", "value": 53 },
+        { "date": "2024-11-10", "value": 57 }
       ],
       "events": [
         {
-          "slug": "pennsylvania-field-offices",
-          "title": "Six new Pennsylvania field offices open ahead of mail voting",
-          "date": "2024-09-24T15:00:00.000Z",
-          "description": "Campaign claims 8,000 volunteers signed up after the openings, using live streams from each ribbon cutting.",
-          "momentum": 46,
-          "relatedItemIds": ["article-5", "article-6"]
+          "slug": "heat-open-training",
+          "title": "Heat open training draws 5,000 fans",
+          "date": "2024-11-05T23:00:00.000Z",
+          "description": "Brisbane Heat unveil their fearless blueprint with live-streamed power surge simulations and junior clinics.",
+          "momentum": 55,
+          "relatedItemIds": ["story-5"]
         },
         {
-          "slug": "rural-bus-tour",
-          "title": "Rural bus tour spotlights energy message",
-          "date": "2024-09-26T20:00:00.000Z",
-          "description": "Surrogates barnstorm rural Ohio and Michigan touting drilling permits and farmers' fuel costs, capturing local TV coverage.",
+          "slug": "stars-keeper-plan",
+          "title": "Stars confirm dual-keeper tactic",
+          "date": "2024-11-08T06:00:00.000Z",
+          "description": "Melbourne Stars rotate young wicketkeepers for specific matchups, freeing Glenn Maxwell for outfield duties.",
+          "momentum": 56,
+          "relatedItemIds": ["story-6"]
+        },
+        {
+          "slug": "sixers-community-hub",
+          "title": "Sixers launch pink community hub",
+          "date": "2024-11-09T09:30:00.000Z",
+          "description": "Game-day village at the SCG features women in sport panels, accessible seating upgrades, and pop-up clinics.",
+          "momentum": 58,
+          "relatedItemIds": ["story-7"]
+        }
+      ]
+    },
+    {
+      "slug": "domestic-pathways",
+      "title": "Domestic Pathways & Grassroots",
+      "summary": "Sheffield Shield, WNCL, and Premier Cricket performances fuelling the next wave of national call-ups.",
+      "curatedCopy": "## Development watch\nPathway coaches highlight how Premier Cricket and National Championships inform rookie contracts. Technology from the National Cricket Centre is filtering down through state hubs, giving analysts richer data on emerging talent.\n\n### Spotlight programs\n- Woolworths Cricket Blast expanding to remote communities.\n- National under-19 tournament streamed in high definition for the first time.\n- Hybrid turf wicket trials in the Northern Territory to extend playing seasons.",
+      "callouts": [
+        {
+          "title": "Talent radar",
+          "markdown": "Leg-spinner Emily Smith (WA) and quick Tom Straker (SA) named as Academy priority picks after standout performances."
+        }
+      ],
+      "spotlightIds": ["story-8"],
+      "momentumSeries": [
+        { "date": "2024-11-02", "value": 34 },
+        { "date": "2024-11-05", "value": 39 },
+        { "date": "2024-11-07", "value": 43 },
+        { "date": "2024-11-09", "value": 47 },
+        { "date": "2024-11-10", "value": 51 }
+      ],
+      "events": [
+        {
+          "slug": "shield-marathon",
+          "title": "Shield marathon in Adelaide lights up selectors",
+          "date": "2024-11-06T04:00:00.000Z",
+          "description": "Queensland and SA share honours in a day-night epic showcasing quick prospects topping 145kph.",
           "momentum": 48,
-          "relatedItemIds": ["article-7"]
+          "relatedItemIds": ["story-8", "story-9"]
         },
         {
-          "slug": "latino-faith-outreach",
-          "title": "Latino faith outreach adds bilingual voter guides",
-          "date": "2024-09-28T17:00:00.000Z",
-          "description": "Church partnerships distribute Spanish-language voter packets, part of a broader move to chip into Biden's coalition.",
-          "momentum": 50,
-          "relatedItemIds": ["article-8"]
-        }
-      ]
-    },
-    {
-      "slug": "issue-messaging",
-      "title": "Issue Messaging & Narrative Testing",
-      "summary": "Rapid-response talking points on immigration, inflation, and foreign policy tested across conservative media.",
-      "curatedCopy": "## Narrative Testing\nCampaign pollsters feed nightly findings into surrogate briefings. Messaging pivots quickly to keep the news cycle on favorable terrain, often marrying immigration with inflation to hold focus.\n\n#### Channels\n- Late-night Truth Social posts.\n- Podcast blitzes hosted by allied influencers.\n- Geo-targeted pre-roll ads that shift by state.",
-      "callouts": [
-        {
-          "title": "Rapid-response cadence",
-          "markdown": "Clip packages are cut within 45 minutes of any major Biden gaffe and sent to a 2,000-person surrogate list."
-        }
-      ],
-      "spotlightIds": ["article-9"],
-      "momentumSeries": [
-        { "date": "2024-09-18", "value": 41 },
-        { "date": "2024-09-22", "value": 43 },
-        { "date": "2024-09-25", "value": 47 },
-        { "date": "2024-09-27", "value": 52 },
-        { "date": "2024-09-30", "value": 55 }
-      ],
-      "events": [
-        {
-          "slug": "immigration-ad-blitz",
-          "title": "Immigration ad blitz ties border to inflation",
-          "date": "2024-09-25T12:00:00.000Z",
-          "description": "A wave of digital ads claims rising grocery prices stem from federal spending on migrants, a talking point echoed by surrogates on radio.",
-          "momentum": 53,
-          "relatedItemIds": ["article-9", "article-10"]
-        },
-        {
-          "slug": "debate-prep-messaging",
-          "title": "Debate prep memos leak to conservative outlets",
-          "date": "2024-09-29T11:00:00.000Z",
-          "description": "Selective leaks preview attacks on Biden's foreign policy, keeping the focus on Afghanistan while framing Trump as steady on world affairs.",
-          "momentum": 57,
-          "relatedItemIds": ["article-11"]
+          "slug": "club-grants-round",
+          "title": "Club grants fund hybrid wickets",
+          "date": "2024-11-08T01:00:00.000Z",
+          "description": "Northern Territory clubs secure infrastructure upgrades to extend dry-season playing windows.",
+          "momentum": 49,
+          "relatedItemIds": ["story-10"]
         }
       ]
     }
   ],
   "items": [
     {
-      "id": "article-1",
-      "title": "Trump campaign blasts Georgia prosecutors after trial delay",
-      "link": "https://example.com/trump-georgia-delay",
-      "pubDate": "2024-09-23T15:45:00.000Z",
-      "content": "Senior aides told reporters the delay proves the case is political, urging supporters to donate to \"finish the fight\".",
-      "source": "Politico",
-      "category": "Legal",
-      "imageUrl": "https://images.example.com/trump-court.jpg",
-      "topics": ["legal-battles"],
-      "eventSlug": "georgia-ruling",
+      "id": "story-1",
+      "title": "Marcus Harris gets nod for Perth Test opener",
+      "link": "https://www.cricket.com.au/news/marcus-harris-australia-test-squad-india-perth-selection/2024-11-04",
+      "pubDate": "2024-11-04T02:30:00.000Z",
+      "content": "Selectors stick with Harris alongside Khawaja while hinting at a flexible middle order for the pink-ball Test.",
+      "source": "cricket.com.au",
+      "category": "International",
+      "imageUrl": "https://images.cricket.com.au/marcus-harris-selection.jpg",
+      "topics": ["international-season"],
+      "eventSlug": "perth-test-squad",
       "sentiment": "positive",
-      "momentumScore": 58
+      "momentumScore": 61
     },
     {
-      "id": "article-2",
-      "title": "Fundraising text blitz follows Georgia ruling",
-      "link": "https://example.com/fundraising-texts",
-      "pubDate": "2024-09-24T02:30:00.000Z",
-      "content": "Within hours of the judge's order, the campaign sent seven fundraising texts referencing \"witch hunt delays\".",
-      "source": "Axios",
-      "category": "Campaign Finance",
-      "imageUrl": "https://images.example.com/text-blitz.jpg",
-      "topics": ["legal-battles", "ground-game"],
-      "eventSlug": "georgia-ruling",
+      "id": "story-2",
+      "title": "Cameron Green ton heaps pressure on incumbents",
+      "link": "https://www.espncricinfo.com/story/cameron-green-scores-another-shield-century-1445123",
+      "pubDate": "2024-11-05T07:45:00.000Z",
+      "content": "Green's unbeaten 142 for WA adds weight to calls for a middle-order reshuffle ahead of India.",
+      "source": "ESPNcricinfo",
+      "category": "Domestic",
+      "imageUrl": "https://img.espncricinfo.com/green-century.jpg",
+      "topics": ["international-season", "domestic-pathways"],
+      "eventSlug": "perth-test-squad",
       "sentiment": "positive",
-      "momentumScore": 57
+      "momentumScore": 60
     },
     {
-      "id": "article-3",
-      "title": "Trump allies decry gag order on conservative media",
-      "link": "https://example.com/gag-order-response",
-      "pubDate": "2024-09-27T22:10:00.000Z",
-      "content": "Surrogates lined up on talk radio to argue that the gag order is really aimed at silencing supporters.",
-      "source": "Fox News",
-      "category": "Media",
-      "imageUrl": "https://images.example.com/gag-order.jpg",
-      "topics": ["legal-battles", "issue-messaging"],
-      "eventSlug": "gag-order-fight",
-      "sentiment": "positive",
-      "momentumScore": 62
-    },
-    {
-      "id": "article-4",
-      "title": "Campaign previews Supreme Court immunity appeal",
-      "link": "https://example.com/immunity-appeal",
-      "pubDate": "2024-09-29T16:05:00.000Z",
-      "content": "Advisers say a conservative majority will rein in the Department of Justice, promising day-one reforms.",
-      "source": "Wall Street Journal",
-      "category": "Legal",
-      "imageUrl": "https://images.example.com/supreme-court.jpg",
-      "topics": ["legal-battles", "issue-messaging"],
-      "eventSlug": "immunity-appeal",
+      "id": "story-3",
+      "title": "Healy declares herself ready for pink-ball Test",
+      "link": "https://www.cricket.com.au/news/alyssa-healy-injury-update-day-night-test-australia-india/2024-11-07",
+      "pubDate": "2024-11-07T10:15:00.000Z",
+      "content": "Captain confirms she will keep wicket after completing running loads at the National Cricket Centre.",
+      "source": "cricket.com.au",
+      "category": "International",
+      "imageUrl": "https://images.cricket.com.au/alyssa-healy-return.jpg",
+      "topics": ["international-season"],
+      "eventSlug": "healy-return",
       "sentiment": "positive",
       "momentumScore": 64
     },
     {
-      "id": "article-5",
-      "title": "Trump opens six field offices across Pennsylvania",
-      "link": "https://example.com/pennsylvania-field",
-      "pubDate": "2024-09-24T18:30:00.000Z",
-      "content": "Ribbon cuttings featured local lawmakers and targeted messages about energy prices.",
-      "source": "Philadelphia Inquirer",
-      "category": "Ground Game",
-      "imageUrl": "https://images.example.com/field-office.jpg",
-      "topics": ["ground-game"],
-      "eventSlug": "pennsylvania-field-offices",
-      "sentiment": "positive",
-      "momentumScore": 46
-    },
-    {
-      "id": "article-6",
-      "title": "Volunteer sign-ups surge after field office blitz",
-      "link": "https://example.com/volunteer-surge",
-      "pubDate": "2024-09-25T14:20:00.000Z",
-      "content": "Campaign claims 8,000 new volunteers, though Democrats dispute the number.",
-      "source": "NBC News",
-      "category": "Ground Game",
-      "imageUrl": "https://images.example.com/volunteers.jpg",
-      "topics": ["ground-game"],
-      "eventSlug": "pennsylvania-field-offices",
+      "id": "story-4",
+      "title": "Gabba ODI rescheduled to twilight slot",
+      "link": "https://www.smh.com.au/sport/cricket/gabba-odi-moved-to-prime-time-after-ticket-rush-20241109-p5jw1f.html",
+      "pubDate": "2024-11-09T06:20:00.000Z",
+      "content": "Cricket Australia adjusts start times to maximise broadcast reach after crowd demand surpasses expectations.",
+      "source": "Sydney Morning Herald",
+      "category": "International",
+      "imageUrl": "https://static.smh.com.au/images/gabba-twilight.jpg",
+      "topics": ["international-season"],
+      "eventSlug": "gabba-odi-shift",
       "sentiment": "neutral",
-      "momentumScore": 44
+      "momentumScore": 58
     },
     {
-      "id": "article-7",
-      "title": "Rural bus tour amplifies energy message",
-      "link": "https://example.com/rural-bus",
-      "pubDate": "2024-09-26T22:40:00.000Z",
-      "content": "The bus tour stops at small-town diners with local radio hits about drilling and inflation.",
-      "source": "Cleveland Plain Dealer",
-      "category": "Ground Game",
-      "imageUrl": "https://images.example.com/bus-tour.jpg",
-      "topics": ["ground-game", "issue-messaging"],
-      "eventSlug": "rural-bus-tour",
-      "sentiment": "positive",
-      "momentumScore": 48
-    },
-    {
-      "id": "article-8",
-      "title": "Latino pastors partner with Trump team on voter guides",
-      "link": "https://example.com/latino-voter-guides",
-      "pubDate": "2024-09-28T19:15:00.000Z",
-      "content": "Spanish-language voter packets are distributed alongside food drives in Phoenix and Orlando.",
-      "source": "Univision",
-      "category": "Outreach",
-      "imageUrl": "https://images.example.com/latino-outreach.jpg",
-      "topics": ["ground-game"],
-      "eventSlug": "latino-faith-outreach",
-      "sentiment": "positive",
-      "momentumScore": 50
-    },
-    {
-      "id": "article-9",
-      "title": "Immigration ad blitz links border to inflation",
-      "link": "https://example.com/immigration-ads",
-      "pubDate": "2024-09-25T13:10:00.000Z",
-      "content": "Ads feature grocery carts and Border Patrol footage, testing a new hybrid message.",
-      "source": "Washington Post",
-      "category": "Advertising",
-      "imageUrl": "https://images.example.com/immigration-ads.jpg",
-      "topics": ["issue-messaging"],
-      "eventSlug": "immigration-ad-blitz",
-      "sentiment": "positive",
-      "momentumScore": 53
-    },
-    {
-      "id": "article-10",
-      "title": "Fact-checkers push back on ad claims about migrant spending",
-      "link": "https://example.com/fact-check",
-      "pubDate": "2024-09-26T09:00:00.000Z",
-      "content": "Independent fact-checkers say the numbers are exaggerated, but the campaign doubles down in response videos.",
-      "source": "AP",
-      "category": "Fact Check",
-      "imageUrl": "https://images.example.com/fact-check.jpg",
-      "topics": ["issue-messaging", "legal-battles"],
-      "eventSlug": "immigration-ad-blitz",
-      "sentiment": "negative",
-      "momentumScore": 48
-    },
-    {
-      "id": "article-11",
-      "title": "Debate prep memo outlines foreign policy attacks",
-      "link": "https://example.com/debate-memo",
-      "pubDate": "2024-09-29T13:55:00.000Z",
-      "content": "Leaked slides suggest a focus on Afghanistan, arguing Biden cannot handle crises abroad.",
-      "source": "Bloomberg",
-      "category": "Debate",
-      "imageUrl": "https://images.example.com/debate-prep.jpg",
-      "topics": ["issue-messaging", "legal-battles"],
-      "eventSlug": "debate-prep-messaging",
+      "id": "story-5",
+      "title": "Heat unveil fearless brand ahead of BBL opener",
+      "link": "https://www.cricket.com.au/news/brisbane-heat-open-training-wade-seccombe-bbl14-plans/2024-11-05",
+      "pubDate": "2024-11-05T23:30:00.000Z",
+      "content": "Brisbane Heat roll out their fast-paced blueprint with open training attracting record pre-season crowds.",
+      "source": "cricket.com.au",
+      "category": "BBL",
+      "imageUrl": "https://images.cricket.com.au/heat-training.jpg",
+      "topics": ["big-bash-leagues"],
+      "eventSlug": "heat-open-training",
       "sentiment": "positive",
       "momentumScore": 57
+    },
+    {
+      "id": "story-6",
+      "title": "Stars back dual-keeper strategy for BBL|14",
+      "link": "https://www.heraldsun.com.au/sport/cricket/stars-to-rotate-keepers-in-bbl-season/news-story/",
+      "pubDate": "2024-11-08T06:05:00.000Z",
+      "content": "Coach Peter Moores reveals the Stars will alternate keepers to maximise matchups and power surge options.",
+      "source": "Herald Sun",
+      "category": "BBL",
+      "imageUrl": "https://content.heraldsun.com.au/stars-keepers.jpg",
+      "topics": ["big-bash-leagues"],
+      "eventSlug": "stars-keeper-plan",
+      "sentiment": "neutral",
+      "momentumScore": 54
+    },
+    {
+      "id": "story-7",
+      "title": "Sixers launch pink community hub at the SCG",
+      "link": "https://www.sydneysixers.com.au/news/pink-hub-launch/2024-11-09",
+      "pubDate": "2024-11-09T09:45:00.000Z",
+      "content": "New match-day precinct features women in sport panels, sensory spaces, and inclusive seating upgrades.",
+      "source": "Sydney Sixers",
+      "category": "BBL",
+      "imageUrl": "https://www.sydneysixers.com.au/media/pink-hub.jpg",
+      "topics": ["big-bash-leagues", "domestic-pathways"],
+      "eventSlug": "sixers-community-hub",
+      "sentiment": "positive",
+      "momentumScore": 56
+    },
+    {
+      "id": "story-8",
+      "title": "Shield day-nighter showcases new quicks",
+      "link": "https://www.abc.net.au/news/2024-11-06/sheffield-shield-day-night-adelaide-pace-prospects/",
+      "pubDate": "2024-11-06T05:10:00.000Z",
+      "content": "Rising pacemen Tom Straker and Liam Haskett headline a gripping draw that boosts their national credentials.",
+      "source": "ABC News",
+      "category": "Domestic",
+      "imageUrl": "https://live-production.wcms.abc-cdn.net.au/sheffield-shield-night.jpg",
+      "topics": ["domestic-pathways", "international-season"],
+      "eventSlug": "shield-marathon",
+      "sentiment": "positive",
+      "momentumScore": 52
+    },
+    {
+      "id": "story-9",
+      "title": "National Championships stream hits record viewers",
+      "link": "https://www.cricket.com.au/news/national-championships-streaming-records-youth-prospects/2024-11-07",
+      "pubDate": "2024-11-07T03:40:00.000Z",
+      "content": "High-definition coverage of the under-19 nationals draws scouts and fans, highlighting prospects from every state.",
+      "source": "cricket.com.au",
+      "category": "Pathways",
+      "imageUrl": "https://images.cricket.com.au/u19-stream.jpg",
+      "topics": ["domestic-pathways"],
+      "eventSlug": "shield-marathon",
+      "sentiment": "positive",
+      "momentumScore": 49
+    },
+    {
+      "id": "story-10",
+      "title": "Hybrid wicket trials funded across the NT",
+      "link": "https://www.playcricket.com.au/community/news/hybrid-wickets-northern-territory-grants",
+      "pubDate": "2024-11-08T01:20:00.000Z",
+      "content": "Grassroots clubs secure grants to install hybrid surfaces, extending the season and reducing maintenance costs.",
+      "source": "PlayCricket",
+      "category": "Community",
+      "imageUrl": "https://www.playcricket.com.au/media/hybrid-wickets.jpg",
+      "topics": ["domestic-pathways"],
+      "eventSlug": "club-grants-round",
+      "sentiment": "positive",
+      "momentumScore": 48
     }
   ]
 }

--- a/server/src/news/news.service.ts
+++ b/server/src/news/news.service.ts
@@ -107,9 +107,9 @@ export class NewsService {
   }
 
   private async fetchReddit(): Promise<NewsItemDto[]> {
-    const subredditQuery = 'politics+news+worldnews';
+    const subredditQuery = 'Cricket+CricketWorldCup+BigBashLeague';
     const searchParams = new URLSearchParams({
-      q: 'trump 2024 campaign',
+      q: '"Australia" AND cricket',
       restrict_sr: '1',
       sort: 'new',
       limit: '100'
@@ -147,7 +147,7 @@ export class NewsService {
     }
 
     const params = new URLSearchParams({
-      q: 'Trump AND (campaign OR election OR 2024)',
+      q: '(Australia AND cricket) OR "Big Bash League"',
       language: 'en',
       sortBy: 'publishedAt',
       apiKey
@@ -182,7 +182,7 @@ export class NewsService {
     }
 
     const params = new URLSearchParams({
-      q: 'Trump presidential campaign 2024',
+      q: 'Australia cricket',
       sort: 'newest',
       'api-key': apiKey
     });
@@ -247,7 +247,7 @@ export class NewsService {
   private async safeFetch(url: string, source: string): Promise<Response> {
     const response = await fetch(url, {
       headers: {
-        'User-Agent': '47presangular-news-aggregator/1.0'
+        'User-Agent': 'aussie-cricket-pulse/1.0'
       }
     });
 

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -12,20 +12,19 @@ class ExperimentServiceStub {
 
 class ReferralServiceStub {
   getReferralCode(): string {
-    return 'T47-TEST';
+    return 'ACP-TEST';
   }
 }
 
 describe('AppComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [AppComponent]
       imports: [AppComponent],
-      providers: [provideRouter([])]
       providers: [
+        provideRouter([]),
         { provide: ExperimentService, useClass: ExperimentServiceStub },
-        { provide: ReferralService, useClass: ReferralServiceStub },
-      ],
+        { provide: ReferralService, useClass: ReferralServiceStub }
+      ]
     }).compileComponents();
   });
 
@@ -35,11 +34,10 @@ describe('AppComponent', () => {
     expect(app).toBeTruthy();
   });
 
-  it('should have the campaign tracker title', () => {
-  it('should have the tracker title', () => {
+  it('should expose the site title', () => {
     const fixture = TestBed.createComponent(AppComponent);
     const app = fixture.componentInstance;
-    expect(app.title).toEqual('Trump 47 Campaign Tracker');
+    expect(app.title).toEqual('Aussie Cricket Pulse');
   });
 
   it('should render a skip link for accessibility', () => {
@@ -47,11 +45,12 @@ describe('AppComponent', () => {
     fixture.detectChanges();
     const compiled = fixture.nativeElement as HTMLElement;
     expect(compiled.querySelector('.skip-link')?.textContent?.trim()).toBe('Skip to main content');
-  it('should render the layout header title', () => {
+  });
+
+  it('should render the brand in the shell header', () => {
     const fixture = TestBed.createComponent(AppComponent);
     fixture.detectChanges();
     const compiled = fixture.nativeElement as HTMLElement;
-    expect(compiled.querySelector('h1')?.textContent).toContain('Trump 47 Campaign Tracker');
-    expect(compiled.querySelector('.brand')?.textContent).toContain('Trump 47 Campaign Tracker');
+    expect(compiled.querySelector('.shell__title')?.textContent).toContain('Aussie Cricket Pulse');
   });
 });

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -8,4 +8,6 @@ import { ShellComponent } from './layout/shell/shell.component';
   templateUrl: './app.component.html',
   styleUrls: ['./app.component.scss']
 })
-export class AppComponent {}
+export class AppComponent {
+  readonly title = 'Aussie Cricket Pulse';
+}

--- a/src/app/components/community/community.component.html
+++ b/src/app/components/community/community.component.html
@@ -1,7 +1,7 @@
 <section class="community" aria-labelledby="community-title">
   <header>
-    <h1 id="community-title">Community War Room</h1>
-    <p>Official forums plus the best conversations from Reddit, all moderated for actionability.</p>
+    <h1 id="community-title">Fan discussion board</h1>
+    <p>Official forums plus the sharpest conversations from around the cricket community.</p>
   </header>
 
   <div class="thread-grid">

--- a/src/app/components/community/community.component.ts
+++ b/src/app/components/community/community.component.ts
@@ -7,7 +7,7 @@ interface CommunityThread {
   description: string;
   link: string;
   platform: 'reddit' | 'official';
-  moderationLevel: 'community' | 'campaign';
+  moderationLevel: 'community' | 'editorial';
 }
 
 @Component({
@@ -20,25 +20,25 @@ interface CommunityThread {
 export class CommunityComponent {
   readonly featuredThreads: CommunityThread[] = [
     {
-      title: 'Strategy AMA with campaign leadership',
-      description: 'Bring your questions for the digital, field, and finance directors. Moderated by the official campaign team.',
-      link: 'https://community.trump47.com/threads/strategy-ama',
-      platform: 'official',
-      moderationLevel: 'campaign',
-    },
-    {
-      title: 'Grassroots organizing toolkit',
-      description: 'Volunteer leaders share the scripts and materials that are working in their counties.',
-      link: 'https://www.reddit.com/r/Conservative/comments/toolkit',
+      title: 'Selection chat: Who opens in Perth?',
+      description: 'Fans debate whether Harris or Renshaw should partner Khawaja in the first Test against India.',
+      link: 'https://www.reddit.com/r/Cricket/comments/selection_chat_first_test_openers/',
       platform: 'reddit',
       moderationLevel: 'community',
     },
     {
-      title: 'Digital rapid response room',
-      description: 'Coordinate social media pushes in real time. Official moderators surface priority narratives.',
-      link: 'https://community.trump47.com/threads/digital-war-room',
+      title: 'Coach forum: WBBL tactics live session',
+      description: 'Brisbane Heat staff share powerplay plans and invite junior coaches to ask questions.',
+      link: 'https://www.cricket.com.au/news/wbbl-coaching-forum-registration/2024-11-05',
       platform: 'official',
-      moderationLevel: 'campaign',
+      moderationLevel: 'editorial',
+    },
+    {
+      title: 'Grassroots grants AMA',
+      description: 'Cricket Australia participation managers outline funding options for clubs upgrading facilities.',
+      link: 'https://www.playcricket.com.au/community/news/club-grants-ama',
+      platform: 'official',
+      moderationLevel: 'editorial',
     },
   ];
 

--- a/src/app/components/engagement-banner/engagement-banner.component.html
+++ b/src/app/components/engagement-banner/engagement-banner.component.html
@@ -1,8 +1,9 @@
-<section class="engagement-banner" aria-label="Campaign engagement actions">
+<section class="engagement-banner" aria-label="Cricket engagement actions">
   <div class="copy">
-    <h2>Power the movement</h2>
+    <h2>Support the game</h2>
     <p>
-      Chip in or jump on a volunteer shift. Every action is synced with HubSpot and NGP VAN so field directors can follow up instantly.
+      Grab seats for the next blockbuster or connect with a club in your area. Every click keeps you close to the heart of
+      Australian cricket.
     </p>
   </div>
 

--- a/src/app/components/featured-stories/featured-stories.component.html
+++ b/src/app/components/featured-stories/featured-stories.component.html
@@ -1,7 +1,7 @@
 <section class="featured-stories" aria-labelledby="featured-heading" id="stories">
   <div class="featured-stories__header">
     <h2 id="featured-heading">Featured stories</h2>
-    <p class="featured-stories__description">Curated highlights from the campaign trail.</p>
+    <p class="featured-stories__description">Curated highlights from across Australian cricket.</p>
   </div>
 
   <ul class="featured-stories__list">

--- a/src/app/components/featured-stories/featured-stories.component.ts
+++ b/src/app/components/featured-stories/featured-stories.component.ts
@@ -19,22 +19,22 @@ type FeaturedStory = {
 export class FeaturedStoriesComponent {
   readonly stories: FeaturedStory[] = [
     {
-      title: 'Ground Game Intensifies in Swing States',
-      excerpt: 'Organizers ramp up door-to-door outreach in Pennsylvania and Arizona as polling margins tighten.',
-      topic: 'Field Operations',
-      url: 'https://www.donaldjtrump.com/news/'
+      title: 'Marsh steadies Australia in Brisbane day-night Test',
+      excerpt: 'The stand-in skipper produced an unbeaten 96 to guide Australia past Pakistan under lights at the Gabba.',
+      topic: 'International',
+      url: 'https://www.cricket.com.au/news/mitchell-marsh-australia-pakistan-gabba-test-highlights/2024-11-08'
     },
     {
-      title: 'Fundraising Push Sets New Monthly Record',
-      excerpt: 'Digital campaigns and grassroots donations combine for a historic funding surge across small-dollar donors.',
-      topic: 'Fundraising',
-      url: 'https://www.donaldjtrump.com/news/'
+      title: 'Heat unveil fearless brand ahead of BBL|14 opener',
+      excerpt: 'Coach Wade Seccombe explains the aggressive blueprint built around young quicks and power hitters.',
+      topic: 'BBL',
+      url: 'https://www.cricket.com.au/news/brisbane-heat-big-bash-league-season-preview-wade-seccombe/2024-11-06'
     },
     {
-      title: 'Policy Rollout Focuses on Energy Independence',
-      excerpt: 'The campaign outlines a renewed strategy for domestic energy production aimed at lowering costs for families.',
-      topic: 'Policy',
-      url: 'https://www.donaldjtrump.com/news/'
+      title: 'WNCL pipeline delivering stars for Southern Stars',
+      excerpt: 'National selectors outline how domestic standouts Phoebe Litchfield and Tess Flintoff forced their way in.',
+      topic: 'Pathways',
+      url: 'https://www.espncricinfo.com/story/how-australia-s-domestic-cricket-is-powering-the-women-s-team-1423897'
     }
   ];
 }

--- a/src/app/components/insights-sidebar/insights-sidebar.component.ts
+++ b/src/app/components/insights-sidebar/insights-sidebar.component.ts
@@ -19,28 +19,28 @@ type Insight = {
 export class InsightsSidebarComponent {
   readonly insights: Insight[] = [
     {
-      label: 'Digital reach',
-      value: '2.1M',
+      label: 'Home summer form',
+      value: '3-0',
       trend: 'up',
-      description: 'Impressions across official channels in the last 48 hours'
+      description: 'Men’s ODI and T20 series wins to start the season'
     },
     {
-      label: 'Grassroots events',
-      value: '38',
+      label: 'BBL run rate',
+      value: '8.6',
+      trend: 'up',
+      description: 'League-wide scoring rate through week three'
+    },
+    {
+      label: 'WBBL attendance',
+      value: '41K',
       trend: 'steady',
-      description: 'Scheduled rallies and town halls this week'
-    },
-    {
-      label: 'Volunteer signups',
-      value: '+14%',
-      trend: 'up',
-      description: 'Week-over-week increase in new volunteers'
+      description: 'Fans through the gates across the most recent round'
     }
   ];
 
   readonly keyActions: string[] = [
-    'Track upcoming debate preparation milestones',
-    'Highlight localized policy rollouts for supporters',
-    'Coordinate regional press availability with rapid response team'
+    'Track Marsh Cup ladder movement each weekend',
+    'Monitor selection whispers ahead of the Perth Test',
+    'Spotlight junior nationals prospects pushing for contracts'
   ];
 }

--- a/src/app/components/news-feed/news-feed.component.html
+++ b/src/app/components/news-feed/news-feed.component.html
@@ -1,6 +1,6 @@
 <div class="news-feed" role="region" aria-labelledby="news-feed-heading">
   <header>
-    <h1 id="news-feed-heading">Trump 2024 Campaign News</h1>
+    <h1 id="news-feed-heading">Australian Cricket News &amp; Analysis</h1>
 
     <div class="controls">
       <div class="filters" role="search">

--- a/src/app/components/news-item/news-item.component.html
+++ b/src/app/components/news-item/news-item.component.html
@@ -36,7 +36,7 @@
       <a
         [routerLink]="detailRoute"
         class="view-story"
-        [attr.aria-label]="'Read campaign context for: ' + item.title"
+        [attr.aria-label]="'Read extended coverage for: ' + item.title"
       >
         View story
       </a>
@@ -45,9 +45,9 @@
         target="_blank"
         rel="noopener noreferrer"
         class="read-more"
-        [attr.aria-label]="'Read full post on Reddit: ' + item.title"
+        [attr.aria-label]="'Open original article: ' + item.title"
       >
-        <span>Read on Reddit</span>
+        <span>Read full article</span>
         <svg
           xmlns="http://www.w3.org/2000/svg"
           width="16"
@@ -66,7 +66,7 @@
       </a>
 
       <div class="share">
-        <span>Amplify:</span>
+        <span>Share:</span>
         <a
           *ngFor="let share of shareLinks"
           class="share-link"

--- a/src/app/components/news-item/news-item.component.ts
+++ b/src/app/components/news-item/news-item.component.ts
@@ -53,7 +53,7 @@ export class NewsItemComponent {
     const params = {
       source: 'news_card',
       medium: 'social_share',
-      campaign: 'news_distribution',
+      initiative: 'news_distribution',
       content: this.item.id,
       referralCode
     } as const;

--- a/src/app/components/shell/shell.component.html
+++ b/src/app/components/shell/shell.component.html
@@ -2,10 +2,10 @@
 <div class="shell">
   <header class="shell__header" role="banner">
     <div class="shell__branding">
-      <span class="shell__logo" aria-hidden="true">47</span>
+      <span class="shell__logo" aria-hidden="true">AC</span>
       <div>
-        <p class="shell__title">Trump 47 Campaign Tracker</p>
-        <p class="shell__subtitle">Real-time updates from across the campaign trail</p>
+        <p class="shell__title">Aussie Cricket Pulse</p>
+        <p class="shell__subtitle">Live coverage of Australian cricket across every level</p>
       </div>
     </div>
 
@@ -39,31 +39,31 @@
           [routerLinkActiveOptions]="{ exact: true }"
           [attr.aria-current]="rla.isActive ? 'page' : null"
         >
-          Campaign Feed
+          Latest coverage
         </a>
       </li>
       <li>
-        <a href="#insights">Insights</a>
+        <a href="#insights">Form guide</a>
       </li>
       <li>
-        <a href="#stories">Featured stories</a>
+        <a href="#stories">Feature reads</a>
       </li>
     </ul>
   </nav>
 
   <main id="main-content" class="shell__main" role="main" tabindex="-1">
-    <div class="shell__grid" aria-label="Campaign dashboard layout">
-      <section class="shell__content" aria-labelledby="campaign-feed-heading">
-        <h2 id="campaign-feed-heading" class="visually-hidden">Campaign news feed</h2>
+    <div class="shell__grid" aria-label="Cricket coverage layout">
+      <section class="shell__content" aria-labelledby="cricket-feed-heading">
+        <h2 id="cricket-feed-heading" class="visually-hidden">Australian cricket news feed</h2>
         <router-outlet></router-outlet>
       </section>
-      <app-featured-stories class="shell__featured"></app-featured-stories>
-      <app-insights-sidebar class="shell__insights"></app-insights-sidebar>
+      <app-featured-stories class="shell__featured" id="stories"></app-featured-stories>
+      <app-insights-sidebar class="shell__insights" id="insights"></app-insights-sidebar>
     </div>
   </main>
 
   <footer class="shell__footer" role="contentinfo">
-    <p>Built for accessibility and real-time insight into the 2024 campaign.</p>
-    <a class="footer__feedback" href="mailto:feedback@trump47tracker.com">Share feedback</a>
+    <p>Built for accessibility and deep insight into Australian cricket.</p>
+    <a class="footer__feedback" href="mailto:hello&#64;aussiecricketpulse.com">Share feedback</a>
   </footer>
 </div>

--- a/src/app/components/story/story-detail/story-detail.component.html
+++ b/src/app/components/story/story-detail/story-detail.component.html
@@ -1,6 +1,6 @@
 <section class="story-detail" *ngIf="!loading && story; else loadingOrError">
   <nav class="breadcrumb">
-    <a routerLink="/" aria-label="Back to campaign news">← Back to news feed</a>
+    <a routerLink="/" aria-label="Back to cricket news">← Back to news feed</a>
   </nav>
 
   <header class="story-header">
@@ -17,7 +17,7 @@
       target="_blank"
       rel="noopener noreferrer"
     >
-      Read on Reddit
+      Read full article
     </a>
   </header>
 

--- a/src/app/components/story/story-detail/story-detail.component.ts
+++ b/src/app/components/story/story-detail/story-detail.component.ts
@@ -72,7 +72,7 @@ export class StoryDetailComponent implements OnInit, OnDestroy {
 
   private updateMeta(detail: StoryDetail): void {
     const summary = detail.summary?.[0] ?? detail.content;
-    const pageTitle = `${detail.title} | Trump 47 Campaign Tracker`;
+    const pageTitle = `${detail.title} | Aussie Cricket Pulse`;
 
     this.title.setTitle(pageTitle);
     this.meta.updateTag({ name: 'description', content: summary });

--- a/src/app/layout/components/footer/layout-footer.component.html
+++ b/src/app/layout/components/footer/layout-footer.component.html
@@ -1,6 +1,6 @@
 <footer class="footer">
   <div class="footer__inner">
-    <p>&copy; {{ updated | date:'yyyy' }} Trump 47 Campaign Tracker. Data aggregated from national outlets.</p>
-    <a href="/media" class="footer__cta" routerLink="/media">Explore campaign media</a>
+    <p>&copy; {{ updated | date:'yyyy' }} Aussie Cricket Pulse. Data aggregated from trusted cricket outlets.</p>
+    <a href="/media" class="footer__cta" routerLink="/media">Watch latest highlights</a>
   </div>
 </footer>

--- a/src/app/layout/components/header/layout-header.component.ts
+++ b/src/app/layout/components/header/layout-header.component.ts
@@ -6,6 +6,6 @@ import { Component } from '@angular/core';
   styleUrls: ['./layout-header.component.scss']
 })
 export class LayoutHeaderComponent {
-  readonly title = 'Trump 47 Campaign Tracker';
-  readonly subtitle = 'Real-time intelligence on the 2024 campaign trail';
+  readonly title = 'Aussie Cricket Pulse';
+  readonly subtitle = 'Real-time intelligence for every level of Australian cricket';
 }

--- a/src/app/layout/components/hero-metrics/hero-metrics.component.html
+++ b/src/app/layout/components/hero-metrics/hero-metrics.component.html
@@ -7,8 +7,8 @@
 
   <ng-template #emptyState>
     <div class="hero__headline">
-      <p class="hero__eyebrow">Campaign insights</p>
-      <h2 class="hero__title">Tracking breaking news, policy shifts, and campaign moments</h2>
+      <p class="hero__eyebrow">Cricket insights</p>
+      <h2 class="hero__title">Tracking breaking news, squad moves, and form lines</h2>
     </div>
   </ng-template>
 
@@ -30,7 +30,7 @@
     </article>
 
     <article class="metric" *ngIf="metrics.trendingIssues.length">
-      <h3 class="metric__value">Trending issues</h3>
+      <h3 class="metric__value">Trending topics</h3>
       <ul class="metric__list">
         <li *ngFor="let issue of metrics.trendingIssues">{{ issue | titlecase }}</li>
       </ul>

--- a/src/app/layout/footer/footer.component.html
+++ b/src/app/layout/footer/footer.component.html
@@ -1,8 +1,8 @@
 <footer class="site-footer" role="contentinfo">
   <div class="site-footer__inner">
     <div class="site-footer__brand">
-      <p class="site-footer__title">Trump 47 Campaign Tracker</p>
-      <p class="site-footer__tagline">Monitoring news, policy, and movement energy on the road to November.</p>
+      <p class="site-footer__title">Aussie Cricket Pulse</p>
+      <p class="site-footer__tagline">Daily news, stats, and community stories across Australian cricket.</p>
     </div>
     <nav class="site-footer__nav" aria-label="Footer">
       <ul>
@@ -13,7 +13,7 @@
     </nav>
   </div>
   <div class="site-footer__meta">
-    <p>&copy; {{ currentYear }} Grassroots Briefing Collective.</p>
-    <a href="mailto:tips&#64;campaigntracker.org">tips&#64;campaigntracker.org</a>
+    <p>&copy; {{ currentYear }} Aussie Cricket Pulse.</p>
+    <a href="mailto:hello&#64;aussiecricketpulse.com">hello&#64;aussiecricketpulse.com</a>
   </div>
 </footer>

--- a/src/app/layout/header/header.component.html
+++ b/src/app/layout/header/header.component.html
@@ -1,11 +1,11 @@
 <header class="site-header" role="banner">
   <div class="site-header__inner">
     <div class="site-header__branding">
-      <a class="site-header__logo" routerLink="/news" aria-label="Trump 47 Tracker home">
-        <span class="site-header__logo-mark" aria-hidden="true">47</span>
+      <a class="site-header__logo" routerLink="/news" aria-label="Aussie Cricket Pulse home">
+        <span class="site-header__logo-mark" aria-hidden="true">AC</span>
         <span class="site-header__logo-text">
-          <span class="site-header__logo-primary">Trump 47</span>
-          <span class="site-header__logo-secondary">Campaign Tracker</span>
+          <span class="site-header__logo-primary">Aussie Cricket</span>
+          <span class="site-header__logo-secondary">Pulse</span>
         </span>
       </a>
     </div>
@@ -20,11 +20,11 @@
         </li>
         <li class="primary-nav__item primary-nav__item--mega">
           <button class="primary-nav__link mega-trigger" type="button" aria-haspopup="true"
-            [attr.aria-expanded]="megaMenuOpen" aria-controls="issues-mega" (click)="toggleMegaMenu()">
-            Issues
+            [attr.aria-expanded]="megaMenuOpen" aria-controls="leagues-mega" (click)="toggleMegaMenu()">
+            Leagues &amp; Squads
             <span class="chevron" [class.is-open]="megaMenuOpen" aria-hidden="true"></span>
           </button>
-          <div id="issues-mega" class="mega-menu" [class.is-open]="megaMenuOpen" [attr.aria-hidden]="!megaMenuOpen">
+          <div id="leagues-mega" class="mega-menu" [class.is-open]="megaMenuOpen" [attr.aria-hidden]="!megaMenuOpen">
             <div class="mega-menu__inner">
               <div class="mega-menu__section" *ngFor="let section of megaMenuSections">
                 <p class="mega-menu__heading">{{ section.heading }}</p>
@@ -44,7 +44,7 @@
     </nav>
 
     <div class="site-header__actions">
-      <div class="cta-list" role="group" aria-label="Campaign calls to action">
+      <div class="cta-list" role="group" aria-label="Featured cricket resources">
         <a *ngFor="let cta of ctas" class="cta" [ngClass]="'cta--' + cta.style" [href]="cta.href" target="_blank"
           rel="noopener noreferrer">
           <span class="cta__label">{{ cta.label }}</span>
@@ -76,7 +76,7 @@
           <li *ngFor="let link of navLinks">
             <a [routerLink]="link.route" routerLinkActive="is-active" (click)="closeMobileMenu()">{{ link.label }}</a>
           </li>
-          <li class="mobile-drawer__section-label">Issues</li>
+          <li class="mobile-drawer__section-label">Leagues &amp; squads</li>
           <li class="mobile-drawer__mega" *ngFor="let section of megaMenuSections">
             <p class="mobile-drawer__heading">{{ section.heading }}</p>
             <ul>
@@ -90,7 +90,7 @@
           </li>
         </ul>
       </nav>
-      <div class="mobile-drawer__ctas" role="group" aria-label="Campaign calls to action">
+      <div class="mobile-drawer__ctas" role="group" aria-label="Featured cricket resources">
         <a *ngFor="let cta of ctas" class="cta" [ngClass]="'cta--' + cta.style" [href]="cta.href" target="_blank"
           rel="noopener noreferrer">
           <span class="cta__label">{{ cta.label }}</span>

--- a/src/app/layout/header/header.component.ts
+++ b/src/app/layout/header/header.component.ts
@@ -38,61 +38,61 @@ export class HeaderComponent {
   megaMenuOpen = false;
 
   readonly navLinks: NavLink[] = [
-    { label: 'News', route: '/news' },
-    { label: 'Dashboard', route: '/dashboard' },
-    { label: 'Events', route: '/events' },
-    { label: 'Get Involved', route: '/get-involved' }
+    { label: 'Latest News', route: '/news' },
+    { label: 'Match Centre', route: '/dashboard' },
+    { label: 'Fixtures', route: '/events' },
+    { label: 'Fan Hub', route: '/get-involved' }
   ];
 
   readonly megaMenuSections: MegaMenuSection[] = [
     {
-      heading: 'Top Priorities',
+      heading: 'National Teams',
       items: [
         {
-          label: 'Economic Agenda',
-          description: 'Jobs, inflation, and trade policy priorities.',
+          label: "Men's Internationals",
+          description: 'Test, ODI, and T20 squads, selections, and injury updates.',
           route: '/issues',
-          fragment: 'economy'
+          fragment: 'mens-australia'
         },
         {
-          label: 'Border & Security',
-          description: 'Immigration, national defense, and public safety.',
+          label: "Women's Internationals",
+          description: 'Southern Stars touring news, selection calls, and form guide.',
           route: '/issues',
-          fragment: 'security'
+          fragment: 'womens-australia'
         }
       ]
     },
     {
-      heading: 'Policy Pillars',
+      heading: 'Domestic Leagues',
       items: [
         {
-          label: 'Healthcare & Social',
-          description: 'Healthcare access, veteran services, and family support.',
+          label: 'Big Bash League',
+          description: 'BBL and WBBL squad moves, draft coverage, and marquee moments.',
           route: '/issues',
-          fragment: 'healthcare'
+          fragment: 'big-bash'
         },
         {
-          label: 'Election Integrity',
-          description: 'Voting reforms and oversight initiatives.',
+          label: 'Sheffield Shield & Marsh Cup',
+          description: 'Red-ball form lines and one-day ladder implications for selectors.',
           route: '/issues',
-          fragment: 'elections'
+          fragment: 'sheffield-shield'
         }
       ]
     },
     {
-      heading: 'Movement Voices',
+      heading: 'Pathways & Community',
       items: [
         {
-          label: 'Grassroots Spotlights',
-          description: 'Community stories and volunteer organizing.',
+          label: 'Premier Cricket',
+          description: 'Club cricket standouts and NextGen prospects to keep an eye on.',
           route: '/issues',
-          fragment: 'grassroots'
+          fragment: 'premier-cricket'
         },
         {
-          label: 'Media Statements',
-          description: 'Campaign press releases and official responses.',
+          label: 'Participation & Grassroots',
+          description: 'Participation programs, community grants, and inclusion initiatives.',
           route: '/issues',
-          fragment: 'media'
+          fragment: 'community-cricket'
         }
       ]
     }
@@ -100,21 +100,21 @@ export class HeaderComponent {
 
   readonly ctas: CtaLink[] = [
     {
-      label: 'Donate',
-      description: 'Power the movement with a contribution.',
-      href: 'https://www.donaldjtrump.com/',
+      label: 'Subscribe',
+      description: 'Weekly digest direct from Aussie Cricket Pulse editors.',
+      href: 'https://www.cricket.com.au/newsletters',
       style: 'primary'
     },
     {
-      label: 'Volunteer',
-      description: 'Host events or knock doors in your community.',
-      href: 'https://www.donaldjtrump.com/join/',
+      label: 'Buy Tickets',
+      description: 'Secure seats for internationals and Big Bash blockbusters.',
+      href: 'https://www.cricket.com.au/tickets',
       style: 'outline'
     },
     {
-      label: 'Subscribe',
-      description: 'Get rapid response alerts from campaign HQ.',
-      href: 'https://www.donaldjtrump.com/subscribe/',
+      label: 'Find a Club',
+      description: 'Join a local side through the national PlayCricket directory.',
+      href: 'https://www.playcricket.com.au/club-finder',
       style: 'ghost'
     }
   ];

--- a/src/app/layout/sidebar/sidebar.component.html
+++ b/src/app/layout/sidebar/sidebar.component.html
@@ -1,25 +1,25 @@
-<aside class="campaign-sidebar" aria-labelledby="sidebar-title">
-  <div class="campaign-sidebar__section">
+<aside class="cricket-sidebar" aria-labelledby="sidebar-title">
+  <div class="cricket-sidebar__section">
     <h2 id="sidebar-title">Stay engaged</h2>
-    <p>Key actions and resources to keep the campaign momentum moving.</p>
-    <ul class="campaign-sidebar__list">
+    <p>Key actions and resources to follow Australian cricket all year long.</p>
+    <ul class="cricket-sidebar__list">
       <li *ngFor="let cta of takeActionCtas">
-        <a class="campaign-sidebar__card" [href]="cta.href" target="_blank" rel="noopener noreferrer"
+        <a class="cricket-sidebar__card" [href]="cta.href" target="_blank" rel="noopener noreferrer"
           [attr.aria-label]="cta.ariaLabel">
-          <span class="campaign-sidebar__card-label">{{ cta.label }}</span>
-          <span class="campaign-sidebar__card-description">{{ cta.description }}</span>
+          <span class="cricket-sidebar__card-label">{{ cta.label }}</span>
+          <span class="cricket-sidebar__card-description">{{ cta.description }}</span>
         </a>
       </li>
     </ul>
   </div>
-  <div class="campaign-sidebar__section">
+  <div class="cricket-sidebar__section">
     <h3>Additional resources</h3>
-    <ul class="campaign-sidebar__list campaign-sidebar__list--compact">
+    <ul class="cricket-sidebar__list cricket-sidebar__list--compact">
       <li *ngFor="let link of resourceLinks">
-        <a class="campaign-sidebar__link" [href]="link.href" target="_blank" rel="noopener noreferrer"
+        <a class="cricket-sidebar__link" [href]="link.href" target="_blank" rel="noopener noreferrer"
           [attr.aria-label]="link.ariaLabel">
-          <span class="campaign-sidebar__card-label">{{ link.label }}</span>
-          <span class="campaign-sidebar__card-description">{{ link.description }}</span>
+          <span class="cricket-sidebar__card-label">{{ link.label }}</span>
+          <span class="cricket-sidebar__card-description">{{ link.description }}</span>
         </a>
       </li>
     </ul>

--- a/src/app/layout/sidebar/sidebar.component.scss
+++ b/src/app/layout/sidebar/sidebar.component.scss
@@ -1,7 +1,7 @@
 @use '../../shared/styles/tokens';
 @use '../../shared/styles/mixins';
 
-.campaign-sidebar {
+.cricket-sidebar {
   position: sticky;
   top: var(--space-9);
   display: grid;
@@ -61,7 +61,7 @@
 }
 
 @include mixins.respond('lg') {
-  .campaign-sidebar {
+  .cricket-sidebar {
     position: static;
     top: auto;
     padding: var(--space-4);
@@ -70,7 +70,7 @@
 }
 
 @include mixins.respond('md') {
-  .campaign-sidebar {
+  .cricket-sidebar {
     gap: var(--space-4);
   }
 }

--- a/src/app/layout/sidebar/sidebar.component.ts
+++ b/src/app/layout/sidebar/sidebar.component.ts
@@ -18,37 +18,37 @@ interface SidebarCta {
 export class SidebarComponent {
   readonly takeActionCtas: SidebarCta[] = [
     {
-      label: 'Chip in $20.24',
-      description: 'Donate to accelerate key battleground operations.',
-      href: 'https://www.donaldjtrump.com/',
-      ariaLabel: 'Donate twenty dollars and twenty four cents'
+      label: 'Stream the action',
+      description: 'Watch internationals and Big Bash via Kayo Sports or Foxtel.',
+      href: 'https://help.kayosports.com.au/s/article/Where-can-I-watch-Cricket-Australia',
+      ariaLabel: 'Find where to stream Australian cricket'
     },
     {
-      label: 'Become a Captain',
-      description: 'Lead local volunteer teams and coordinate canvasses.',
-      href: 'https://www.donaldjtrump.com/join/',
-      ariaLabel: 'Sign up to become a neighborhood captain'
+      label: 'Ticket hub',
+      description: 'Secure seats for internationals, WBBL, and domestic finals.',
+      href: 'https://www.cricket.com.au/tickets',
+      ariaLabel: 'Open the Cricket Australia ticket hub'
     },
     {
-      label: 'Rapid Response List',
-      description: 'Get SMS alerts for breaking news and key votes.',
-      href: 'https://www.donaldjtrump.com/subscribe/',
-      ariaLabel: 'Subscribe to the Trump rapid response list'
+      label: 'Join a local club',
+      description: 'Use PlayCricket to discover junior and senior clubs near you.',
+      href: 'https://www.playcricket.com.au/club-finder',
+      ariaLabel: 'Find a local cricket club via PlayCricket'
     }
   ];
 
   readonly resourceLinks: SidebarCta[] = [
     {
-      label: 'State Leadership',
-      description: 'Find your state director and field staff.',
-      href: 'https://www.donaldjtrump.com/states/',
-      ariaLabel: 'Explore state leadership contacts'
+      label: 'Domestic ladders',
+      description: 'Follow Sheffield Shield, WNCL, and Premier Cricket tables.',
+      href: 'https://www.cricket.com.au/matches/domestic',
+      ariaLabel: 'View domestic cricket ladders'
     },
     {
-      label: 'Events Calendar',
-      description: 'See rallies, town halls, and digital events near you.',
-      href: 'https://www.donaldjtrump.com/events/',
-      ariaLabel: 'Open the campaign events calendar'
+      label: 'High Performance Centre',
+      description: 'Insights from the National Cricket Centre and pathway squads.',
+      href: 'https://www.cricket.com.au/high-performance',
+      ariaLabel: 'Learn about Cricket Australia high performance programs'
     }
   ];
 }

--- a/src/app/pages/dashboard/dashboard.component.html
+++ b/src/app/pages/dashboard/dashboard.component.html
@@ -1,9 +1,9 @@
 <section class="dashboard" aria-labelledby="dashboard-heading">
   <header class="dashboard__header">
-    <p class="dashboard__eyebrow">Campaign intelligence</p>
-    <h1 id="dashboard-heading">Tracker dashboard</h1>
+    <p class="dashboard__eyebrow">Form radar</p>
+    <h1 id="dashboard-heading">Cricket performance dashboard</h1>
     <p class="dashboard__lede">
-      Real-time organizing metrics and earned media snapshots to keep rapid response teams aligned.
+      Quick-glance stats for international squads and headline domestic competitions so you never miss a momentum swing.
     </p>
   </header>
   <div class="dashboard__metrics" role="list">
@@ -15,18 +15,18 @@
   </div>
   <section class="dashboard__updates" aria-label="Latest updates">
     <article class="dashboard__card">
-      <h2>War room brief</h2>
+      <h2>Selector notebook</h2>
       <p>
-        State directors report strong volunteer sign-ups following the Phoenix town hall. Digital ads are
-        outperforming benchmarks in Wisconsin and Pennsylvania.
+        National selectors are tracking Cameron Green’s Shield run glut and Alyssa Healy’s return from a calf tweak ahead of the
+        Perth Test double-header.
       </p>
     </article>
     <article class="dashboard__card">
-      <h2>Field priorities</h2>
+      <h2>Domestic focus</h2>
       <ul>
-        <li>Expand Hispanic media buys in Las Vegas and Miami.</li>
-        <li>Coordinate door-to-door weekend of action with national surrogates.</li>
-        <li>Drive early vote education in Sun Belt metros.</li>
+        <li>WNCL pace stocks surge with Maitlan Brown clocking 130kph in Canberra.</li>
+        <li>Heat and Sixers trial rookie keepers during BBL practice matches.</li>
+        <li>Victoria’s Premier Cricket T20 finals live-streamed statewide this weekend.</li>
       </ul>
     </article>
   </section>

--- a/src/app/pages/dashboard/dashboard.component.ts
+++ b/src/app/pages/dashboard/dashboard.component.ts
@@ -11,19 +11,19 @@ import { CommonModule } from '@angular/common';
 export class DashboardComponent {
   readonly metrics = [
     {
-      label: 'Battleground events this week',
-      value: 18,
-      change: '+4 vs. last week'
+      label: 'International wins this summer',
+      value: '6',
+      change: '+2 vs. same time last year'
     },
     {
-      label: 'Grassroots captains onboarded',
-      value: 312,
-      change: '+28 in the last 24 hours'
+      label: 'BBL strike-rate leaders',
+      value: '3',
+      change: 'All averaging 170+ SR'
     },
     {
-      label: 'Digital impressions YTD',
-      value: '47M',
-      change: '+8% month over month'
+      label: 'Premier Cricket live streams',
+      value: '12',
+      change: '+4 new broadcasts this week'
     }
   ];
 }

--- a/src/app/pages/events/events.component.html
+++ b/src/app/pages/events/events.component.html
@@ -1,8 +1,8 @@
 <section class="events" aria-labelledby="events-heading">
   <header class="events__intro">
-    <p class="events__eyebrow">On the road</p>
-    <h1 id="events-heading">Upcoming events</h1>
-    <p>Find campaign stops and grassroots meetups to plug into the movement.</p>
+    <p class="events__eyebrow">On the calendar</p>
+    <h1 id="events-heading">Upcoming fixtures &amp; fan events</h1>
+    <p>Lock in the biggest matches and supporter meet-ups across Australia.</p>
   </header>
   <div class="events__list" role="list">
     <article class="events__card" role="listitem" *ngFor="let event of events">
@@ -10,7 +10,7 @@
       <h2>{{ event.title }}</h2>
       <p class="events__location">{{ event.location }}</p>
       <p>{{ event.description }}</p>
-      <a class="events__cta" [href]="event.rsvpUrl" target="_blank" rel="noopener noreferrer">RSVP &rsaquo;</a>
+      <a class="events__cta" [href]="event.rsvpUrl" target="_blank" rel="noopener noreferrer">Details &rsaquo;</a>
     </article>
   </div>
 </section>

--- a/src/app/pages/events/events.component.ts
+++ b/src/app/pages/events/events.component.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 import { CommonModule } from '@angular/common';
 
-interface CampaignEvent {
+interface CricketEvent {
   title: string;
   location: string;
   date: string;
@@ -17,27 +17,27 @@ interface CampaignEvent {
   styleUrls: ['./events.component.scss']
 })
 export class EventsComponent {
-  readonly events: CampaignEvent[] = [
+  readonly events: CricketEvent[] = [
     {
-      title: 'Rust Belt Jobs Rally',
-      location: 'Erie, Pennsylvania',
-      date: 'June 22, 2024',
-      description: 'Manufacturing workers and small business owners share testimonies on economic revival.',
-      rsvpUrl: 'https://www.donaldjtrump.com/events/'
+      title: 'NRMA Insurance Test – Australia v India (Perth)',
+      location: 'Optus Stadium, Perth',
+      date: '25–29 November 2024',
+      description: 'Day-night opener of the Border-Gavaskar Trophy with fan zones and junior coaching clinics on the outer.',
+      rsvpUrl: 'https://www.cricket.com.au/tickets'
     },
     {
-      title: 'Border Security Town Hall',
-      location: 'Yuma, Arizona',
-      date: 'June 24, 2024',
-      description: 'Policy roundtable featuring sheriffs, border agents, and Angel families.',
-      rsvpUrl: 'https://www.donaldjtrump.com/events/'
+      title: 'WBBL Semi-Final Fan Night',
+      location: 'North Sydney Oval, Sydney',
+      date: '4 December 2024',
+      description: 'Meet the players, collect autographs, and enjoy live music before the knockout begins.',
+      rsvpUrl: 'https://www.cricket.com.au/news/wbbl-finals-hub/2024-10-31'
     },
     {
-      title: 'Faith & Freedom Summit',
-      location: 'Greenville, South Carolina',
-      date: 'June 27, 2024',
-      description: 'Pastors, faith leaders, and youth ministries coordinating voter outreach.',
-      rsvpUrl: 'https://www.donaldjtrump.com/events/'
+      title: 'Big Bash League Opening Weekend Live Site',
+      location: 'King George Square, Brisbane',
+      date: '7–8 December 2024',
+      description: 'Free entry fan zone with big screens, player Q&amp;As, and junior skills sessions hosted by Queensland Cricket.',
+      rsvpUrl: 'https://www.brisbaneheat.com.au/fans'
     }
   ];
 }

--- a/src/app/pages/get-involved/get-involved.component.html
+++ b/src/app/pages/get-involved/get-involved.component.html
@@ -1,8 +1,8 @@
 <section class="get-involved" aria-labelledby="get-involved-heading">
   <header class="get-involved__intro">
-    <p class="get-involved__eyebrow">Take action</p>
-    <h1 id="get-involved-heading">Get involved today</h1>
-    <p>Choose a pathway to contribute your time, talent, or resources to the movement.</p>
+    <p class="get-involved__eyebrow">Join in</p>
+    <h1 id="get-involved-heading">Get involved with Australian cricket</h1>
+    <p>Choose a pathway to support the game, develop skills, or volunteer in your community.</p>
   </header>
   <div class="get-involved__grid">
     <article class="get-involved__card" *ngFor="let step of steps">
@@ -13,8 +13,8 @@
   </div>
   <section class="get-involved__newsletter" aria-label="Newsletter signup">
     <h2>Stay informed</h2>
-    <p>Subscribe to get the daily briefing and volunteer opportunities in your inbox.</p>
-    <form class="get-involved__form" aria-label="Subscribe to campaign updates" (submit)="onSubmit($event)" novalidate>
+    <p>Subscribe for our weekly digest featuring squads, ladder updates, and grassroots success stories.</p>
+    <form class="get-involved__form" aria-label="Subscribe to Aussie Cricket Pulse updates" (submit)="onSubmit($event)" novalidate>
       <label class="visually-hidden" for="newsletter-email">Email address</label>
       <input id="newsletter-email" type="email" placeholder="you@example.com" required />
       <button type="submit">Subscribe</button>

--- a/src/app/pages/get-involved/get-involved.component.ts
+++ b/src/app/pages/get-involved/get-involved.component.ts
@@ -17,19 +17,19 @@ interface ActionStep {
 export class GetInvolvedComponent {
   readonly steps: ActionStep[] = [
     {
-      title: 'Join the grassroots team',
-      description: 'Become a neighborhood captain to coordinate phone banks and canvasses.',
-      link: 'https://www.donaldjtrump.com/join/'
+      title: 'Volunteer at community cricket',
+      description: 'Register with your state association to coach, score, or help run match days.',
+      link: 'https://www.playcricket.com.au/clubs/volunteers'
     },
     {
-      title: 'Host a house meeting',
-      description: 'Download our toolkit and invite supporters for a rapid response briefing.',
-      link: 'https://www.donaldjtrump.com/get-involved/'
+      title: 'Umpiring & scoring pathway',
+      description: 'Complete online accreditation and join the roster for local and Premier Cricket fixtures.',
+      link: 'https://www.cricketaustralia.com.au/umpiring'
     },
     {
-      title: 'Digital rapid responders',
-      description: 'Amplify campaign messaging with social media share kits and daily talking points.',
-      link: 'https://www.donaldjtrump.com/subscribe/'
+      title: 'High performance newsletter',
+      description: 'Get high performance updates, training resources, and talent ID opportunities.',
+      link: 'https://www.cricket.com.au/newsletters'
     }
   ];
 

--- a/src/app/pages/issues/issues.component.html
+++ b/src/app/pages/issues/issues.component.html
@@ -1,9 +1,9 @@
 <section class="issues" aria-labelledby="issues-heading">
   <header class="issues__intro">
-    <p class="issues__eyebrow">Policy agenda</p>
-    <h1 id="issues-heading">Where the campaign is focused</h1>
+    <p class="issues__eyebrow">Deep dives</p>
+    <h1 id="issues-heading">Where Australian cricket is focused</h1>
     <p class="issues__lede">
-      Explore core priorities shaping the movement and dive into highlight reels pulled from the campaign trail.
+      Explore the leagues, squads, and programs shaping the summer — from national teams to grassroots development.
     </p>
   </header>
   <div class="issues__grid">

--- a/src/app/pages/issues/issues.component.ts
+++ b/src/app/pages/issues/issues.component.ts
@@ -18,63 +18,63 @@ interface IssueSection {
 export class IssuesComponent {
   readonly sections: IssueSection[] = [
     {
-      id: 'economy',
-      title: 'Economy first agenda',
-      summary: 'Tax relief for working families, energy dominance, and small business expansion.',
+      id: 'mens-australia',
+      title: "Men's national team",
+      summary: 'Test, ODI, and T20 squads juggling a packed summer and overseas tours.',
       bullets: [
-        'Pledge to extend middle-class tax cuts and expand opportunity zones.',
-        'Reinvest in American energy with new drilling permits and refining capacity.',
-        'Launch apprenticeship partnerships with community colleges.'
+        'Usman Khawaja leads the Test top order with selectors weighing Marsh Cup form for the final batting spot.',
+        'Pat Cummins managing workloads with rotation plans for the India and New Zealand series.',
+        'White-ball squad refreshing middle-order options ahead of the 2025 Champions Trophy.'
       ]
     },
     {
-      id: 'security',
-      title: 'Border & national security',
-      summary: 'Finish the wall, restore remain-in-Mexico, and boost law enforcement resources.',
+      id: 'womens-australia',
+      title: "Women’s national team",
+      summary: 'The Southern Stars balance a dominant home schedule with global franchise commitments.',
       bullets: [
-        'Deploy additional border agents and accelerate asylum processing reforms.',
-        'Block fentanyl trafficking with new technology at ports of entry.',
-        'Back the blue with federal support for local task forces.'
+        'Meg Lanning mentoring emerging leaders while Alyssa Healy returns from injury.',
+        'Spin depth led by Ash Gardner and Alana King with WBBL form dictating selections.',
+        'Expanded tour of India creating chances for WNCL standouts to debut.'
       ]
     },
     {
-      id: 'healthcare',
-      title: 'Healthcare & social supports',
-      summary: 'Lower costs, protect seniors, and expand rural care access.',
+      id: 'big-bash',
+      title: 'Big Bash League spotlight',
+      summary: 'BBL|14 and WBBL|10 innovate with power surge tactics and local wildcard rules.',
       bullets: [
-        'Drive price transparency across hospitals and insurers.',
-        'Expand telehealth waivers for rural clinics and veteran care.',
-        'Protect Medicare and Social Security with fiscal discipline.'
+        'Draft retentions lock in international stars while clubs chase emerging quicks.',
+        'Clubs investing in member experiences with revamped live sites and digital hubs.',
+        'New finals format ensures double-headers for both BBL and WBBL weekends.'
       ]
     },
     {
-      id: 'elections',
-      title: 'Election integrity',
-      summary: 'Secure ballots, clean voter rolls, and restore confidence in elections.',
+      id: 'sheffield-shield',
+      title: 'Sheffield Shield & Marsh Cup',
+      summary: 'Red-ball form lines continue to shape national selection narratives.',
       bullets: [
-        'Advance voter ID standards with state partners.',
-        'Invest in poll watcher training and legal rapid response teams.',
-        'Modernize election systems with paper backups and audits.'
+        'Queensland and Victoria pace stocks dominate the wickets tally through four rounds.',
+        'WA blooding young batters after back-to-back titles keeps pressure on incumbents.',
+        'Day-night Shield fixtures at Adelaide Oval used to simulate Test conditions.'
       ]
     },
     {
-      id: 'grassroots',
-      title: 'Grassroots spotlights',
-      summary: 'Stories from volunteers building the movement at the local level.',
+      id: 'premier-cricket',
+      title: 'Premier & pathway cricket',
+      summary: 'Club competitions feed talent into state squads and Cricket Australia academies.',
       bullets: [
-        'Faith coalition in Georgia registering new voters weekly.',
-        'Small business owners hosting roundtables on regulatory reform.',
-        'College chapters leading campus debate nights.'
+        'Premier T20 competitions streaming weekly with enhanced analytics for scouts.',
+        'National Championships in Adelaide showcase next generation quicks topping 140kph.',
+        'State rookie contracts linked to community coaching and ambassador roles.'
       ]
     },
     {
-      id: 'media',
-      title: 'Media statements',
-      summary: 'Official campaign messaging and fact checks in response to breaking news.',
+      id: 'community-cricket',
+      title: 'Community & participation',
+      summary: 'Inclusion and growth programs expanding across metropolitan and regional hubs.',
       bullets: [
-        'Weekly talking points for surrogate interviews.',
-        'Shareable graphics for social platforms.',
-        'Rapid rebuttal briefs for newsroom outreach.'
+        'Woolworths Cricket Blast participation up 12% year-on-year nationwide.',
+        'Regional infrastructure grants funding new hybrid turf wickets in the NT.',
+        'Female leadership forums connecting club presidents and pathway mentors.'
       ]
     }
   ];

--- a/src/app/services/engagement.service.ts
+++ b/src/app/services/engagement.service.ts
@@ -2,54 +2,54 @@ import { Injectable } from '@angular/core';
 import { TrackingService, TrackingParams } from './tracking.service';
 
 export interface EngagementAction {
-  id: 'donate' | 'volunteer';
+  id: 'tickets' | 'club';
   label: string;
   description: string;
   url: string;
-  platform: 'winRed' | 'actBlue' | 'custom';
+  platform: 'cricket.com.au' | 'playcricket';
 }
 
 @Injectable({ providedIn: 'root' })
 export class EngagementService {
-  private readonly donationBaseUrl = 'https://secure.winred.com/trump47/donate';
-  private readonly volunteerBaseUrl = 'https://action.ngpvan.com/trump47/volunteer';
+  private readonly ticketBaseUrl = 'https://www.cricket.com.au/tickets';
+  private readonly clubFinderUrl = 'https://www.playcricket.com.au/club-finder';
 
   constructor(private tracking: TrackingService) {}
 
   getInlineActions(referralCode?: string): EngagementAction[] {
     return [
-      this.buildAction('donate', {
+      this.buildAction('tickets', {
         source: 'site',
         medium: 'inline_cta',
-        campaign: 'daily_engagement',
-        content: 'donation_banner',
+        initiative: 'aussie_cricket_pulse',
+        content: 'ticket_banner',
         referralCode,
       }),
-      this.buildAction('volunteer', {
+      this.buildAction('club', {
         source: 'site',
         medium: 'inline_cta',
-        campaign: 'daily_engagement',
-        content: 'volunteer_banner',
+        initiative: 'aussie_cricket_pulse',
+        content: 'club_banner',
         referralCode,
       }),
     ];
   }
 
-  private buildAction(id: 'donate' | 'volunteer', params: TrackingParams): EngagementAction {
-    const isDonate = id === 'donate';
+  private buildAction(id: EngagementAction['id'], params: TrackingParams): EngagementAction {
+    const isTicket = id === 'tickets';
     const url = this.tracking.buildTrackedUrl(
-      isDonate ? this.donationBaseUrl : this.volunteerBaseUrl,
+      isTicket ? this.ticketBaseUrl : this.clubFinderUrl,
       params
     );
 
     return {
       id,
-      label: isDonate ? 'Donate Now' : 'Volunteer Today',
-      description: isDonate
-        ? 'Fuel the ground game with a rapid contribution via WinRed-style checkout.'
-        : 'Join the field team, phone bank, or host events synced to NGP VAN.',
+      label: isTicket ? 'Buy match tickets' : 'Find a club',
+      description: isTicket
+        ? 'Reserve seats for internationals, WBBL, and Big Bash fixtures.'
+        : 'Connect with junior and senior teams across Australia.',
       url,
-      platform: isDonate ? 'winRed' : 'actBlue',
+      platform: isTicket ? 'cricket.com.au' : 'playcricket',
     };
   }
 }

--- a/src/app/services/entitlement.service.ts
+++ b/src/app/services/entitlement.service.ts
@@ -9,6 +9,7 @@ export interface EntitlementState {
 
 @Injectable({ providedIn: 'root' })
 export class EntitlementService {
+  private readonly storageKey = 'acp_entitlement';
   private readonly state$ = new BehaviorSubject<EntitlementState>({
     isAuthenticated: false,
     plan: 'free',
@@ -21,7 +22,7 @@ export class EntitlementService {
       return;
     }
 
-    const raw = localStorage.getItem('trump47_entitlement');
+    const raw = localStorage.getItem(this.storageKey);
     if (raw) {
       const parsed = JSON.parse(raw) as EntitlementState;
       if (parsed.expiresAt) {
@@ -68,6 +69,6 @@ export class EntitlementService {
     }
 
     const state = this.state$.value;
-    localStorage.setItem('trump47_entitlement', JSON.stringify(state));
+    localStorage.setItem(this.storageKey, JSON.stringify(state));
   }
 }

--- a/src/app/services/experiment.service.ts
+++ b/src/app/services/experiment.service.ts
@@ -8,7 +8,7 @@ export interface ExperimentVariant {
 
 @Injectable({ providedIn: 'root' })
 export class ExperimentService {
-  private readonly storageKeyPrefix = 'trump47_experiment_';
+  private readonly storageKeyPrefix = 'acp_experiment_';
 
   assignVariant(experimentId: string, variants: ExperimentVariant[]): ExperimentVariant {
     if (typeof window === 'undefined') {

--- a/src/app/services/news-api.service.ts
+++ b/src/app/services/news-api.service.ts
@@ -81,7 +81,7 @@ export class NewsApiService {
           .filter((event: any) => event)
           .map((event: any) => ({
             date: event.date ?? event.timestamp ?? '',
-            headline: event.headline ?? event.title ?? 'Campaign milestone',
+            headline: event.headline ?? event.title ?? 'Cricket milestone',
             description: event.description ?? event.summary
           }))
           .filter((event: TimelineEvent) => !!event.date && !!event.headline)
@@ -89,11 +89,11 @@ export class NewsApiService {
 
     return {
       id: response.id ?? response.articleId ?? '',
-      title: response.title ?? 'Campaign story',
+      title: response.title ?? 'Cricket story',
       link: response.link ?? response.url ?? '',
       pubDate: response.pubDate ? new Date(response.pubDate) : new Date(),
       content: response.content ?? response.summary ?? '',
-      source: response.source ?? response.primarySource ?? 'Campaign coverage',
+      source: response.source ?? response.primarySource ?? 'Cricket coverage',
       category: response.category,
       imageUrl: response.imageUrl ?? response.image,
       summary,

--- a/src/app/services/referral.service.ts
+++ b/src/app/services/referral.service.ts
@@ -2,11 +2,11 @@ import { Injectable } from '@angular/core';
 
 @Injectable({ providedIn: 'root' })
 export class ReferralService {
-  private readonly storageKey = 'trump47_referral_code';
+  private readonly storageKey = 'acp_referral_code';
 
   getReferralCode(): string {
     if (typeof window === 'undefined') {
-      return 'T47-OFFLINE';
+      return 'ACP-OFFLINE';
     }
 
     const existing = localStorage.getItem(this.storageKey);
@@ -14,7 +14,7 @@ export class ReferralService {
       return existing;
     }
 
-    const generated = `T47-${Math.random().toString(36).slice(2, 8).toUpperCase()}`;
+    const generated = `ACP-${Math.random().toString(36).slice(2, 8).toUpperCase()}`;
     localStorage.setItem(this.storageKey, generated);
     return generated;
   }

--- a/src/app/services/tracking.service.ts
+++ b/src/app/services/tracking.service.ts
@@ -3,7 +3,7 @@ import { Injectable } from '@angular/core';
 export interface TrackingParams {
   source: string;
   medium: string;
-  campaign: string;
+  initiative: string;
   content?: string;
   referralCode?: string;
   [key: string]: string | undefined;
@@ -11,8 +11,8 @@ export interface TrackingParams {
 
 @Injectable({ providedIn: 'root' })
 export class TrackingService {
-  private readonly hubspotPortalId = 'HUBSPOT_PORTAL_ID';
-  private readonly ngpVANCommitteeId = 'NGP_VAN_COMMITTEE_ID';
+  private readonly analyticsPartnerId = 'SPORTS_HUB_ID';
+  private readonly participationPartnerId = 'PLAYCRICKET_PARTNER_ID';
 
   buildTrackedUrl(baseUrl: string, params: TrackingParams): string {
     const url = new URL(baseUrl);
@@ -22,16 +22,16 @@ export class TrackingService {
       }
     });
 
-    // Attach CRM references so the links can be ingested downstream.
-    url.searchParams.set('hubspot_portal_id', this.hubspotPortalId);
-    url.searchParams.set('ngp_van_committee_id', this.ngpVANCommitteeId);
+    // Attach analytics references used by partner dashboards.
+    url.searchParams.set('analytics_partner_id', this.analyticsPartnerId);
+    url.searchParams.set('participation_partner_id', this.participationPartnerId);
 
     return url.toString();
   }
 
   emitEvent(eventName: string, payload: Record<string, unknown> = {}): void {
-    // In a real deployment this would forward to Google Analytics, HubSpot, and NGP VAN.
-    // For now we log to the console so the data pipeline can be validated in QA.
+    // In a real deployment this would forward to GA4, Adobe Analytics, or partner data pipelines.
+    // For now we log to the console so the instrumentation can be validated in QA environments.
     console.debug('[tracking]', eventName, payload);
   }
 }

--- a/src/assets/data/news-topics.json
+++ b/src/assets/data/news-topics.json
@@ -1,295 +1,281 @@
 {
-  "lastUpdated": "2024-09-30T18:30:00.000Z",
+  "lastUpdated": "2024-11-10T08:00:00.000Z",
   "topics": [
     {
-      "slug": "legal-battles",
-      "title": "Legal Battles and Court Strategy",
-      "summary": "Tracking how Trump's campaign weaponizes ongoing court fights to energize supporters and drive fundraising.",
-      "curatedCopy": "## Courtroom vs. Campaign\nThe campaign treats every filing and hearing as a two-for-one opportunity: legal defense by day, campaign rallying cry by night. Fundraising texts reference each development within minutes, and surrogates translate legal jargon into a persecution narrative built for cable hits.\n\n### Messaging pillars\n- Portray restrictions as election interference.\n- Tie prosecutors to Democratic leaders by name.\n- Pledge to overhaul the justice system on day one.",
+      "slug": "international-season",
+      "title": "Australian International Summer",
+      "summary": "Tracking squads, injuries, and momentum as Australia hosts India and Pakistan across formats.",
+      "curatedCopy": "## Summer storyline\nAustralia opens the Border-Gavaskar Trophy under lights in Perth before a quick-turnaround ODI series. Selectors are balancing Shield form, player workloads, and an expanded bowling group ahead of the New Zealand tour.\n\n### What we're watching\n- Mitchell Marsh's captaincy cadence with Cummins rotating.\n- Cameron Green's Shield form compared to Matt Renshaw and Marcus Harris.\n- How Alyssa Healy's return shapes dual men's and women's Test preparations.",
       "callouts": [
         {
           "title": "Why it matters",
-          "markdown": "- Legal updates regularly spike small-dollar donations.\n- Base voters cite legal fights as proof the movement is under attack."
+          "markdown": "- India arrive with a near full-strength attack, demanding fresh plans for Australian batters.\n- Dual men's and women's Tests at Optus Stadium require careful pitch preparation and squad balance."
         },
         {
-          "title": "Watch the calendar",
-          "markdown": "Sentencing and pre-trial hearings align with key fundraising deadlines, giving the campaign recurring content moments."
+          "title": "Injury watch",
+          "markdown": "Mitchell Starc is being managed through groin soreness while Ellyse Perry completes modified training after back spasms."
         }
       ],
-      "spotlightIds": ["article-1"],
+      "spotlightIds": ["story-1"],
       "momentumSeries": [
-        { "date": "2024-09-18", "value": 38 },
-        { "date": "2024-09-22", "value": 47 },
-        { "date": "2024-09-25", "value": 56 },
-        { "date": "2024-09-27", "value": 59 },
-        { "date": "2024-09-30", "value": 61 }
+        { "date": "2024-11-02", "value": 45 },
+        { "date": "2024-11-05", "value": 52 },
+        { "date": "2024-11-07", "value": 58 },
+        { "date": "2024-11-09", "value": 63 },
+        { "date": "2024-11-10", "value": 67 }
       ],
       "events": [
         {
-          "slug": "georgia-ruling",
-          "title": "Georgia racketeering ruling resets the clock",
-          "date": "2024-09-23T10:00:00.000Z",
-          "description": "A Fulton County judge delays proceedings into 2025. The campaign frames the pause as proof the case is collapsing and uses the reprieve to claim momentum in swing states.",
-          "momentum": 58,
-          "relatedItemIds": ["article-1", "article-2"]
+          "slug": "perth-test-squad",
+          "title": "Australia confirms Perth Test squad",
+          "date": "2024-11-04T00:00:00.000Z",
+          "description": "Selectors back Marcus Harris to open with Khawaja while Cameron Green is earmarked for No. 4 after blistering Shield form.",
+          "momentum": 61,
+          "relatedItemIds": ["story-1", "story-2"]
         },
         {
-          "slug": "gag-order-fight",
-          "title": "New York gag order fight becomes a censorship narrative",
-          "date": "2024-09-27T18:00:00.000Z",
-          "description": "Surrogates argue that limits on Trump's speech are an attack on supporters, driving sympathetic coverage and op-eds from allies.",
-          "momentum": 62,
-          "relatedItemIds": ["article-3"]
-        },
-        {
-          "slug": "immunity-appeal",
-          "title": "Supreme Court appeal teasers revive immunity storyline",
-          "date": "2024-09-29T14:30:00.000Z",
-          "description": "Campaign lawyers preview new filings that they say will shield Trump from future prosecutions, reinforcing the promise of a second-term crackdown on DOJ critics.",
+          "slug": "healy-return",
+          "title": "Healy cleared for day-night Test",
+          "date": "2024-11-07T08:30:00.000Z",
+          "description": "Alyssa Healy passes fitness tests to lead the Southern Stars, freeing Phoebe Litchfield to bat in her preferred role.",
           "momentum": 64,
-          "relatedItemIds": ["article-4"]
+          "relatedItemIds": ["story-3"]
+        },
+        {
+          "slug": "gabba-odi-shift",
+          "title": "Gabba ODI moved to twilight slot",
+          "date": "2024-11-09T05:15:00.000Z",
+          "description": "Cricket Australia adjusts start times to maximise prime-time coverage after ticket demand surges above 35,000.",
+          "momentum": 66,
+          "relatedItemIds": ["story-4"]
         }
       ]
     },
     {
-      "slug": "ground-game",
-      "title": "Swing-State Ground Game",
-      "summary": "Field organizing pushes in the Rust Belt and Sun Belt aimed at closing the early-vote gap.",
-      "curatedCopy": "## Organizing Infrastructure\nField staff are leaning on county GOP offices, faith leaders, and a revived \"Trump Force 47\" volunteer portal. The campaign highlights door-knocking stats at every rally to signal professionalization while maintaining the outsider vibe.\n\n### Key tactics\n1. Overlapping bus tours in Pennsylvania, Michigan, and Georgia.\n2. Micro-targeted radio ads focused on energy costs and border security.\n3. Faith outreach breakfasts that double as data collection events.",
+      "slug": "big-bash-leagues",
+      "title": "Big Bash League Watch",
+      "summary": "Roster shuffles, draft picks, and tactical tweaks as BBL|14 and WBBL|10 hit full stride.",
+      "curatedCopy": "## League pulse\nClubs are finalising marquee signings while trialling rule tweaks in practice matches. Expect more power-surge gambles, floating finishers, and aggressive use of local replacement players as international windows tighten.\n\n### Key talking points\n1. Brisbane Heat prioritising pace depth with Spencer Johnson on managed loads.\n2. Melbourne Stars banking on Glenn Maxwell's fitness and a rookie wicketkeeper rotation.\n3. Sydney Sixers launching community hubs alongside every home game.",
       "callouts": [
         {
-          "title": "Staffing snapshot",
-          "markdown": "- 48 paid staffers announced across four battleground states.\n- County captains recruited from 2020 stop-the-steal networks."
+          "title": "Fan experience",
+          "markdown": "Member upgrades now include behind-the-scenes streaming from changerooms and mic'd-up warm-ups."
         }
       ],
-      "spotlightIds": ["article-5"],
+      "spotlightIds": ["story-5"],
       "momentumSeries": [
-        { "date": "2024-09-18", "value": 32 },
-        { "date": "2024-09-22", "value": 36 },
-        { "date": "2024-09-25", "value": 40 },
-        { "date": "2024-09-27", "value": 44 },
-        { "date": "2024-09-30", "value": 49 }
+        { "date": "2024-11-01", "value": 38 },
+        { "date": "2024-11-04", "value": 44 },
+        { "date": "2024-11-07", "value": 49 },
+        { "date": "2024-11-09", "value": 53 },
+        { "date": "2024-11-10", "value": 57 }
       ],
       "events": [
         {
-          "slug": "pennsylvania-field-offices",
-          "title": "Six new Pennsylvania field offices open ahead of mail voting",
-          "date": "2024-09-24T15:00:00.000Z",
-          "description": "Campaign claims 8,000 volunteers signed up after the openings, using live streams from each ribbon cutting.",
-          "momentum": 46,
-          "relatedItemIds": ["article-5", "article-6"]
+          "slug": "heat-open-training",
+          "title": "Heat open training draws 5,000 fans",
+          "date": "2024-11-05T23:00:00.000Z",
+          "description": "Brisbane Heat unveil their fearless blueprint with live-streamed power surge simulations and junior clinics.",
+          "momentum": 55,
+          "relatedItemIds": ["story-5"]
         },
         {
-          "slug": "rural-bus-tour",
-          "title": "Rural bus tour spotlights energy message",
-          "date": "2024-09-26T20:00:00.000Z",
-          "description": "Surrogates barnstorm rural Ohio and Michigan touting drilling permits and farmers' fuel costs, capturing local TV coverage.",
+          "slug": "stars-keeper-plan",
+          "title": "Stars confirm dual-keeper tactic",
+          "date": "2024-11-08T06:00:00.000Z",
+          "description": "Melbourne Stars rotate young wicketkeepers for specific matchups, freeing Glenn Maxwell for outfield duties.",
+          "momentum": 56,
+          "relatedItemIds": ["story-6"]
+        },
+        {
+          "slug": "sixers-community-hub",
+          "title": "Sixers launch pink community hub",
+          "date": "2024-11-09T09:30:00.000Z",
+          "description": "Game-day village at the SCG features women in sport panels, accessible seating upgrades, and pop-up clinics.",
+          "momentum": 58,
+          "relatedItemIds": ["story-7"]
+        }
+      ]
+    },
+    {
+      "slug": "domestic-pathways",
+      "title": "Domestic Pathways & Grassroots",
+      "summary": "Sheffield Shield, WNCL, and Premier Cricket performances fuelling the next wave of national call-ups.",
+      "curatedCopy": "## Development watch\nPathway coaches highlight how Premier Cricket and National Championships inform rookie contracts. Technology from the National Cricket Centre is filtering down through state hubs, giving analysts richer data on emerging talent.\n\n### Spotlight programs\n- Woolworths Cricket Blast expanding to remote communities.\n- National under-19 tournament streamed in high definition for the first time.\n- Hybrid turf wicket trials in the Northern Territory to extend playing seasons.",
+      "callouts": [
+        {
+          "title": "Talent radar",
+          "markdown": "Leg-spinner Emily Smith (WA) and quick Tom Straker (SA) named as Academy priority picks after standout performances."
+        }
+      ],
+      "spotlightIds": ["story-8"],
+      "momentumSeries": [
+        { "date": "2024-11-02", "value": 34 },
+        { "date": "2024-11-05", "value": 39 },
+        { "date": "2024-11-07", "value": 43 },
+        { "date": "2024-11-09", "value": 47 },
+        { "date": "2024-11-10", "value": 51 }
+      ],
+      "events": [
+        {
+          "slug": "shield-marathon",
+          "title": "Shield marathon in Adelaide lights up selectors",
+          "date": "2024-11-06T04:00:00.000Z",
+          "description": "Queensland and SA share honours in a day-night epic showcasing quick prospects topping 145kph.",
           "momentum": 48,
-          "relatedItemIds": ["article-7"]
+          "relatedItemIds": ["story-8", "story-9"]
         },
         {
-          "slug": "latino-faith-outreach",
-          "title": "Latino faith outreach adds bilingual voter guides",
-          "date": "2024-09-28T17:00:00.000Z",
-          "description": "Church partnerships distribute Spanish-language voter packets, part of a broader move to chip into Biden's coalition.",
-          "momentum": 50,
-          "relatedItemIds": ["article-8"]
-        }
-      ]
-    },
-    {
-      "slug": "issue-messaging",
-      "title": "Issue Messaging & Narrative Testing",
-      "summary": "Rapid-response talking points on immigration, inflation, and foreign policy tested across conservative media.",
-      "curatedCopy": "## Narrative Testing\nCampaign pollsters feed nightly findings into surrogate briefings. Messaging pivots quickly to keep the news cycle on favorable terrain, often marrying immigration with inflation to hold focus.\n\n#### Channels\n- Late-night Truth Social posts.\n- Podcast blitzes hosted by allied influencers.\n- Geo-targeted pre-roll ads that shift by state.",
-      "callouts": [
-        {
-          "title": "Rapid-response cadence",
-          "markdown": "Clip packages are cut within 45 minutes of any major Biden gaffe and sent to a 2,000-person surrogate list."
-        }
-      ],
-      "spotlightIds": ["article-9"],
-      "momentumSeries": [
-        { "date": "2024-09-18", "value": 41 },
-        { "date": "2024-09-22", "value": 43 },
-        { "date": "2024-09-25", "value": 47 },
-        { "date": "2024-09-27", "value": 52 },
-        { "date": "2024-09-30", "value": 55 }
-      ],
-      "events": [
-        {
-          "slug": "immigration-ad-blitz",
-          "title": "Immigration ad blitz ties border to inflation",
-          "date": "2024-09-25T12:00:00.000Z",
-          "description": "A wave of digital ads claims rising grocery prices stem from federal spending on migrants, a talking point echoed by surrogates on radio.",
-          "momentum": 53,
-          "relatedItemIds": ["article-9", "article-10"]
-        },
-        {
-          "slug": "debate-prep-messaging",
-          "title": "Debate prep memos leak to conservative outlets",
-          "date": "2024-09-29T11:00:00.000Z",
-          "description": "Selective leaks preview attacks on Biden's foreign policy, keeping the focus on Afghanistan while framing Trump as steady on world affairs.",
-          "momentum": 57,
-          "relatedItemIds": ["article-11"]
+          "slug": "club-grants-round",
+          "title": "Club grants fund hybrid wickets",
+          "date": "2024-11-08T01:00:00.000Z",
+          "description": "Northern Territory clubs secure infrastructure upgrades to extend dry-season playing windows.",
+          "momentum": 49,
+          "relatedItemIds": ["story-10"]
         }
       ]
     }
   ],
   "items": [
     {
-      "id": "article-1",
-      "title": "Trump campaign blasts Georgia prosecutors after trial delay",
-      "link": "https://example.com/trump-georgia-delay",
-      "pubDate": "2024-09-23T15:45:00.000Z",
-      "content": "Senior aides told reporters the delay proves the case is political, urging supporters to donate to \"finish the fight\".",
-      "source": "Politico",
-      "category": "Legal",
-      "imageUrl": "https://images.example.com/trump-court.jpg",
-      "topics": ["legal-battles"],
-      "eventSlug": "georgia-ruling",
+      "id": "story-1",
+      "title": "Marcus Harris gets nod for Perth Test opener",
+      "link": "https://www.cricket.com.au/news/marcus-harris-australia-test-squad-india-perth-selection/2024-11-04",
+      "pubDate": "2024-11-04T02:30:00.000Z",
+      "content": "Selectors stick with Harris alongside Khawaja while hinting at a flexible middle order for the pink-ball Test.",
+      "source": "cricket.com.au",
+      "category": "International",
+      "imageUrl": "https://images.cricket.com.au/marcus-harris-selection.jpg",
+      "topics": ["international-season"],
+      "eventSlug": "perth-test-squad",
       "sentiment": "positive",
-      "momentumScore": 58
+      "momentumScore": 61
     },
     {
-      "id": "article-2",
-      "title": "Fundraising text blitz follows Georgia ruling",
-      "link": "https://example.com/fundraising-texts",
-      "pubDate": "2024-09-24T02:30:00.000Z",
-      "content": "Within hours of the judge's order, the campaign sent seven fundraising texts referencing \"witch hunt delays\".",
-      "source": "Axios",
-      "category": "Campaign Finance",
-      "imageUrl": "https://images.example.com/text-blitz.jpg",
-      "topics": ["legal-battles", "ground-game"],
-      "eventSlug": "georgia-ruling",
+      "id": "story-2",
+      "title": "Cameron Green ton heaps pressure on incumbents",
+      "link": "https://www.espncricinfo.com/story/cameron-green-scores-another-shield-century-1445123",
+      "pubDate": "2024-11-05T07:45:00.000Z",
+      "content": "Green's unbeaten 142 for WA adds weight to calls for a middle-order reshuffle ahead of India.",
+      "source": "ESPNcricinfo",
+      "category": "Domestic",
+      "imageUrl": "https://img.espncricinfo.com/green-century.jpg",
+      "topics": ["international-season", "domestic-pathways"],
+      "eventSlug": "perth-test-squad",
       "sentiment": "positive",
-      "momentumScore": 57
+      "momentumScore": 60
     },
     {
-      "id": "article-3",
-      "title": "Trump allies decry gag order on conservative media",
-      "link": "https://example.com/gag-order-response",
-      "pubDate": "2024-09-27T22:10:00.000Z",
-      "content": "Surrogates lined up on talk radio to argue that the gag order is really aimed at silencing supporters.",
-      "source": "Fox News",
-      "category": "Media",
-      "imageUrl": "https://images.example.com/gag-order.jpg",
-      "topics": ["legal-battles", "issue-messaging"],
-      "eventSlug": "gag-order-fight",
-      "sentiment": "positive",
-      "momentumScore": 62
-    },
-    {
-      "id": "article-4",
-      "title": "Campaign previews Supreme Court immunity appeal",
-      "link": "https://example.com/immunity-appeal",
-      "pubDate": "2024-09-29T16:05:00.000Z",
-      "content": "Advisers say a conservative majority will rein in the Department of Justice, promising day-one reforms.",
-      "source": "Wall Street Journal",
-      "category": "Legal",
-      "imageUrl": "https://images.example.com/supreme-court.jpg",
-      "topics": ["legal-battles", "issue-messaging"],
-      "eventSlug": "immunity-appeal",
+      "id": "story-3",
+      "title": "Healy declares herself ready for pink-ball Test",
+      "link": "https://www.cricket.com.au/news/alyssa-healy-injury-update-day-night-test-australia-india/2024-11-07",
+      "pubDate": "2024-11-07T10:15:00.000Z",
+      "content": "Captain confirms she will keep wicket after completing running loads at the National Cricket Centre.",
+      "source": "cricket.com.au",
+      "category": "International",
+      "imageUrl": "https://images.cricket.com.au/alyssa-healy-return.jpg",
+      "topics": ["international-season"],
+      "eventSlug": "healy-return",
       "sentiment": "positive",
       "momentumScore": 64
     },
     {
-      "id": "article-5",
-      "title": "Trump opens six field offices across Pennsylvania",
-      "link": "https://example.com/pennsylvania-field",
-      "pubDate": "2024-09-24T18:30:00.000Z",
-      "content": "Ribbon cuttings featured local lawmakers and targeted messages about energy prices.",
-      "source": "Philadelphia Inquirer",
-      "category": "Ground Game",
-      "imageUrl": "https://images.example.com/field-office.jpg",
-      "topics": ["ground-game"],
-      "eventSlug": "pennsylvania-field-offices",
-      "sentiment": "positive",
-      "momentumScore": 46
-    },
-    {
-      "id": "article-6",
-      "title": "Volunteer sign-ups surge after field office blitz",
-      "link": "https://example.com/volunteer-surge",
-      "pubDate": "2024-09-25T14:20:00.000Z",
-      "content": "Campaign claims 8,000 new volunteers, though Democrats dispute the number.",
-      "source": "NBC News",
-      "category": "Ground Game",
-      "imageUrl": "https://images.example.com/volunteers.jpg",
-      "topics": ["ground-game"],
-      "eventSlug": "pennsylvania-field-offices",
+      "id": "story-4",
+      "title": "Gabba ODI rescheduled to twilight slot",
+      "link": "https://www.smh.com.au/sport/cricket/gabba-odi-moved-to-prime-time-after-ticket-rush-20241109-p5jw1f.html",
+      "pubDate": "2024-11-09T06:20:00.000Z",
+      "content": "Cricket Australia adjusts start times to maximise broadcast reach after crowd demand surpasses expectations.",
+      "source": "Sydney Morning Herald",
+      "category": "International",
+      "imageUrl": "https://static.smh.com.au/images/gabba-twilight.jpg",
+      "topics": ["international-season"],
+      "eventSlug": "gabba-odi-shift",
       "sentiment": "neutral",
-      "momentumScore": 44
+      "momentumScore": 58
     },
     {
-      "id": "article-7",
-      "title": "Rural bus tour amplifies energy message",
-      "link": "https://example.com/rural-bus",
-      "pubDate": "2024-09-26T22:40:00.000Z",
-      "content": "The bus tour stops at small-town diners with local radio hits about drilling and inflation.",
-      "source": "Cleveland Plain Dealer",
-      "category": "Ground Game",
-      "imageUrl": "https://images.example.com/bus-tour.jpg",
-      "topics": ["ground-game", "issue-messaging"],
-      "eventSlug": "rural-bus-tour",
-      "sentiment": "positive",
-      "momentumScore": 48
-    },
-    {
-      "id": "article-8",
-      "title": "Latino pastors partner with Trump team on voter guides",
-      "link": "https://example.com/latino-voter-guides",
-      "pubDate": "2024-09-28T19:15:00.000Z",
-      "content": "Spanish-language voter packets are distributed alongside food drives in Phoenix and Orlando.",
-      "source": "Univision",
-      "category": "Outreach",
-      "imageUrl": "https://images.example.com/latino-outreach.jpg",
-      "topics": ["ground-game"],
-      "eventSlug": "latino-faith-outreach",
-      "sentiment": "positive",
-      "momentumScore": 50
-    },
-    {
-      "id": "article-9",
-      "title": "Immigration ad blitz links border to inflation",
-      "link": "https://example.com/immigration-ads",
-      "pubDate": "2024-09-25T13:10:00.000Z",
-      "content": "Ads feature grocery carts and Border Patrol footage, testing a new hybrid message.",
-      "source": "Washington Post",
-      "category": "Advertising",
-      "imageUrl": "https://images.example.com/immigration-ads.jpg",
-      "topics": ["issue-messaging"],
-      "eventSlug": "immigration-ad-blitz",
-      "sentiment": "positive",
-      "momentumScore": 53
-    },
-    {
-      "id": "article-10",
-      "title": "Fact-checkers push back on ad claims about migrant spending",
-      "link": "https://example.com/fact-check",
-      "pubDate": "2024-09-26T09:00:00.000Z",
-      "content": "Independent fact-checkers say the numbers are exaggerated, but the campaign doubles down in response videos.",
-      "source": "AP",
-      "category": "Fact Check",
-      "imageUrl": "https://images.example.com/fact-check.jpg",
-      "topics": ["issue-messaging", "legal-battles"],
-      "eventSlug": "immigration-ad-blitz",
-      "sentiment": "negative",
-      "momentumScore": 48
-    },
-    {
-      "id": "article-11",
-      "title": "Debate prep memo outlines foreign policy attacks",
-      "link": "https://example.com/debate-memo",
-      "pubDate": "2024-09-29T13:55:00.000Z",
-      "content": "Leaked slides suggest a focus on Afghanistan, arguing Biden cannot handle crises abroad.",
-      "source": "Bloomberg",
-      "category": "Debate",
-      "imageUrl": "https://images.example.com/debate-prep.jpg",
-      "topics": ["issue-messaging", "legal-battles"],
-      "eventSlug": "debate-prep-messaging",
+      "id": "story-5",
+      "title": "Heat unveil fearless brand ahead of BBL opener",
+      "link": "https://www.cricket.com.au/news/brisbane-heat-open-training-wade-seccombe-bbl14-plans/2024-11-05",
+      "pubDate": "2024-11-05T23:30:00.000Z",
+      "content": "Brisbane Heat roll out their fast-paced blueprint with open training attracting record pre-season crowds.",
+      "source": "cricket.com.au",
+      "category": "BBL",
+      "imageUrl": "https://images.cricket.com.au/heat-training.jpg",
+      "topics": ["big-bash-leagues"],
+      "eventSlug": "heat-open-training",
       "sentiment": "positive",
       "momentumScore": 57
+    },
+    {
+      "id": "story-6",
+      "title": "Stars back dual-keeper strategy for BBL|14",
+      "link": "https://www.heraldsun.com.au/sport/cricket/stars-to-rotate-keepers-in-bbl-season/news-story/",
+      "pubDate": "2024-11-08T06:05:00.000Z",
+      "content": "Coach Peter Moores reveals the Stars will alternate keepers to maximise matchups and power surge options.",
+      "source": "Herald Sun",
+      "category": "BBL",
+      "imageUrl": "https://content.heraldsun.com.au/stars-keepers.jpg",
+      "topics": ["big-bash-leagues"],
+      "eventSlug": "stars-keeper-plan",
+      "sentiment": "neutral",
+      "momentumScore": 54
+    },
+    {
+      "id": "story-7",
+      "title": "Sixers launch pink community hub at the SCG",
+      "link": "https://www.sydneysixers.com.au/news/pink-hub-launch/2024-11-09",
+      "pubDate": "2024-11-09T09:45:00.000Z",
+      "content": "New match-day precinct features women in sport panels, sensory spaces, and inclusive seating upgrades.",
+      "source": "Sydney Sixers",
+      "category": "BBL",
+      "imageUrl": "https://www.sydneysixers.com.au/media/pink-hub.jpg",
+      "topics": ["big-bash-leagues", "domestic-pathways"],
+      "eventSlug": "sixers-community-hub",
+      "sentiment": "positive",
+      "momentumScore": 56
+    },
+    {
+      "id": "story-8",
+      "title": "Shield day-nighter showcases new quicks",
+      "link": "https://www.abc.net.au/news/2024-11-06/sheffield-shield-day-night-adelaide-pace-prospects/",
+      "pubDate": "2024-11-06T05:10:00.000Z",
+      "content": "Rising pacemen Tom Straker and Liam Haskett headline a gripping draw that boosts their national credentials.",
+      "source": "ABC News",
+      "category": "Domestic",
+      "imageUrl": "https://live-production.wcms.abc-cdn.net.au/sheffield-shield-night.jpg",
+      "topics": ["domestic-pathways", "international-season"],
+      "eventSlug": "shield-marathon",
+      "sentiment": "positive",
+      "momentumScore": 52
+    },
+    {
+      "id": "story-9",
+      "title": "National Championships stream hits record viewers",
+      "link": "https://www.cricket.com.au/news/national-championships-streaming-records-youth-prospects/2024-11-07",
+      "pubDate": "2024-11-07T03:40:00.000Z",
+      "content": "High-definition coverage of the under-19 nationals draws scouts and fans, highlighting prospects from every state.",
+      "source": "cricket.com.au",
+      "category": "Pathways",
+      "imageUrl": "https://images.cricket.com.au/u19-stream.jpg",
+      "topics": ["domestic-pathways"],
+      "eventSlug": "shield-marathon",
+      "sentiment": "positive",
+      "momentumScore": 49
+    },
+    {
+      "id": "story-10",
+      "title": "Hybrid wicket trials funded across the NT",
+      "link": "https://www.playcricket.com.au/community/news/hybrid-wickets-northern-territory-grants",
+      "pubDate": "2024-11-08T01:20:00.000Z",
+      "content": "Grassroots clubs secure grants to install hybrid surfaces, extending the season and reducing maintenance costs.",
+      "source": "PlayCricket",
+      "category": "Community",
+      "imageUrl": "https://www.playcricket.com.au/media/hybrid-wickets.jpg",
+      "topics": ["domestic-pathways"],
+      "eventSlug": "club-grants-round",
+      "sentiment": "positive",
+      "momentumScore": 48
     }
   ]
 }

--- a/src/index.html
+++ b/src/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="utf-8">
-  <title>TrumpTracker</title>
+  <title>AussieCricketPulse</title>
   <base href="/">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="icon" type="image/x-icon" href="favicon.ico">


### PR DESCRIPTION
## Summary
- rebrand the application as "Aussie Cricket Pulse" across the shell, header, footer, and navigation
- rewrite dashboard, fixtures, get involved, league guide, and sidebar content to highlight Australian cricket information
- refresh static datasets, API queries, and services to surface Australian cricket news and pathways data

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68eab9a7cbb08326a89a77ffd6a73e50