### PR TITLE
Refocus site on Australian cricket coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# TrumpTracker
+# AussieCricketPulse
 
-This project was generated with [Angular CLI](https://github.com/angular/angular-cli) version 18.0.3.
+This project was generated with [Angular CLI](https://github.com/angular/angular-cli) version 18.0.3 and powers an Australian cricket news dashboard that blends coverage from international tours, domestic leagues, and grassroots pathways.
 
 ## Development server
 
@@ -60,7 +60,7 @@ Pushing to the `main` branch automatically builds and publishes the static site 
 
 1. Installs dependencies with `npm ci` using Node.js 20.
 2. Builds the Angular app with a repository-aware `base-href` so assets resolve correctly at `https://<user>.github.io/<repo>/`.
-3. Uploads `dist/trump-tracker/browser` as the static artifact and deploys it to GitHub Pages.
+3. Uploads `dist/trump-tracker/browser` (the default Angular output directory for this project) as the static artifact and deploys it to GitHub Pages.
 
 After the first successful run, enable GitHub Pages in the repository settings and choose the "GitHub Actions" source. Subsequent pushes to `main` will update the live site automatically.
 

--- a/server/data/news-topics.json
+++ b/server/data/news-topics.json
@@ -1,137 +1,137 @@
 {
-  "lastUpdated": "2024-09-30T18:30:00.000Z",
+  "lastUpdated": "2024-10-05T08:30:00.000Z",
   "topics": [
     {
-      "slug": "legal-battles",
-      "title": "Legal Battles and Court Strategy",
-      "summary": "Tracking how Trump's campaign weaponizes ongoing court fights to energize supporters and drive fundraising.",
-      "curatedCopy": "## Courtroom vs. Campaign\nThe campaign treats every filing and hearing as a two-for-one opportunity: legal defense by day, campaign rallying cry by night. Fundraising texts reference each development within minutes, and surrogates translate legal jargon into a persecution narrative built for cable hits.\n\n### Messaging pillars\n- Portray restrictions as election interference.\n- Tie prosecutors to Democratic leaders by name.\n- Pledge to overhaul the justice system on day one.",
+      "slug": "international-tours",
+      "title": "International tours and squad strategy",
+      "summary": "How Australia is juggling heavy travel schedules with selection calls for India and the Caribbean.",
+      "curatedCopy": "## Series outlook\nSelectors are keeping one eye on the Border-Gavaskar rematch while managing player loads during the white-ball swing through the Caribbean. The men pivot from subcontinent spin plans to extra pace options in Perth, while the women balance WBBL commitments with a multi-format Ashes defence.\n\n### Key talking points\n- Rotation policy for frontline quicks across formats.\n- Batting order tweaks to cover a recovering Steve Smith.\n- Match simulation camps for the women's squad before England arrive.",
       "callouts": [
         {
           "title": "Why it matters",
-          "markdown": "- Legal updates regularly spike small-dollar donations.\n- Base voters cite legal fights as proof the movement is under attack."
+          "markdown": "- Australia plays nine internationals in 28 days.\n- Selection decisions now flow directly into World Cup qualification scenarios."
         },
         {
-          "title": "Watch the calendar",
-          "markdown": "Sentencing and pre-trial hearings align with key fundraising deadlines, giving the campaign recurring content moments."
+          "title": "Watch the travel",
+          "markdown": "Perth, Melbourne, Barbados, then Chennai across six weeks demands strong recovery protocols."
         }
       ],
       "spotlightIds": ["article-1"],
       "momentumSeries": [
-        { "date": "2024-09-18", "value": 38 },
-        { "date": "2024-09-22", "value": 47 },
-        { "date": "2024-09-25", "value": 56 },
-        { "date": "2024-09-27", "value": 59 },
-        { "date": "2024-09-30", "value": 61 }
+        { "date": "2024-09-25", "value": 42 },
+        { "date": "2024-09-28", "value": 48 },
+        { "date": "2024-09-30", "value": 55 },
+        { "date": "2024-10-02", "value": 59 },
+        { "date": "2024-10-05", "value": 63 }
       ],
       "events": [
         {
-          "slug": "georgia-ruling",
-          "title": "Georgia racketeering ruling resets the clock",
-          "date": "2024-09-23T10:00:00.000Z",
-          "description": "A Fulton County judge delays proceedings into 2025. The campaign frames the pause as proof the case is collapsing and uses the reprieve to claim momentum in swing states.",
-          "momentum": 58,
+          "slug": "perth-test-selection",
+          "title": "Selectors hint at three-prong pace for Perth Test",
+          "date": "2024-09-30T02:00:00.000Z",
+          "description": "George Bailey confirms a pace-heavy attack is likely for the opening India Test, with Nathan Lyon still pencilled in as the lone specialist spinner.",
+          "momentum": 61,
           "relatedItemIds": ["article-1", "article-2"]
         },
         {
-          "slug": "gag-order-fight",
-          "title": "New York gag order fight becomes a censorship narrative",
-          "date": "2024-09-27T18:00:00.000Z",
-          "description": "Surrogates argue that limits on Trump's speech are an attack on supporters, driving sympathetic coverage and op-eds from allies.",
+          "slug": "womens-ashes-camp",
+          "title": "Women's squad reconvenes ahead of Ashes defence",
+          "date": "2024-10-01T22:00:00.000Z",
+          "description": "Meg Lanning leads a Gold Coast camp blending Ashes prep with WBBL planning, spotlighting emerging quicks from the WNCL.",
           "momentum": 62,
           "relatedItemIds": ["article-3"]
         },
         {
-          "slug": "immunity-appeal",
-          "title": "Supreme Court appeal teasers revive immunity storyline",
-          "date": "2024-09-29T14:30:00.000Z",
-          "description": "Campaign lawyers preview new filings that they say will shield Trump from future prosecutions, reinforcing the promise of a second-term crackdown on DOJ critics.",
-          "momentum": 64,
+          "slug": "caribbean-t20-shuffle",
+          "title": "Caribbean T20 tour forces middle-order rethink",
+          "date": "2024-10-04T12:30:00.000Z",
+          "description": "Matthew Wade's hamstring tweak prompts a recall for Josh Inglis and a flexible finishing role for Glenn Maxwell.",
+          "momentum": 65,
           "relatedItemIds": ["article-4"]
         }
       ]
     },
     {
-      "slug": "ground-game",
-      "title": "Swing-State Ground Game",
-      "summary": "Field organizing pushes in the Rust Belt and Sun Belt aimed at closing the early-vote gap.",
-      "curatedCopy": "## Organizing Infrastructure\nField staff are leaning on county GOP offices, faith leaders, and a revived \"Trump Force 47\" volunteer portal. The campaign highlights door-knocking stats at every rally to signal professionalization while maintaining the outsider vibe.\n\n### Key tactics\n1. Overlapping bus tours in Pennsylvania, Michigan, and Georgia.\n2. Micro-targeted radio ads focused on energy costs and border security.\n3. Faith outreach breakfasts that double as data collection events.",
+      "slug": "domestic-leagues",
+      "title": "Domestic leagues reset",
+      "summary": "Sheffield Shield and Big Bash clubs jostle for form and signatures before the summer rush.",
+      "curatedCopy": "## Domestic pulse\nShield run machines are staking claims for Perth while BBL list managers weigh marquee retention picks. State coaches emphasise rotation with several Test hopefuls flying in from county stints.\n\n### What we’re tracking\n1. Queensland's charge up the Shield ladder.\n2. WBBL recruiting battles for fast-bowling depth.\n3. Infrastructure upgrades ahead of a packed Christmas-New Year fixture block.",
       "callouts": [
         {
-          "title": "Staffing snapshot",
-          "markdown": "- 48 paid staffers announced across four battleground states.\n- County captains recruited from 2020 stop-the-steal networks."
+          "title": "Ladder watch",
+          "markdown": "- Queensland move into second after the Gabba draw.\n- South Australia banking bonus points despite two close losses."
         }
       ],
       "spotlightIds": ["article-5"],
       "momentumSeries": [
-        { "date": "2024-09-18", "value": 32 },
-        { "date": "2024-09-22", "value": 36 },
-        { "date": "2024-09-25", "value": 40 },
-        { "date": "2024-09-27", "value": 44 },
-        { "date": "2024-09-30", "value": 49 }
+        { "date": "2024-09-25", "value": 36 },
+        { "date": "2024-09-28", "value": 41 },
+        { "date": "2024-09-30", "value": 46 },
+        { "date": "2024-10-03", "value": 51 },
+        { "date": "2024-10-05", "value": 55 }
       ],
       "events": [
         {
-          "slug": "pennsylvania-field-offices",
-          "title": "Six new Pennsylvania field offices open ahead of mail voting",
-          "date": "2024-09-24T15:00:00.000Z",
-          "description": "Campaign claims 8,000 volunteers signed up after the openings, using live streams from each ribbon cutting.",
-          "momentum": 46,
+          "slug": "shield-double-ton",
+          "title": "Pucovski double-ton reignites Test talk",
+          "date": "2024-09-29T06:00:00.000Z",
+          "description": "The Victorian opener peels off 202 at Adelaide Oval, pushing his case for a recall after two seasons on the sidelines.",
+          "momentum": 54,
           "relatedItemIds": ["article-5", "article-6"]
         },
         {
-          "slug": "rural-bus-tour",
-          "title": "Rural bus tour spotlights energy message",
-          "date": "2024-09-26T20:00:00.000Z",
-          "description": "Surrogates barnstorm rural Ohio and Michigan touting drilling permits and farmers' fuel costs, capturing local TV coverage.",
-          "momentum": 48,
+          "slug": "bbl-retention-deadline",
+          "title": "BBL clubs lock in retention picks",
+          "date": "2024-10-02T09:00:00.000Z",
+          "description": "Sydney Sixers keep hold of Tom Curran as Brisbane Heat chase another power hitter ahead of the overseas draft.",
+          "momentum": 57,
           "relatedItemIds": ["article-7"]
         },
         {
-          "slug": "latino-faith-outreach",
-          "title": "Latino faith outreach adds bilingual voter guides",
-          "date": "2024-09-28T17:00:00.000Z",
-          "description": "Church partnerships distribute Spanish-language voter packets, part of a broader move to chip into Biden's coalition.",
-          "momentum": 50,
+          "slug": "wncl-fast-bowler",
+          "title": "WNCL quick clocks 130 km/h in season opener",
+          "date": "2024-10-04T03:30:00.000Z",
+          "description": "Teenager Chloe Ainsworth rips through Victoria with a five-wicket haul, raising talk of an Australia A berth.",
+          "momentum": 58,
           "relatedItemIds": ["article-8"]
         }
       ]
     },
     {
-      "slug": "issue-messaging",
-      "title": "Issue Messaging & Narrative Testing",
-      "summary": "Rapid-response talking points on immigration, inflation, and foreign policy tested across conservative media.",
-      "curatedCopy": "## Narrative Testing\nCampaign pollsters feed nightly findings into surrogate briefings. Messaging pivots quickly to keep the news cycle on favorable terrain, often marrying immigration with inflation to hold focus.\n\n#### Channels\n- Late-night Truth Social posts.\n- Podcast blitzes hosted by allied influencers.\n- Geo-targeted pre-roll ads that shift by state.",
+      "slug": "pathways",
+      "title": "Pathways and participation",
+      "summary": "Grassroots programs and Australia A tours shaping the next generation.",
+      "curatedCopy": "## Building the pipeline\nCricket Australia is funnelling extra support into remote communities while academy coaches celebrate cross-code recruits. The Australia A schedule doubles as a trial for future World Cup squads, and Premier Cricket clubs are experimenting with twilight rounds to draw bigger crowds.\n\n### Spotlight initiatives\n- First Nations cricket festivals expanding into the NT.\n- PlayCricket club grants for regional Victoria.\n- Australia A mixed-format tour giving fringe players multi-day exposure.",
       "callouts": [
         {
-          "title": "Rapid-response cadence",
-          "markdown": "Clip packages are cut within 45 minutes of any major Biden gaffe and sent to a 2,000-person surrogate list."
+          "title": "Participation snapshot",
+          "markdown": "- Junior registrations up 11% year-on-year.\n- 42% of new sign-ups are girls or women."
         }
       ],
       "spotlightIds": ["article-9"],
       "momentumSeries": [
-        { "date": "2024-09-18", "value": 41 },
-        { "date": "2024-09-22", "value": 43 },
-        { "date": "2024-09-25", "value": 47 },
-        { "date": "2024-09-27", "value": 52 },
-        { "date": "2024-09-30", "value": 55 }
+        { "date": "2024-09-25", "value": 28 },
+        { "date": "2024-09-28", "value": 31 },
+        { "date": "2024-09-30", "value": 35 },
+        { "date": "2024-10-02", "value": 39 },
+        { "date": "2024-10-05", "value": 44 }
       ],
       "events": [
         {
-          "slug": "immigration-ad-blitz",
-          "title": "Immigration ad blitz ties border to inflation",
-          "date": "2024-09-25T12:00:00.000Z",
-          "description": "A wave of digital ads claims rising grocery prices stem from federal spending on migrants, a talking point echoed by surrogates on radio.",
-          "momentum": 53,
-          "relatedItemIds": ["article-9", "article-10"]
+          "slug": "australia-a-tour",
+          "title": "Australia A squad named for NZ tour",
+          "date": "2024-09-27T01:00:00.000Z",
+          "description": "A youth-heavy squad will contest red and white-ball fixtures, with selectors highlighting versatility as the key metric.",
+          "momentum": 42,
+          "relatedItemIds": ["article-9"]
         },
         {
-          "slug": "debate-prep-messaging",
-          "title": "Debate prep memos leak to conservative outlets",
-          "date": "2024-09-29T11:00:00.000Z",
-          "description": "Selective leaks preview attacks on Biden's foreign policy, keeping the focus on Afghanistan while framing Trump as steady on world affairs.",
-          "momentum": 57,
-          "relatedItemIds": ["article-11"]
+          "slug": "playcricket-grants",
+          "title": "PlayCricket grants open for regional clubs",
+          "date": "2024-10-03T20:00:00.000Z",
+          "description": "Clubs can access equipment funding aimed at growing girls' and all-abilities programs before summer.",
+          "momentum": 45,
+          "relatedItemIds": ["article-10"]
         }
       ]
     }
@@ -139,157 +139,143 @@
   "items": [
     {
       "id": "article-1",
-      "title": "Trump campaign blasts Georgia prosecutors after trial delay",
-      "link": "https://example.com/trump-georgia-delay",
-      "pubDate": "2024-09-23T15:45:00.000Z",
-      "content": "Senior aides told reporters the delay proves the case is political, urging supporters to donate to \"finish the fight\".",
-      "source": "Politico",
-      "category": "Legal",
-      "imageUrl": "https://images.example.com/trump-court.jpg",
-      "topics": ["legal-battles"],
-      "eventSlug": "georgia-ruling",
+      "title": "Australia weigh three quicks for opening India Test",
+      "link": "https://www.cricket.com.au/news/australia-india-test-selection-pace-attack/2024-09-30",
+      "pubDate": "2024-09-30T04:45:00.000Z",
+      "content": "Pat Cummins signals confidence in his quicks with Cameron Green on standby as an all-round option.",
+      "source": "cricket.com.au",
+      "category": "International",
+      "imageUrl": "https://images.example.com/australia-pace-group.jpg",
+      "topics": ["international-tours"],
+      "eventSlug": "perth-test-selection",
       "sentiment": "positive",
-      "momentumScore": 58
+      "momentumScore": 61
     },
     {
       "id": "article-2",
-      "title": "Fundraising text blitz follows Georgia ruling",
-      "link": "https://example.com/fundraising-texts",
-      "pubDate": "2024-09-24T02:30:00.000Z",
-      "content": "Within hours of the judge's order, the campaign sent seven fundraising texts referencing \"witch hunt delays\".",
-      "source": "Axios",
-      "category": "Campaign Finance",
-      "imageUrl": "https://images.example.com/text-blitz.jpg",
-      "topics": ["legal-battles", "ground-game"],
-      "eventSlug": "georgia-ruling",
-      "sentiment": "positive",
-      "momentumScore": 57
+      "title": "Smith rests up with minor wrist niggle",
+      "link": "https://www.espncricinfo.com/story/steven-smith-wrist-injury-india-series-update-1413569",
+      "pubDate": "2024-10-01T01:15:00.000Z",
+      "content": "Batting coach Michael Di Venuto says the veteran will be fit for Perth after missing the final ODI in Trinidad.",
+      "source": "ESPNcricinfo",
+      "category": "International",
+      "imageUrl": "https://images.example.com/smith-fitness.jpg",
+      "topics": ["international-tours"],
+      "eventSlug": "perth-test-selection",
+      "sentiment": "neutral",
+      "momentumScore": 58
     },
     {
       "id": "article-3",
-      "title": "Trump allies decry gag order on conservative media",
-      "link": "https://example.com/gag-order-response",
-      "pubDate": "2024-09-27T22:10:00.000Z",
-      "content": "Surrogates lined up on talk radio to argue that the gag order is really aimed at silencing supporters.",
-      "source": "Fox News",
-      "category": "Media",
-      "imageUrl": "https://images.example.com/gag-order.jpg",
-      "topics": ["legal-battles", "issue-messaging"],
-      "eventSlug": "gag-order-fight",
+      "title": "Lanning leads high-intensity camp on Gold Coast",
+      "link": "https://www.cricket.com.au/news/australia-women-ashes-prep-gold-coast-camp/2024-10-02",
+      "pubDate": "2024-10-02T06:05:00.000Z",
+      "content": "The skipper says younger quicks are pushing speeds that rival established stars ahead of the Ashes.",
+      "source": "cricket.com.au",
+      "category": "Women",
+      "imageUrl": "https://images.example.com/womens-camp.jpg",
+      "topics": ["international-tours"],
+      "eventSlug": "womens-ashes-camp",
       "sentiment": "positive",
       "momentumScore": 62
     },
     {
       "id": "article-4",
-      "title": "Campaign previews Supreme Court immunity appeal",
-      "link": "https://example.com/immunity-appeal",
-      "pubDate": "2024-09-29T16:05:00.000Z",
-      "content": "Advisers say a conservative majority will rein in the Department of Justice, promising day-one reforms.",
-      "source": "Wall Street Journal",
-      "category": "Legal",
-      "imageUrl": "https://images.example.com/supreme-court.jpg",
-      "topics": ["legal-battles", "issue-messaging"],
-      "eventSlug": "immunity-appeal",
+      "title": "Maxwell embraces floating finisher role in Caribbean",
+      "link": "https://www.smh.com.au/sport/cricket/maxwell-caribbean-t20-tour-role-20241004-p5bg88.html",
+      "pubDate": "2024-10-04T14:20:00.000Z",
+      "content": "Australia consider Glenn Maxwell as a flexible option after Matthew Wade's hamstring concern.",
+      "source": "Sydney Morning Herald",
+      "category": "International",
+      "imageUrl": "https://images.example.com/maxwell-caribbean.jpg",
+      "topics": ["international-tours"],
+      "eventSlug": "caribbean-t20-shuffle",
       "sentiment": "positive",
-      "momentumScore": 64
+      "momentumScore": 65
     },
     {
       "id": "article-5",
-      "title": "Trump opens six field offices across Pennsylvania",
-      "link": "https://example.com/pennsylvania-field",
-      "pubDate": "2024-09-24T18:30:00.000Z",
-      "content": "Ribbon cuttings featured local lawmakers and targeted messages about energy prices.",
-      "source": "Philadelphia Inquirer",
-      "category": "Ground Game",
-      "imageUrl": "https://images.example.com/field-office.jpg",
-      "topics": ["ground-game"],
-      "eventSlug": "pennsylvania-field-offices",
+      "title": "Pucovski double-ton drives Victoria to bonus points",
+      "link": "https://www.theage.com.au/sport/cricket/pucovski-double-ton-puts-victoria-in-the-frame-20240929-p5bfy0.html",
+      "pubDate": "2024-09-29T07:30:00.000Z",
+      "content": "A 202-run marathon sees Victoria leapfrog South Australia on the Shield ladder.",
+      "source": "The Age",
+      "category": "Sheffield Shield",
+      "imageUrl": "https://images.example.com/pucovski-celebrates.jpg",
+      "topics": ["domestic-leagues"],
+      "eventSlug": "shield-double-ton",
       "sentiment": "positive",
-      "momentumScore": 46
+      "momentumScore": 54
     },
     {
       "id": "article-6",
-      "title": "Volunteer sign-ups surge after field office blitz",
-      "link": "https://example.com/volunteer-surge",
-      "pubDate": "2024-09-25T14:20:00.000Z",
-      "content": "Campaign claims 8,000 new volunteers, though Democrats dispute the number.",
-      "source": "NBC News",
-      "category": "Ground Game",
-      "imageUrl": "https://images.example.com/volunteers.jpg",
-      "topics": ["ground-game"],
-      "eventSlug": "pennsylvania-field-offices",
-      "sentiment": "neutral",
-      "momentumScore": 44
+      "title": "Queensland climb with gritty Gabba draw",
+      "link": "https://www.cricket.com.au/news/sheffield-shield-queensland-draw-tasmania-table-update/2024-10-01",
+      "pubDate": "2024-10-01T03:55:00.000Z",
+      "content": "Usman Khawaja's final-day 89 anchors the Bulls as they move into second on the ladder.",
+      "source": "cricket.com.au",
+      "category": "Sheffield Shield",
+      "imageUrl": "https://images.example.com/khawaja-gabba.jpg",
+      "topics": ["domestic-leagues"],
+      "eventSlug": "shield-double-ton",
+      "sentiment": "positive",
+      "momentumScore": 52
     },
     {
       "id": "article-7",
-      "title": "Rural bus tour amplifies energy message",
-      "link": "https://example.com/rural-bus",
-      "pubDate": "2024-09-26T22:40:00.000Z",
-      "content": "The bus tour stops at small-town diners with local radio hits about drilling and inflation.",
-      "source": "Cleveland Plain Dealer",
-      "category": "Ground Game",
-      "imageUrl": "https://images.example.com/bus-tour.jpg",
-      "topics": ["ground-game", "issue-messaging"],
-      "eventSlug": "rural-bus-tour",
+      "title": "Sixers retain Curran ahead of BBL overseas draft",
+      "link": "https://www.foxsports.com.au/cricket/bbl/sydney-sixers-tom-curran-retention-window-2024/news-story",
+      "pubDate": "2024-10-02T10:10:00.000Z",
+      "content": "Sydney lock in the English quick while Brisbane Heat pursue a power hitter for the top order.",
+      "source": "Fox Sports",
+      "category": "BBL",
+      "imageUrl": "https://images.example.com/curran-bbl.jpg",
+      "topics": ["domestic-leagues"],
+      "eventSlug": "bbl-retention-deadline",
       "sentiment": "positive",
-      "momentumScore": 48
+      "momentumScore": 57
     },
     {
       "id": "article-8",
-      "title": "Latino pastors partner with Trump team on voter guides",
-      "link": "https://example.com/latino-voter-guides",
-      "pubDate": "2024-09-28T19:15:00.000Z",
-      "content": "Spanish-language voter packets are distributed alongside food drives in Phoenix and Orlando.",
-      "source": "Univision",
-      "category": "Outreach",
-      "imageUrl": "https://images.example.com/latino-outreach.jpg",
-      "topics": ["ground-game"],
-      "eventSlug": "latino-faith-outreach",
+      "title": "Ainsworth five-for headlines WNCL opener",
+      "link": "https://www.cricket.com.au/news/wncl-chloe-ainsworth-five-wicket-haul-2024-25/2024-10-04",
+      "pubDate": "2024-10-04T04:50:00.000Z",
+      "content": "The teenage quick clocks 130 km/h and rips through Victoria to open the season in style.",
+      "source": "cricket.com.au",
+      "category": "WNCL",
+      "imageUrl": "https://images.example.com/ainsworth-wncl.jpg",
+      "topics": ["domestic-leagues"],
+      "eventSlug": "wncl-fast-bowler",
       "sentiment": "positive",
-      "momentumScore": 50
+      "momentumScore": 58
     },
     {
       "id": "article-9",
-      "title": "Immigration ad blitz links border to inflation",
-      "link": "https://example.com/immigration-ads",
-      "pubDate": "2024-09-25T13:10:00.000Z",
-      "content": "Ads feature grocery carts and Border Patrol footage, testing a new hybrid message.",
-      "source": "Washington Post",
-      "category": "Advertising",
-      "imageUrl": "https://images.example.com/immigration-ads.jpg",
-      "topics": ["issue-messaging"],
-      "eventSlug": "immigration-ad-blitz",
+      "title": "Youthful Australia A squad locks in NZ itinerary",
+      "link": "https://www.cricket.com.au/news/australia-a-squad-new-zealand-tour-announced/2024-09-27",
+      "pubDate": "2024-09-27T02:30:00.000Z",
+      "content": "Led by Nathan McSweeney, the group will play two four-day matches and three T20s across the ditch.",
+      "source": "cricket.com.au",
+      "category": "Australia A",
+      "imageUrl": "https://images.example.com/australia-a-squad.jpg",
+      "topics": ["pathways"],
+      "eventSlug": "australia-a-tour",
       "sentiment": "positive",
-      "momentumScore": 53
+      "momentumScore": 42
     },
     {
       "id": "article-10",
-      "title": "Fact-checkers push back on ad claims about migrant spending",
-      "link": "https://example.com/fact-check",
-      "pubDate": "2024-09-26T09:00:00.000Z",
-      "content": "Independent fact-checkers say the numbers are exaggerated, but the campaign doubles down in response videos.",
-      "source": "AP",
-      "category": "Fact Check",
-      "imageUrl": "https://images.example.com/fact-check.jpg",
-      "topics": ["issue-messaging", "legal-battles"],
-      "eventSlug": "immigration-ad-blitz",
-      "sentiment": "negative",
-      "momentumScore": 48
-    },
-    {
-      "id": "article-11",
-      "title": "Debate prep memo outlines foreign policy attacks",
-      "link": "https://example.com/debate-memo",
-      "pubDate": "2024-09-29T13:55:00.000Z",
-      "content": "Leaked slides suggest a focus on Afghanistan, arguing Biden cannot handle crises abroad.",
-      "source": "Bloomberg",
-      "category": "Debate",
-      "imageUrl": "https://images.example.com/debate-prep.jpg",
-      "topics": ["issue-messaging", "legal-battles"],
-      "eventSlug": "debate-prep-messaging",
+      "title": "PlayCricket grants expand girls' programs",
+      "link": "https://www.community.cricket.com.au/clubs/playcricket-grants-2024",
+      "pubDate": "2024-10-03T22:45:00.000Z",
+      "content": "Regional clubs can apply for $5,000 equipment packages aimed at girls' and all-abilities teams.",
+      "source": "Community Cricket",
+      "category": "Participation",
+      "imageUrl": "https://images.example.com/community-cricket-grants.jpg",
+      "topics": ["pathways"],
+      "eventSlug": "playcricket-grants",
       "sentiment": "positive",
-      "momentumScore": 57
+      "momentumScore": 45
     }
   ]
 }

--- a/server/src/news/news.service.ts
+++ b/server/src/news/news.service.ts
@@ -107,9 +107,9 @@ export class NewsService {
   }
 
   private async fetchReddit(): Promise<NewsItemDto[]> {
-    const subredditQuery = 'politics+news+worldnews';
+    const subredditQuery = 'Cricket+BigBashLeague+CricketAustralia';
     const searchParams = new URLSearchParams({
-      q: 'trump 2024 campaign',
+      q: 'Australian cricket OR Big Bash',
       restrict_sr: '1',
       sort: 'new',
       limit: '100'
@@ -147,7 +147,7 @@ export class NewsService {
     }
 
     const params = new URLSearchParams({
-      q: 'Trump AND (campaign OR election OR 2024)',
+      q: '"Australian cricket" OR "Australia cricket" OR "Big Bash League" OR "BBL" OR "WBBL" OR "Sheffield Shield"',
       language: 'en',
       sortBy: 'publishedAt',
       apiKey
@@ -182,7 +182,7 @@ export class NewsService {
     }
 
     const params = new URLSearchParams({
-      q: 'Trump presidential campaign 2024',
+      q: 'Australian cricket',
       sort: 'newest',
       'api-key': apiKey
     });

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -1,31 +1,12 @@
 import { TestBed } from '@angular/core/testing';
 import { provideRouter } from '@angular/router';
 import { AppComponent } from './app.component';
-import { ExperimentService, ExperimentVariant } from './services/experiment.service';
-import { ReferralService } from './services/referral.service';
-
-class ExperimentServiceStub {
-  assignVariant(_: string, variants: ExperimentVariant[]): ExperimentVariant {
-    return variants[0];
-  }
-}
-
-class ReferralServiceStub {
-  getReferralCode(): string {
-    return 'T47-TEST';
-  }
-}
 
 describe('AppComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [AppComponent]
       imports: [AppComponent],
       providers: [provideRouter([])]
-      providers: [
-        { provide: ExperimentService, useClass: ExperimentServiceStub },
-        { provide: ReferralService, useClass: ReferralServiceStub },
-      ],
     }).compileComponents();
   });
 
@@ -35,23 +16,17 @@ describe('AppComponent', () => {
     expect(app).toBeTruthy();
   });
 
-  it('should have the campaign tracker title', () => {
-  it('should have the tracker title', () => {
-    const fixture = TestBed.createComponent(AppComponent);
-    const app = fixture.componentInstance;
-    expect(app.title).toEqual('Trump 47 Campaign Tracker');
-  });
-
   it('should render a skip link for accessibility', () => {
     const fixture = TestBed.createComponent(AppComponent);
     fixture.detectChanges();
     const compiled = fixture.nativeElement as HTMLElement;
     expect(compiled.querySelector('.skip-link')?.textContent?.trim()).toBe('Skip to main content');
-  it('should render the layout header title', () => {
+  });
+
+  it('should render the Aussie Cricket Pulse brand', () => {
     const fixture = TestBed.createComponent(AppComponent);
     fixture.detectChanges();
     const compiled = fixture.nativeElement as HTMLElement;
-    expect(compiled.querySelector('h1')?.textContent).toContain('Trump 47 Campaign Tracker');
-    expect(compiled.querySelector('.brand')?.textContent).toContain('Trump 47 Campaign Tracker');
+    expect(compiled.querySelector('.shell__title')?.textContent).toContain('Aussie Cricket Pulse');
   });
 });

--- a/src/app/components/community/community.component.html
+++ b/src/app/components/community/community.component.html
@@ -1,7 +1,7 @@
 <section class="community" aria-labelledby="community-title">
   <header>
-    <h1 id="community-title">Community War Room</h1>
-    <p>Official forums plus the best conversations from Reddit, all moderated for actionability.</p>
+    <h1 id="community-title">Cricket Community Hub</h1>
+    <p>Official forums plus the liveliest Reddit threads, all moderated to keep things insightful and respectful.</p>
   </header>
 
   <div class="thread-grid">

--- a/src/app/components/community/community.component.ts
+++ b/src/app/components/community/community.component.ts
@@ -7,7 +7,7 @@ interface CommunityThread {
   description: string;
   link: string;
   platform: 'reddit' | 'official';
-  moderationLevel: 'community' | 'campaign';
+  moderationLevel: 'community' | 'official';
 }
 
 @Component({
@@ -20,25 +20,25 @@ interface CommunityThread {
 export class CommunityComponent {
   readonly featuredThreads: CommunityThread[] = [
     {
-      title: 'Strategy AMA with campaign leadership',
-      description: 'Bring your questions for the digital, field, and finance directors. Moderated by the official campaign team.',
-      link: 'https://community.trump47.com/threads/strategy-ama',
+      title: 'Selector Q&A: Perth Test talking points',
+      description: 'Official stream recapping key selection calls before India arrive in November.',
+      link: 'https://www.cricket.com.au/news',
       platform: 'official',
-      moderationLevel: 'campaign',
+      moderationLevel: 'official',
     },
     {
-      title: 'Grassroots organizing toolkit',
-      description: 'Volunteer leaders share the scripts and materials that are working in their counties.',
-      link: 'https://www.reddit.com/r/Conservative/comments/toolkit',
+      title: 'Club cricket coaching swap',
+      description: 'Coaches trade session plans and training drills from grade and premier cricket.',
+      link: 'https://www.reddit.com/r/Cricket/comments',
       platform: 'reddit',
       moderationLevel: 'community',
     },
     {
-      title: 'Digital rapid response room',
-      description: 'Coordinate social media pushes in real time. Official moderators surface priority narratives.',
-      link: 'https://community.trump47.com/threads/digital-war-room',
+      title: 'Women & Girls participation forum',
+      description: 'Share success stories and funding tips for growing female cricket programs nationwide.',
+      link: 'https://www.community.cricket.com.au/clubs',
       platform: 'official',
-      moderationLevel: 'campaign',
+      moderationLevel: 'official',
     },
   ];
 

--- a/src/app/components/engagement-banner/engagement-banner.component.html
+++ b/src/app/components/engagement-banner/engagement-banner.component.html
@@ -1,8 +1,8 @@
-<section class="engagement-banner" aria-label="Campaign engagement actions">
+<section class="engagement-banner" aria-label="Cricket supporter actions">
   <div class="copy">
-    <h2>Power the movement</h2>
+    <h2>Follow the action</h2>
     <p>
-      Chip in or jump on a volunteer shift. Every action is synced with HubSpot and NGP VAN so field directors can follow up instantly.
+      Stream matches, secure seats, or find a local club to stay part of the Aussie cricket conversation every week of the year.
     </p>
   </div>
 

--- a/src/app/components/featured-stories/featured-stories.component.html
+++ b/src/app/components/featured-stories/featured-stories.component.html
@@ -1,7 +1,7 @@
 <section class="featured-stories" aria-labelledby="featured-heading" id="stories">
   <div class="featured-stories__header">
     <h2 id="featured-heading">Featured stories</h2>
-    <p class="featured-stories__description">Curated highlights from the campaign trail.</p>
+    <p class="featured-stories__description">Curated highlights from across Australian cricket.</p>
   </div>
 
   <ul class="featured-stories__list">

--- a/src/app/components/featured-stories/featured-stories.component.ts
+++ b/src/app/components/featured-stories/featured-stories.component.ts
@@ -19,22 +19,22 @@ type FeaturedStory = {
 export class FeaturedStoriesComponent {
   readonly stories: FeaturedStory[] = [
     {
-      title: 'Ground Game Intensifies in Swing States',
-      excerpt: 'Organizers ramp up door-to-door outreach in Pennsylvania and Arizona as polling margins tighten.',
-      topic: 'Field Operations',
-      url: 'https://www.donaldjtrump.com/news/'
+      title: 'Shield run machines push for Test recalls',
+      excerpt: 'Twin centuries in Adelaide have selectors reconsidering the pecking order before India arrive.',
+      topic: 'Sheffield Shield',
+      url: 'https://www.cricket.com.au/news'
     },
     {
-      title: 'Fundraising Push Sets New Monthly Record',
-      excerpt: 'Digital campaigns and grassroots donations combine for a historic funding surge across small-dollar donors.',
-      topic: 'Fundraising',
-      url: 'https://www.donaldjtrump.com/news/'
+      title: 'WBBL stars headline Australia A tour',
+      excerpt: 'A youth-heavy squad departs for New Zealand with spots in the national setup on the line.',
+      topic: 'Women’s Cricket',
+      url: 'https://www.cricket.com.au/news'
     },
     {
-      title: 'Policy Rollout Focuses on Energy Independence',
-      excerpt: 'The campaign outlines a renewed strategy for domestic energy production aimed at lowering costs for families.',
-      topic: 'Policy',
-      url: 'https://www.donaldjtrump.com/news/'
+      title: 'BBL trade period sparks marquee shuffle',
+      excerpt: 'Clubs are juggling retention picks and overseas slots as the contracting window opens.',
+      topic: 'Big Bash',
+      url: 'https://www.cricket.com.au/news'
     }
   ];
 }

--- a/src/app/components/insights-sidebar/insights-sidebar.component.html
+++ b/src/app/components/insights-sidebar/insights-sidebar.component.html
@@ -1,7 +1,7 @@
 <aside class="insights" aria-labelledby="insights-heading" id="insights">
   <div class="insights__header">
-    <h2 id="insights-heading">Campaign insights</h2>
-    <p class="insights__description">Key performance signals updated throughout the day.</p>
+    <h2 id="insights-heading">Cricket insights</h2>
+    <p class="insights__description">Form indicators and storylines refreshed throughout the day.</p>
   </div>
 
   <ul class="insights__metrics" role="list">

--- a/src/app/components/insights-sidebar/insights-sidebar.component.ts
+++ b/src/app/components/insights-sidebar/insights-sidebar.component.ts
@@ -19,28 +19,28 @@ type Insight = {
 export class InsightsSidebarComponent {
   readonly insights: Insight[] = [
     {
-      label: 'Digital reach',
-      value: '2.1M',
+      label: 'International form guide',
+      value: '4-1',
       trend: 'up',
-      description: 'Impressions across official channels in the last 48 hours'
+      description: 'Combined record from the last five Australian internationals'
     },
     {
-      label: 'Grassroots events',
-      value: '38',
+      label: 'Domestic ladder movers',
+      value: '3 clubs',
       trend: 'steady',
-      description: 'Scheduled rallies and town halls this week'
+      description: 'Teams jumping two or more spots across Shield and WNCL tables'
     },
     {
-      label: 'Volunteer signups',
-      value: '+14%',
+      label: 'Standout performers',
+      value: '6 players',
       trend: 'up',
-      description: 'Week-over-week increase in new volunteers'
+      description: 'Reached 50+ runs or 3+ wickets in the past 48 hours'
     }
   ];
 
   readonly keyActions: string[] = [
-    'Track upcoming debate preparation milestones',
-    'Highlight localized policy rollouts for supporters',
-    'Coordinate regional press availability with rapid response team'
+    'Monitor upcoming squad announcements and injury reports',
+    'Highlight Big Bash contract windows and trade whispers',
+    'Spotlight community cricket participation drives across the states'
   ];
 }

--- a/src/app/components/news-feed/news-feed.component.html
+++ b/src/app/components/news-feed/news-feed.component.html
@@ -1,6 +1,6 @@
 <div class="news-feed" role="region" aria-labelledby="news-feed-heading">
   <header>
-    <h1 id="news-feed-heading">Trump 2024 Campaign News</h1>
+    <h1 id="news-feed-heading">Australian Cricket News &amp; Analysis</h1>
 
     <div class="controls">
       <div class="filters" role="search">

--- a/src/app/components/news-item/news-item.component.html
+++ b/src/app/components/news-item/news-item.component.html
@@ -36,7 +36,7 @@
       <a
         [routerLink]="detailRoute"
         class="view-story"
-        [attr.aria-label]="'Read campaign context for: ' + item.title"
+        [attr.aria-label]="'Read cricket context for: ' + item.title"
       >
         View story
       </a>
@@ -45,9 +45,9 @@
         target="_blank"
         rel="noopener noreferrer"
         class="read-more"
-        [attr.aria-label]="'Read full post on Reddit: ' + item.title"
+        [attr.aria-label]="'Read full story from ' + item.source"
       >
-        <span>Read on Reddit</span>
+        <span>Read full story</span>
         <svg
           xmlns="http://www.w3.org/2000/svg"
           width="16"
@@ -66,7 +66,7 @@
       </a>
 
       <div class="share">
-        <span>Amplify:</span>
+        <span>Share:</span>
         <a
           *ngFor="let share of shareLinks"
           class="share-link"

--- a/src/app/components/news-item/news-item.component.ts
+++ b/src/app/components/news-item/news-item.component.ts
@@ -53,7 +53,7 @@ export class NewsItemComponent {
     const params = {
       source: 'news_card',
       medium: 'social_share',
-      campaign: 'news_distribution',
+      campaign: 'aussie_cricket_news_distribution',
       content: this.item.id,
       referralCode
     } as const;

--- a/src/app/components/shell/shell.component.html
+++ b/src/app/components/shell/shell.component.html
@@ -2,10 +2,10 @@
 <div class="shell">
   <header class="shell__header" role="banner">
     <div class="shell__branding">
-      <span class="shell__logo" aria-hidden="true">47</span>
+      <span class="shell__logo" aria-hidden="true">AUS</span>
       <div>
-        <p class="shell__title">Trump 47 Campaign Tracker</p>
-        <p class="shell__subtitle">Real-time updates from across the campaign trail</p>
+        <p class="shell__title">Aussie Cricket Pulse</p>
+        <p class="shell__subtitle">Real-time updates from international tours to grassroots pitches</p>
       </div>
     </div>
 
@@ -39,7 +39,7 @@
           [routerLinkActiveOptions]="{ exact: true }"
           [attr.aria-current]="rla.isActive ? 'page' : null"
         >
-          Campaign Feed
+          Cricket Feed
         </a>
       </li>
       <li>
@@ -52,9 +52,9 @@
   </nav>
 
   <main id="main-content" class="shell__main" role="main" tabindex="-1">
-    <div class="shell__grid" aria-label="Campaign dashboard layout">
-      <section class="shell__content" aria-labelledby="campaign-feed-heading">
-        <h2 id="campaign-feed-heading" class="visually-hidden">Campaign news feed</h2>
+    <div class="shell__grid" aria-label="Cricket dashboard layout">
+      <section class="shell__content" aria-labelledby="cricket-feed-heading">
+        <h2 id="cricket-feed-heading" class="visually-hidden">Australian cricket news feed</h2>
         <router-outlet></router-outlet>
       </section>
       <app-featured-stories class="shell__featured"></app-featured-stories>
@@ -63,7 +63,7 @@
   </main>
 
   <footer class="shell__footer" role="contentinfo">
-    <p>Built for accessibility and real-time insight into the 2024 campaign.</p>
-    <a class="footer__feedback" href="mailto:feedback@trump47tracker.com">Share feedback</a>
+    <p>Built for accessibility and real-time insight into Australian cricket.</p>
+    <a class="footer__feedback" href="mailto:hello@aussiecricketpulse.com">Share feedback</a>
   </footer>
 </div>

--- a/src/app/components/story/story-detail/story-detail.component.html
+++ b/src/app/components/story/story-detail/story-detail.component.html
@@ -1,6 +1,6 @@
 <section class="story-detail" *ngIf="!loading && story; else loadingOrError">
   <nav class="breadcrumb">
-    <a routerLink="/" aria-label="Back to campaign news">← Back to news feed</a>
+    <a routerLink="/" aria-label="Back to cricket news">← Back to news feed</a>
   </nav>
 
   <header class="story-header">
@@ -17,7 +17,7 @@
       target="_blank"
       rel="noopener noreferrer"
     >
-      Read on Reddit
+      Read full story
     </a>
   </header>
 

--- a/src/app/components/story/story-detail/story-detail.component.ts
+++ b/src/app/components/story/story-detail/story-detail.component.ts
@@ -72,7 +72,7 @@ export class StoryDetailComponent implements OnInit, OnDestroy {
 
   private updateMeta(detail: StoryDetail): void {
     const summary = detail.summary?.[0] ?? detail.content;
-    const pageTitle = `${detail.title} | Trump 47 Campaign Tracker`;
+    const pageTitle = `${detail.title} | Aussie Cricket Pulse`;
 
     this.title.setTitle(pageTitle);
     this.meta.updateTag({ name: 'description', content: summary });

--- a/src/app/components/story/story-timeline/story-timeline.component.html
+++ b/src/app/components/story/story-timeline/story-timeline.component.html
@@ -1,6 +1,6 @@
 <section class="story-timeline" *ngIf="events?.length">
   <header>
-    <h2>Campaign Timeline</h2>
+    <h2>Cricket Timeline</h2>
     <p class="subtitle">Key developments related to this story</p>
   </header>
 

--- a/src/app/layout/components/footer/layout-footer.component.html
+++ b/src/app/layout/components/footer/layout-footer.component.html
@@ -1,6 +1,6 @@
 <footer class="footer">
   <div class="footer__inner">
-    <p>&copy; {{ updated | date:'yyyy' }} Trump 47 Campaign Tracker. Data aggregated from national outlets.</p>
-    <a href="/media" class="footer__cta" routerLink="/media">Explore campaign media</a>
+    <p>&copy; {{ updated | date:'yyyy' }} Aussie Cricket Pulse. Coverage aggregated from Australian and international cricket outlets.</p>
+    <a href="/media" class="footer__cta" routerLink="/media">Explore cricket media</a>
   </div>
 </footer>

--- a/src/app/layout/components/header/layout-header.component.ts
+++ b/src/app/layout/components/header/layout-header.component.ts
@@ -6,6 +6,6 @@ import { Component } from '@angular/core';
   styleUrls: ['./layout-header.component.scss']
 })
 export class LayoutHeaderComponent {
-  readonly title = 'Trump 47 Campaign Tracker';
-  readonly subtitle = 'Real-time intelligence on the 2024 campaign trail';
+  readonly title = 'Aussie Cricket Pulse';
+  readonly subtitle = 'Real-time intelligence across Australian cricket.';
 }

--- a/src/app/layout/components/hero-metrics/hero-metrics.component.html
+++ b/src/app/layout/components/hero-metrics/hero-metrics.component.html
@@ -7,8 +7,8 @@
 
   <ng-template #emptyState>
     <div class="hero__headline">
-      <p class="hero__eyebrow">Campaign insights</p>
-      <h2 class="hero__title">Tracking breaking news, policy shifts, and campaign moments</h2>
+      <p class="hero__eyebrow">Cricket insights</p>
+      <h2 class="hero__title">Tracking breaking news, selection calls, and match-defining moments</h2>
     </div>
   </ng-template>
 
@@ -25,7 +25,7 @@
       <h3 class="metric__value">{{ metrics.topSources[0].name }}</h3>
       <p class="metric__label">Most active source</p>
       <p class="metric__helper">
-        {{ metrics.topSources[0].count }} mentions across national coverage
+        {{ metrics.topSources[0].count }} mentions across cricket coverage
       </p>
     </article>
 

--- a/src/app/layout/components/nav/layout-nav.component.ts
+++ b/src/app/layout/components/nav/layout-nav.component.ts
@@ -17,7 +17,7 @@ export class LayoutNavComponent {
     { path: '', label: 'Overview', icon: 'dashboard' },
     { path: 'latest', label: 'Latest', icon: 'flash_on' },
     { path: 'timeline', label: 'Timeline', icon: 'timeline' },
-    { path: 'issues', label: 'Issues', icon: 'forum' },
+    { path: 'issues', label: 'Focus Areas', icon: 'forum' },
     { path: 'media', label: 'Media', icon: 'play_circle' }
   ];
 

--- a/src/app/layout/footer/footer.component.html
+++ b/src/app/layout/footer/footer.component.html
@@ -1,8 +1,8 @@
 <footer class="site-footer" role="contentinfo">
   <div class="site-footer__inner">
     <div class="site-footer__brand">
-      <p class="site-footer__title">Trump 47 Campaign Tracker</p>
-      <p class="site-footer__tagline">Monitoring news, policy, and movement energy on the road to November.</p>
+      <p class="site-footer__title">Aussie Cricket Pulse</p>
+      <p class="site-footer__tagline">Tracking news, form, and fixtures across every level of Australian cricket.</p>
     </div>
     <nav class="site-footer__nav" aria-label="Footer">
       <ul>
@@ -13,7 +13,7 @@
     </nav>
   </div>
   <div class="site-footer__meta">
-    <p>&copy; {{ currentYear }} Grassroots Briefing Collective.</p>
-    <a href="mailto:tips&#64;campaigntracker.org">tips&#64;campaigntracker.org</a>
+    <p>&copy; {{ currentYear }} Aussie Cricket Pulse editors.</p>
+    <a href="mailto:hello&#64;aussiecricketpulse.com">hello&#64;aussiecricketpulse.com</a>
   </div>
 </footer>

--- a/src/app/layout/footer/footer.component.ts
+++ b/src/app/layout/footer/footer.component.ts
@@ -13,8 +13,8 @@ export class FooterComponent {
   readonly navLinks = [
     { label: 'News', route: '/news' },
     { label: 'Dashboard', route: '/dashboard' },
-    { label: 'Issues', route: '/issues' },
-    { label: 'Events', route: '/events' },
+    { label: 'Focus Areas', route: '/issues' },
+    { label: 'Fixtures', route: '/events' },
     { label: 'Get Involved', route: '/get-involved' }
   ];
 

--- a/src/app/layout/header/header.component.html
+++ b/src/app/layout/header/header.component.html
@@ -1,11 +1,11 @@
 <header class="site-header" role="banner">
   <div class="site-header__inner">
     <div class="site-header__branding">
-      <a class="site-header__logo" routerLink="/news" aria-label="Trump 47 Tracker home">
-        <span class="site-header__logo-mark" aria-hidden="true">47</span>
+      <a class="site-header__logo" routerLink="/news" aria-label="Aussie Cricket Pulse home">
+        <span class="site-header__logo-mark" aria-hidden="true">AUS</span>
         <span class="site-header__logo-text">
-          <span class="site-header__logo-primary">Trump 47</span>
-          <span class="site-header__logo-secondary">Campaign Tracker</span>
+          <span class="site-header__logo-primary">Aussie Cricket</span>
+          <span class="site-header__logo-secondary">Pulse</span>
         </span>
       </a>
     </div>
@@ -21,7 +21,7 @@
         <li class="primary-nav__item primary-nav__item--mega">
           <button class="primary-nav__link mega-trigger" type="button" aria-haspopup="true"
             [attr.aria-expanded]="megaMenuOpen" aria-controls="issues-mega" (click)="toggleMegaMenu()">
-            Issues
+            Focus Areas
             <span class="chevron" [class.is-open]="megaMenuOpen" aria-hidden="true"></span>
           </button>
           <div id="issues-mega" class="mega-menu" [class.is-open]="megaMenuOpen" [attr.aria-hidden]="!megaMenuOpen">
@@ -44,7 +44,7 @@
     </nav>
 
     <div class="site-header__actions">
-      <div class="cta-list" role="group" aria-label="Campaign calls to action">
+      <div class="cta-list" role="group" aria-label="Cricket supporter actions">
         <a *ngFor="let cta of ctas" class="cta" [ngClass]="'cta--' + cta.style" [href]="cta.href" target="_blank"
           rel="noopener noreferrer">
           <span class="cta__label">{{ cta.label }}</span>
@@ -76,7 +76,7 @@
           <li *ngFor="let link of navLinks">
             <a [routerLink]="link.route" routerLinkActive="is-active" (click)="closeMobileMenu()">{{ link.label }}</a>
           </li>
-          <li class="mobile-drawer__section-label">Issues</li>
+          <li class="mobile-drawer__section-label">Focus Areas</li>
           <li class="mobile-drawer__mega" *ngFor="let section of megaMenuSections">
             <p class="mobile-drawer__heading">{{ section.heading }}</p>
             <ul>
@@ -90,7 +90,7 @@
           </li>
         </ul>
       </nav>
-      <div class="mobile-drawer__ctas" role="group" aria-label="Campaign calls to action">
+      <div class="mobile-drawer__ctas" role="group" aria-label="Cricket supporter actions">
         <a *ngFor="let cta of ctas" class="cta" [ngClass]="'cta--' + cta.style" [href]="cta.href" target="_blank"
           rel="noopener noreferrer">
           <span class="cta__label">{{ cta.label }}</span>

--- a/src/app/layout/header/header.component.ts
+++ b/src/app/layout/header/header.component.ts
@@ -40,59 +40,59 @@ export class HeaderComponent {
   readonly navLinks: NavLink[] = [
     { label: 'News', route: '/news' },
     { label: 'Dashboard', route: '/dashboard' },
-    { label: 'Events', route: '/events' },
+    { label: 'Fixtures', route: '/events' },
     { label: 'Get Involved', route: '/get-involved' }
   ];
 
   readonly megaMenuSections: MegaMenuSection[] = [
     {
-      heading: 'Top Priorities',
+      heading: 'International Focus',
       items: [
         {
-          label: 'Economic Agenda',
-          description: 'Jobs, inflation, and trade policy priorities.',
+          label: "Men's internationals",
+          description: 'Test, ODI, and T20 tour outlooks for the national side.',
           route: '/issues',
-          fragment: 'economy'
+          fragment: 'internationals'
         },
         {
-          label: 'Border & Security',
-          description: 'Immigration, national defense, and public safety.',
+          label: "Women's internationals",
+          description: 'Series updates, selection talking points, and rival previews.',
           route: '/issues',
-          fragment: 'security'
+          fragment: 'womens-internationals'
         }
       ]
     },
     {
-      heading: 'Policy Pillars',
+      heading: 'Domestic Spotlight',
       items: [
         {
-          label: 'Healthcare & Social',
-          description: 'Healthcare access, veteran services, and family support.',
+          label: 'Sheffield Shield & Marsh Cup',
+          description: 'State squads, form lines, and ladder movement.',
           route: '/issues',
-          fragment: 'healthcare'
+          fragment: 'domestic'
         },
         {
-          label: 'Election Integrity',
-          description: 'Voting reforms and oversight initiatives.',
+          label: 'Big Bash leagues',
+          description: 'BBL and WBBL headlines, contracts, and trade whispers.',
           route: '/issues',
-          fragment: 'elections'
+          fragment: 'big-bash'
         }
       ]
     },
     {
-      heading: 'Movement Voices',
+      heading: 'Pathways & Community',
       items: [
         {
-          label: 'Grassroots Spotlights',
-          description: 'Community stories and volunteer organizing.',
+          label: 'Premier cricket focus',
+          description: 'Club cricket standouts pushing for higher honours.',
           route: '/issues',
-          fragment: 'grassroots'
+          fragment: 'pathways'
         },
         {
-          label: 'Media Statements',
-          description: 'Campaign press releases and official responses.',
+          label: 'Participation & growth',
+          description: 'Nationwide initiatives growing the game.',
           route: '/issues',
-          fragment: 'media'
+          fragment: 'participation'
         }
       ]
     }
@@ -100,21 +100,21 @@ export class HeaderComponent {
 
   readonly ctas: CtaLink[] = [
     {
-      label: 'Donate',
-      description: 'Power the movement with a contribution.',
-      href: 'https://www.donaldjtrump.com/',
+      label: 'Buy Tickets',
+      description: 'Secure seats for upcoming internationals and domestic fixtures.',
+      href: 'https://www.cricket.com.au/tickets',
       style: 'primary'
     },
     {
-      label: 'Volunteer',
-      description: 'Host events or knock doors in your community.',
-      href: 'https://www.donaldjtrump.com/join/',
+      label: 'Stream Matches',
+      description: 'Catch every ball with the latest streaming subscriptions.',
+      href: 'https://kayosports.com.au/',
       style: 'outline'
     },
     {
-      label: 'Subscribe',
-      description: 'Get rapid response alerts from campaign HQ.',
-      href: 'https://www.donaldjtrump.com/subscribe/',
+      label: 'Join a Club',
+      description: 'Find a local program through Cricket Australia Club Finder.',
+      href: 'https://www.community.cricket.com.au/clubfinder',
       style: 'ghost'
     }
   ];

--- a/src/app/layout/pages/landing/landing.component.html
+++ b/src/app/layout/pages/landing/landing.component.html
@@ -3,8 +3,8 @@
 
   <section class="landing__news">
     <header class="landing__news-header">
-      <h2>Campaign briefing</h2>
-      <p>Explore the latest reporting gathered across national outlets.</p>
+      <h2>Cricket briefing</h2>
+      <p>Explore the latest coverage spanning internationals, domestic leagues, and pathways.</p>
     </header>
     <app-news-feed></app-news-feed>
   </section>

--- a/src/app/layout/pages/latest/latest.component.html
+++ b/src/app/layout/pages/latest/latest.component.html
@@ -1,7 +1,7 @@
 <section class="latest">
   <header class="latest__header">
     <h2>Latest reporting</h2>
-    <p>Fresh stories and rapid-response coverage from the past 24 hours.</p>
+    <p>Fresh stories and rapid-response coverage from the past 24 hours of Australian cricket.</p>
   </header>
 
   <div class="latest__grid" *ngIf="items$ | async as items; else loading">

--- a/src/app/layout/pages/media/media.component.html
+++ b/src/app/layout/pages/media/media.component.html
@@ -1,7 +1,7 @@
 <section class="media" *ngIf="media$ | async as media">
   <header class="media__header">
-    <h2>Campaign media spotlight</h2>
-    <p>Visual coverage from national outlets and on-the-ground reporting.</p>
+    <h2>Cricket media spotlight</h2>
+    <p>Visual coverage from broadcasters, clubs, and on-the-ground reporters.</p>
   </header>
 
   <div class="media__grid">

--- a/src/app/layout/pages/timeline/timeline.component.html
+++ b/src/app/layout/pages/timeline/timeline.component.html
@@ -1,7 +1,7 @@
 <section class="timeline" *ngIf="timeline$ | async as timeline">
   <header class="timeline__header">
-    <h2>Campaign timeline</h2>
-    <p>Daily chronology of notable headlines and developments.</p>
+    <h2>Cricket timeline</h2>
+    <p>Daily chronology of notable results, squad news, and off-field developments.</p>
   </header>
 
   <ol class="timeline__list">

--- a/src/app/layout/sidebar/sidebar.component.html
+++ b/src/app/layout/sidebar/sidebar.component.html
@@ -1,7 +1,7 @@
 <aside class="campaign-sidebar" aria-labelledby="sidebar-title">
   <div class="campaign-sidebar__section">
-    <h2 id="sidebar-title">Stay engaged</h2>
-    <p>Key actions and resources to keep the campaign momentum moving.</p>
+    <h2 id="sidebar-title">Stay connected</h2>
+    <p>Key links to follow Australian cricket across every competition.</p>
     <ul class="campaign-sidebar__list">
       <li *ngFor="let cta of takeActionCtas">
         <a class="campaign-sidebar__card" [href]="cta.href" target="_blank" rel="noopener noreferrer"
@@ -13,7 +13,7 @@
     </ul>
   </div>
   <div class="campaign-sidebar__section">
-    <h3>Additional resources</h3>
+    <h3>Additional coverage</h3>
     <ul class="campaign-sidebar__list campaign-sidebar__list--compact">
       <li *ngFor="let link of resourceLinks">
         <a class="campaign-sidebar__link" [href]="link.href" target="_blank" rel="noopener noreferrer"

--- a/src/app/layout/sidebar/sidebar.component.ts
+++ b/src/app/layout/sidebar/sidebar.component.ts
@@ -18,37 +18,37 @@ interface SidebarCta {
 export class SidebarComponent {
   readonly takeActionCtas: SidebarCta[] = [
     {
-      label: 'Chip in $20.24',
-      description: 'Donate to accelerate key battleground operations.',
-      href: 'https://www.donaldjtrump.com/',
-      ariaLabel: 'Donate twenty dollars and twenty four cents'
+      label: 'Ticket finder',
+      description: 'Browse upcoming internationals and Big Bash fixtures.',
+      href: 'https://www.cricket.com.au/tickets',
+      ariaLabel: 'Open the Cricket Australia ticket finder'
     },
     {
-      label: 'Become a Captain',
-      description: 'Lead local volunteer teams and coordinate canvasses.',
-      href: 'https://www.donaldjtrump.com/join/',
-      ariaLabel: 'Sign up to become a neighborhood captain'
+      label: 'Club locator',
+      description: 'Connect with local clubs through PlayCricket.',
+      href: 'https://play.cricket.com.au/clubs',
+      ariaLabel: 'Find a local cricket club via PlayCricket'
     },
     {
-      label: 'Rapid Response List',
-      description: 'Get SMS alerts for breaking news and key votes.',
-      href: 'https://www.donaldjtrump.com/subscribe/',
-      ariaLabel: 'Subscribe to the Trump rapid response list'
+      label: 'Match Centre app',
+      description: 'Download the CA Live app for scores and highlights.',
+      href: 'https://www.cricket.com.au/live',
+      ariaLabel: 'Download the Cricket Australia Live app'
     }
   ];
 
   readonly resourceLinks: SidebarCta[] = [
     {
-      label: 'State Leadership',
-      description: 'Find your state director and field staff.',
-      href: 'https://www.donaldjtrump.com/states/',
-      ariaLabel: 'Explore state leadership contacts'
+      label: 'National team hub',
+      description: 'Official news on Australian squads and selection.',
+      href: 'https://www.cricket.com.au/teams/australia-men',
+      ariaLabel: 'View official Australian national team news'
     },
     {
-      label: 'Events Calendar',
-      description: 'See rallies, town halls, and digital events near you.',
-      href: 'https://www.donaldjtrump.com/events/',
-      ariaLabel: 'Open the campaign events calendar'
+      label: 'Community cricket',
+      description: 'Participation resources and programs nationwide.',
+      href: 'https://www.community.cricket.com.au/',
+      ariaLabel: 'Explore Community Cricket resources'
     }
   ];
 }

--- a/src/app/pages/dashboard/dashboard.component.html
+++ b/src/app/pages/dashboard/dashboard.component.html
@@ -1,9 +1,9 @@
 <section class="dashboard" aria-labelledby="dashboard-heading">
   <header class="dashboard__header">
-    <p class="dashboard__eyebrow">Campaign intelligence</p>
-    <h1 id="dashboard-heading">Tracker dashboard</h1>
+    <p class="dashboard__eyebrow">Cricket intelligence</p>
+    <h1 id="dashboard-heading">Performance dashboard</h1>
     <p class="dashboard__lede">
-      Real-time organizing metrics and earned media snapshots to keep rapid response teams aligned.
+      Real-time form lines, selection chatter, and media buzz to keep every level of Aussie cricket in view.
     </p>
   </header>
   <div class="dashboard__metrics" role="list">
@@ -15,18 +15,18 @@
   </div>
   <section class="dashboard__updates" aria-label="Latest updates">
     <article class="dashboard__card">
-      <h2>War room brief</h2>
+      <h2>Selection watch</h2>
       <p>
-        State directors report strong volunteer sign-ups following the Phoenix town hall. Digital ads are
-        outperforming benchmarks in Wisconsin and Pennsylvania.
+        National selectors are weighing an extra spinner for the next Asian tour, while the WBBL talent pool could see two
+        Australia A call-ups fast-tracked after standout weekends.
       </p>
     </article>
     <article class="dashboard__card">
-      <h2>Field priorities</h2>
+      <h2>Focus points</h2>
       <ul>
-        <li>Expand Hispanic media buys in Las Vegas and Miami.</li>
-        <li>Coordinate door-to-door weekend of action with national surrogates.</li>
-        <li>Drive early vote education in Sun Belt metros.</li>
+        <li>Monitor Shield workloads for frontline quicks returning from the UK.</li>
+        <li>Track Big Bash retention deadlines and marquee negotiations.</li>
+        <li>Amplify participation initiatives rolling out in regional communities.</li>
       </ul>
     </article>
   </section>

--- a/src/app/pages/dashboard/dashboard.component.ts
+++ b/src/app/pages/dashboard/dashboard.component.ts
@@ -11,19 +11,19 @@ import { CommonModule } from '@angular/common';
 export class DashboardComponent {
   readonly metrics = [
     {
-      label: 'Battleground events this week',
+      label: 'International matches this month',
+      value: 12,
+      change: '+3 vs. last tour block'
+    },
+    {
+      label: 'Domestic fixtures this week',
+      value: 27,
+      change: '+5 after rain reschedules'
+    },
+    {
+      label: 'Players in form watchlist',
       value: 18,
-      change: '+4 vs. last week'
-    },
-    {
-      label: 'Grassroots captains onboarded',
-      value: 312,
-      change: '+28 in the last 24 hours'
-    },
-    {
-      label: 'Digital impressions YTD',
-      value: '47M',
-      change: '+8% month over month'
+      change: '+6 earning media buzz'
     }
   ];
 }

--- a/src/app/pages/events/events.component.html
+++ b/src/app/pages/events/events.component.html
@@ -1,8 +1,8 @@
 <section class="events" aria-labelledby="events-heading">
   <header class="events__intro">
-    <p class="events__eyebrow">On the road</p>
-    <h1 id="events-heading">Upcoming events</h1>
-    <p>Find campaign stops and grassroots meetups to plug into the movement.</p>
+    <p class="events__eyebrow">Fixtures radar</p>
+    <h1 id="events-heading">Upcoming fixtures</h1>
+    <p>Track the next hits of Australian cricket across internationals and domestic leagues.</p>
   </header>
   <div class="events__list" role="list">
     <article class="events__card" role="listitem" *ngFor="let event of events">
@@ -10,7 +10,7 @@
       <h2>{{ event.title }}</h2>
       <p class="events__location">{{ event.location }}</p>
       <p>{{ event.description }}</p>
-      <a class="events__cta" [href]="event.rsvpUrl" target="_blank" rel="noopener noreferrer">RSVP &rsaquo;</a>
+      <a class="events__cta" [href]="event.matchUrl" target="_blank" rel="noopener noreferrer">Match centre &rsaquo;</a>
     </article>
   </div>
 </section>

--- a/src/app/pages/events/events.component.ts
+++ b/src/app/pages/events/events.component.ts
@@ -1,12 +1,12 @@
 import { Component } from '@angular/core';
 import { CommonModule } from '@angular/common';
 
-interface CampaignEvent {
+interface FixtureEvent {
   title: string;
   location: string;
   date: string;
   description: string;
-  rsvpUrl: string;
+  matchUrl: string;
 }
 
 @Component({
@@ -17,27 +17,27 @@ interface CampaignEvent {
   styleUrls: ['./events.component.scss']
 })
 export class EventsComponent {
-  readonly events: CampaignEvent[] = [
+  readonly events: FixtureEvent[] = [
     {
-      title: 'Rust Belt Jobs Rally',
-      location: 'Erie, Pennsylvania',
-      date: 'June 22, 2024',
-      description: 'Manufacturing workers and small business owners share testimonies on economic revival.',
-      rsvpUrl: 'https://www.donaldjtrump.com/events/'
+      title: 'Australia vs India – 1st Test',
+      location: 'Perth Stadium, Perth',
+      date: '24 November 2024',
+      description: 'The home summer opens with a day-night Test as Australia leans on a three-prong pace attack.',
+      matchUrl: 'https://www.cricket.com.au/series/australia-v-india-test-series'
     },
     {
-      title: 'Border Security Town Hall',
-      location: 'Yuma, Arizona',
-      date: 'June 24, 2024',
-      description: 'Policy roundtable featuring sheriffs, border agents, and Angel families.',
-      rsvpUrl: 'https://www.donaldjtrump.com/events/'
+      title: 'Sydney Sixers vs Brisbane Heat – BBL',
+      location: 'Sydney Cricket Ground, Sydney',
+      date: '12 December 2024',
+      description: 'Two finals contenders clash with marquee all-rounders fresh from overseas stints.',
+      matchUrl: 'https://www.cricket.com.au/fixtures'
     },
     {
-      title: 'Faith & Freedom Summit',
-      location: 'Greenville, South Carolina',
-      date: 'June 27, 2024',
-      description: 'Pastors, faith leaders, and youth ministries coordinating voter outreach.',
-      rsvpUrl: 'https://www.donaldjtrump.com/events/'
+      title: 'WNCL Final',
+      location: 'Allan Border Field, Brisbane',
+      date: '22 February 2025',
+      description: 'State pride on the line with national selectors watching every over for breakout stars.',
+      matchUrl: 'https://www.cricket.com.au/series/wncl'
     }
   ];
 }

--- a/src/app/pages/get-involved/get-involved.component.html
+++ b/src/app/pages/get-involved/get-involved.component.html
@@ -1,8 +1,8 @@
 <section class="get-involved" aria-labelledby="get-involved-heading">
   <header class="get-involved__intro">
-    <p class="get-involved__eyebrow">Take action</p>
+    <p class="get-involved__eyebrow">Stay part of the game</p>
     <h1 id="get-involved-heading">Get involved today</h1>
-    <p>Choose a pathway to contribute your time, talent, or resources to the movement.</p>
+    <p>Choose a pathway to follow, support, or play Australian cricket in your community.</p>
   </header>
   <div class="get-involved__grid">
     <article class="get-involved__card" *ngFor="let step of steps">
@@ -13,8 +13,8 @@
   </div>
   <section class="get-involved__newsletter" aria-label="Newsletter signup">
     <h2>Stay informed</h2>
-    <p>Subscribe to get the daily briefing and volunteer opportunities in your inbox.</p>
-    <form class="get-involved__form" aria-label="Subscribe to campaign updates" (submit)="onSubmit($event)" novalidate>
+    <p>Subscribe for cricket news round-ups, fixture alerts, and grassroots stories.</p>
+    <form class="get-involved__form" aria-label="Subscribe to cricket updates" (submit)="onSubmit($event)" novalidate>
       <label class="visually-hidden" for="newsletter-email">Email address</label>
       <input id="newsletter-email" type="email" placeholder="you@example.com" required />
       <button type="submit">Subscribe</button>

--- a/src/app/pages/get-involved/get-involved.component.ts
+++ b/src/app/pages/get-involved/get-involved.component.ts
@@ -17,19 +17,19 @@ interface ActionStep {
 export class GetInvolvedComponent {
   readonly steps: ActionStep[] = [
     {
-      title: 'Join the grassroots team',
-      description: 'Become a neighborhood captain to coordinate phone banks and canvasses.',
-      link: 'https://www.donaldjtrump.com/join/'
+      title: 'Subscribe to match alerts',
+      description: 'Get fixture reminders and squad news direct from Cricket Australia.',
+      link: 'https://www.cricket.com.au/newsletters'
     },
     {
-      title: 'Host a house meeting',
-      description: 'Download our toolkit and invite supporters for a rapid response briefing.',
-      link: 'https://www.donaldjtrump.com/get-involved/'
+      title: 'Volunteer with community cricket',
+      description: 'Support junior programs and festivals in your state.',
+      link: 'https://www.community.cricket.com.au/volunteers'
     },
     {
-      title: 'Digital rapid responders',
-      description: 'Amplify campaign messaging with social media share kits and daily talking points.',
-      link: 'https://www.donaldjtrump.com/subscribe/'
+      title: 'Support a local club',
+      description: 'Find a club near you and help keep grassroots cricket thriving.',
+      link: 'https://play.cricket.com.au/clubs'
     }
   ];
 

--- a/src/app/pages/issues/issues.component.html
+++ b/src/app/pages/issues/issues.component.html
@@ -1,9 +1,9 @@
 <section class="issues" aria-labelledby="issues-heading">
   <header class="issues__intro">
-    <p class="issues__eyebrow">Policy agenda</p>
-    <h1 id="issues-heading">Where the campaign is focused</h1>
+    <p class="issues__eyebrow">Focus areas</p>
+    <h1 id="issues-heading">Where Australian cricket is focused</h1>
     <p class="issues__lede">
-      Explore core priorities shaping the movement and dive into highlight reels pulled from the campaign trail.
+      Explore the competitions and storylines shaping the summer, from national teams to pathways programs.
     </p>
   </header>
   <div class="issues__grid">

--- a/src/app/pages/issues/issues.component.ts
+++ b/src/app/pages/issues/issues.component.ts
@@ -18,63 +18,63 @@ interface IssueSection {
 export class IssuesComponent {
   readonly sections: IssueSection[] = [
     {
-      id: 'economy',
-      title: 'Economy first agenda',
-      summary: 'Tax relief for working families, energy dominance, and small business expansion.',
+      id: 'internationals',
+      title: "Men's internationals",
+      summary: 'Tests, ODIs, and T20s featuring the Australian men.',
       bullets: [
-        'Pledge to extend middle-class tax cuts and expand opportunity zones.',
-        'Reinvest in American energy with new drilling permits and refining capacity.',
-        'Launch apprenticeship partnerships with community colleges.'
+        'Selectors weighing spin options for the next subcontinent tour.',
+        'Managing the pace cartel workloads through overlapping series.',
+        'Stabilising the middle order in white-ball squads ahead of the World Cup.'
       ]
     },
     {
-      id: 'security',
-      title: 'Border & national security',
-      summary: 'Finish the wall, restore remain-in-Mexico, and boost law enforcement resources.',
+      id: 'womens-internationals',
+      title: "Women's internationals",
+      summary: 'World champion Aussies fine-tuning for multi-format series.',
       bullets: [
-        'Deploy additional border agents and accelerate asylum processing reforms.',
-        'Block fentanyl trafficking with new technology at ports of entry.',
-        'Back the blue with federal support for local task forces.'
+        'Rotation plan to balance WPL commitments with national duties.',
+        'Emerging quicks pressing for debuts after standout WNCL campaigns.',
+        'Leadership group mapping out Ashes defence later in the summer.'
       ]
     },
     {
-      id: 'healthcare',
-      title: 'Healthcare & social supports',
-      summary: 'Lower costs, protect seniors, and expand rural care access.',
+      id: 'domestic',
+      title: 'Sheffield Shield & Marsh Cup',
+      summary: 'State rivalries driving selection debates and ladder movement.',
       bullets: [
-        'Drive price transparency across hospitals and insurers.',
-        'Expand telehealth waivers for rural clinics and veteran care.',
-        'Protect Medicare and Social Security with fiscal discipline.'
+        'Queensland and Victoria jostling for top-two berths in the Shield.',
+        'White-ball bolters staking claims with heavy Marsh Cup returns.',
+        'Spin depth chart evolving as SCG and Adelaide decks take turn.'
       ]
     },
     {
-      id: 'elections',
-      title: 'Election integrity',
-      summary: 'Secure ballots, clean voter rolls, and restore confidence in elections.',
+      id: 'big-bash',
+      title: 'Big Bash leagues',
+      summary: 'BBL and WBBL squads recalibrating under the new contracting windows.',
       bullets: [
-        'Advance voter ID standards with state partners.',
-        'Invest in poll watcher training and legal rapid response teams.',
-        'Modernize election systems with paper backups and audits.'
+        'Draft retention lists due before international player nominations open.',
+        'Clubs chasing marquee all-rounders after standout Hundred campaigns.',
+        'Venue upgrades and themed rounds to broaden audience reach.'
       ]
     },
     {
-      id: 'grassroots',
-      title: 'Grassroots spotlights',
-      summary: 'Stories from volunteers building the movement at the local level.',
+      id: 'pathways',
+      title: 'Premier cricket focus',
+      summary: 'Club standouts and Australia A tours feeding the national depth chart.',
       bullets: [
-        'Faith coalition in Georgia registering new voters weekly.',
-        'Small business owners hosting roundtables on regulatory reform.',
-        'College chapters leading campus debate nights.'
+        'Under-19 squads locking in for the next Youth World Cup cycle.',
+        'Premier competitions trialling nighttime red-ball fixtures.',
+        'Academy coaches spotlighting multi-sport talent conversions.'
       ]
     },
     {
-      id: 'media',
-      title: 'Media statements',
-      summary: 'Official campaign messaging and fact checks in response to breaking news.',
+      id: 'participation',
+      title: 'Participation & growth',
+      summary: 'Initiatives widening the player base from schools to social leagues.',
       bullets: [
-        'Weekly talking points for surrogate interviews.',
-        'Shareable graphics for social platforms.',
-        'Rapid rebuttal briefs for newsroom outreach.'
+        'Woolworths Cricket Blast expanding into more remote communities.',
+        'State associations piloting inclusive equipment grants.',
+        'First Nations programs pairing cultural exchange with coaching clinics.'
       ]
     }
   ];

--- a/src/app/routes/timeline/timeline.component.html
+++ b/src/app/routes/timeline/timeline.component.html
@@ -11,9 +11,9 @@
   <ng-container *ngIf="state.state === 'loaded'">
     <header class="timeline__header">
       <div>
-        <h1>Campaign Timeline</h1>
+        <h1>Cricket Timeline</h1>
         <p class="timeline__subhead">
-          Curated moments and news grouped by topic, with a quick read on how momentum is shifting.
+          Curated moments and news grouped by topic, with a quick read on how momentum is shifting across Australian cricket.
         </p>
       </div>
       <div class="timeline__meta">

--- a/src/app/services/entitlement.service.ts
+++ b/src/app/services/entitlement.service.ts
@@ -21,7 +21,7 @@ export class EntitlementService {
       return;
     }
 
-    const raw = localStorage.getItem('trump47_entitlement');
+    const raw = localStorage.getItem('acp_entitlement');
     if (raw) {
       const parsed = JSON.parse(raw) as EntitlementState;
       if (parsed.expiresAt) {
@@ -68,6 +68,6 @@ export class EntitlementService {
     }
 
     const state = this.state$.value;
-    localStorage.setItem('trump47_entitlement', JSON.stringify(state));
+    localStorage.setItem('acp_entitlement', JSON.stringify(state));
   }
 }

--- a/src/app/services/experiment.service.ts
+++ b/src/app/services/experiment.service.ts
@@ -8,7 +8,7 @@ export interface ExperimentVariant {
 
 @Injectable({ providedIn: 'root' })
 export class ExperimentService {
-  private readonly storageKeyPrefix = 'trump47_experiment_';
+  private readonly storageKeyPrefix = 'acp_experiment_';
 
   assignVariant(experimentId: string, variants: ExperimentVariant[]): ExperimentVariant {
     if (typeof window === 'undefined') {

--- a/src/app/services/news-api.service.ts
+++ b/src/app/services/news-api.service.ts
@@ -81,7 +81,7 @@ export class NewsApiService {
           .filter((event: any) => event)
           .map((event: any) => ({
             date: event.date ?? event.timestamp ?? '',
-            headline: event.headline ?? event.title ?? 'Campaign milestone',
+            headline: event.headline ?? event.title ?? 'Match highlight',
             description: event.description ?? event.summary
           }))
           .filter((event: TimelineEvent) => !!event.date && !!event.headline)
@@ -89,11 +89,11 @@ export class NewsApiService {
 
     return {
       id: response.id ?? response.articleId ?? '',
-      title: response.title ?? 'Campaign story',
+      title: response.title ?? 'Cricket story',
       link: response.link ?? response.url ?? '',
       pubDate: response.pubDate ? new Date(response.pubDate) : new Date(),
       content: response.content ?? response.summary ?? '',
-      source: response.source ?? response.primarySource ?? 'Campaign coverage',
+      source: response.source ?? response.primarySource ?? 'Cricket coverage',
       category: response.category,
       imageUrl: response.imageUrl ?? response.image,
       summary,

--- a/src/app/services/referral.service.ts
+++ b/src/app/services/referral.service.ts
@@ -2,11 +2,11 @@ import { Injectable } from '@angular/core';
 
 @Injectable({ providedIn: 'root' })
 export class ReferralService {
-  private readonly storageKey = 'trump47_referral_code';
+  private readonly storageKey = 'acp_referral_code';
 
   getReferralCode(): string {
     if (typeof window === 'undefined') {
-      return 'T47-OFFLINE';
+      return 'ACR-OFFLINE';
     }
 
     const existing = localStorage.getItem(this.storageKey);
@@ -14,7 +14,7 @@ export class ReferralService {
       return existing;
     }
 
-    const generated = `T47-${Math.random().toString(36).slice(2, 8).toUpperCase()}`;
+    const generated = `ACR-${Math.random().toString(36).slice(2, 8).toUpperCase()}`;
     localStorage.setItem(this.storageKey, generated);
     return generated;
   }

--- a/src/app/services/tracking.service.ts
+++ b/src/app/services/tracking.service.ts
@@ -11,8 +11,7 @@ export interface TrackingParams {
 
 @Injectable({ providedIn: 'root' })
 export class TrackingService {
-  private readonly hubspotPortalId = 'HUBSPOT_PORTAL_ID';
-  private readonly ngpVANCommitteeId = 'NGP_VAN_COMMITTEE_ID';
+  private readonly referralTag = 'AUSSIE_CRICKET_PULSE';
 
   buildTrackedUrl(baseUrl: string, params: TrackingParams): string {
     const url = new URL(baseUrl);
@@ -22,16 +21,15 @@ export class TrackingService {
       }
     });
 
-    // Attach CRM references so the links can be ingested downstream.
-    url.searchParams.set('hubspot_portal_id', this.hubspotPortalId);
-    url.searchParams.set('ngp_van_committee_id', this.ngpVANCommitteeId);
+    // Tag outbound links so downstream partners can attribute referrals.
+    url.searchParams.set('ref', this.referralTag);
 
     return url.toString();
   }
 
   emitEvent(eventName: string, payload: Record<string, unknown> = {}): void {
-    // In a real deployment this would forward to Google Analytics, HubSpot, and NGP VAN.
-    // For now we log to the console so the data pipeline can be validated in QA.
+    // In a real deployment this would forward to analytics and partner attribution tools.
+    // For now we log to the console so signal flow can be validated in QA.
     console.debug('[tracking]', eventName, payload);
   }
 }

--- a/src/assets/data/news-topics.json
+++ b/src/assets/data/news-topics.json
@@ -1,137 +1,137 @@
 {
-  "lastUpdated": "2024-09-30T18:30:00.000Z",
+  "lastUpdated": "2024-10-05T08:30:00.000Z",
   "topics": [
     {
-      "slug": "legal-battles",
-      "title": "Legal Battles and Court Strategy",
-      "summary": "Tracking how Trump's campaign weaponizes ongoing court fights to energize supporters and drive fundraising.",
-      "curatedCopy": "## Courtroom vs. Campaign\nThe campaign treats every filing and hearing as a two-for-one opportunity: legal defense by day, campaign rallying cry by night. Fundraising texts reference each development within minutes, and surrogates translate legal jargon into a persecution narrative built for cable hits.\n\n### Messaging pillars\n- Portray restrictions as election interference.\n- Tie prosecutors to Democratic leaders by name.\n- Pledge to overhaul the justice system on day one.",
+      "slug": "international-tours",
+      "title": "International tours and squad strategy",
+      "summary": "How Australia is juggling heavy travel schedules with selection calls for India and the Caribbean.",
+      "curatedCopy": "## Series outlook\nSelectors are keeping one eye on the Border-Gavaskar rematch while managing player loads during the white-ball swing through the Caribbean. The men pivot from subcontinent spin plans to extra pace options in Perth, while the women balance WBBL commitments with a multi-format Ashes defence.\n\n### Key talking points\n- Rotation policy for frontline quicks across formats.\n- Batting order tweaks to cover a recovering Steve Smith.\n- Match simulation camps for the women's squad before England arrive.",
       "callouts": [
         {
           "title": "Why it matters",
-          "markdown": "- Legal updates regularly spike small-dollar donations.\n- Base voters cite legal fights as proof the movement is under attack."
+          "markdown": "- Australia plays nine internationals in 28 days.\n- Selection decisions now flow directly into World Cup qualification scenarios."
         },
         {
-          "title": "Watch the calendar",
-          "markdown": "Sentencing and pre-trial hearings align with key fundraising deadlines, giving the campaign recurring content moments."
+          "title": "Watch the travel",
+          "markdown": "Perth, Melbourne, Barbados, then Chennai across six weeks demands strong recovery protocols."
         }
       ],
       "spotlightIds": ["article-1"],
       "momentumSeries": [
-        { "date": "2024-09-18", "value": 38 },
-        { "date": "2024-09-22", "value": 47 },
-        { "date": "2024-09-25", "value": 56 },
-        { "date": "2024-09-27", "value": 59 },
-        { "date": "2024-09-30", "value": 61 }
+        { "date": "2024-09-25", "value": 42 },
+        { "date": "2024-09-28", "value": 48 },
+        { "date": "2024-09-30", "value": 55 },
+        { "date": "2024-10-02", "value": 59 },
+        { "date": "2024-10-05", "value": 63 }
       ],
       "events": [
         {
-          "slug": "georgia-ruling",
-          "title": "Georgia racketeering ruling resets the clock",
-          "date": "2024-09-23T10:00:00.000Z",
-          "description": "A Fulton County judge delays proceedings into 2025. The campaign frames the pause as proof the case is collapsing and uses the reprieve to claim momentum in swing states.",
-          "momentum": 58,
+          "slug": "perth-test-selection",
+          "title": "Selectors hint at three-prong pace for Perth Test",
+          "date": "2024-09-30T02:00:00.000Z",
+          "description": "George Bailey confirms a pace-heavy attack is likely for the opening India Test, with Nathan Lyon still pencilled in as the lone specialist spinner.",
+          "momentum": 61,
           "relatedItemIds": ["article-1", "article-2"]
         },
         {
-          "slug": "gag-order-fight",
-          "title": "New York gag order fight becomes a censorship narrative",
-          "date": "2024-09-27T18:00:00.000Z",
-          "description": "Surrogates argue that limits on Trump's speech are an attack on supporters, driving sympathetic coverage and op-eds from allies.",
+          "slug": "womens-ashes-camp",
+          "title": "Women's squad reconvenes ahead of Ashes defence",
+          "date": "2024-10-01T22:00:00.000Z",
+          "description": "Meg Lanning leads a Gold Coast camp blending Ashes prep with WBBL planning, spotlighting emerging quicks from the WNCL.",
           "momentum": 62,
           "relatedItemIds": ["article-3"]
         },
         {
-          "slug": "immunity-appeal",
-          "title": "Supreme Court appeal teasers revive immunity storyline",
-          "date": "2024-09-29T14:30:00.000Z",
-          "description": "Campaign lawyers preview new filings that they say will shield Trump from future prosecutions, reinforcing the promise of a second-term crackdown on DOJ critics.",
-          "momentum": 64,
+          "slug": "caribbean-t20-shuffle",
+          "title": "Caribbean T20 tour forces middle-order rethink",
+          "date": "2024-10-04T12:30:00.000Z",
+          "description": "Matthew Wade's hamstring tweak prompts a recall for Josh Inglis and a flexible finishing role for Glenn Maxwell.",
+          "momentum": 65,
           "relatedItemIds": ["article-4"]
         }
       ]
     },
     {
-      "slug": "ground-game",
-      "title": "Swing-State Ground Game",
-      "summary": "Field organizing pushes in the Rust Belt and Sun Belt aimed at closing the early-vote gap.",
-      "curatedCopy": "## Organizing Infrastructure\nField staff are leaning on county GOP offices, faith leaders, and a revived \"Trump Force 47\" volunteer portal. The campaign highlights door-knocking stats at every rally to signal professionalization while maintaining the outsider vibe.\n\n### Key tactics\n1. Overlapping bus tours in Pennsylvania, Michigan, and Georgia.\n2. Micro-targeted radio ads focused on energy costs and border security.\n3. Faith outreach breakfasts that double as data collection events.",
+      "slug": "domestic-leagues",
+      "title": "Domestic leagues reset",
+      "summary": "Sheffield Shield and Big Bash clubs jostle for form and signatures before the summer rush.",
+      "curatedCopy": "## Domestic pulse\nShield run machines are staking claims for Perth while BBL list managers weigh marquee retention picks. State coaches emphasise rotation with several Test hopefuls flying in from county stints.\n\n### What we’re tracking\n1. Queensland's charge up the Shield ladder.\n2. WBBL recruiting battles for fast-bowling depth.\n3. Infrastructure upgrades ahead of a packed Christmas-New Year fixture block.",
       "callouts": [
         {
-          "title": "Staffing snapshot",
-          "markdown": "- 48 paid staffers announced across four battleground states.\n- County captains recruited from 2020 stop-the-steal networks."
+          "title": "Ladder watch",
+          "markdown": "- Queensland move into second after the Gabba draw.\n- South Australia banking bonus points despite two close losses."
         }
       ],
       "spotlightIds": ["article-5"],
       "momentumSeries": [
-        { "date": "2024-09-18", "value": 32 },
-        { "date": "2024-09-22", "value": 36 },
-        { "date": "2024-09-25", "value": 40 },
-        { "date": "2024-09-27", "value": 44 },
-        { "date": "2024-09-30", "value": 49 }
+        { "date": "2024-09-25", "value": 36 },
+        { "date": "2024-09-28", "value": 41 },
+        { "date": "2024-09-30", "value": 46 },
+        { "date": "2024-10-03", "value": 51 },
+        { "date": "2024-10-05", "value": 55 }
       ],
       "events": [
         {
-          "slug": "pennsylvania-field-offices",
-          "title": "Six new Pennsylvania field offices open ahead of mail voting",
-          "date": "2024-09-24T15:00:00.000Z",
-          "description": "Campaign claims 8,000 volunteers signed up after the openings, using live streams from each ribbon cutting.",
-          "momentum": 46,
+          "slug": "shield-double-ton",
+          "title": "Pucovski double-ton reignites Test talk",
+          "date": "2024-09-29T06:00:00.000Z",
+          "description": "The Victorian opener peels off 202 at Adelaide Oval, pushing his case for a recall after two seasons on the sidelines.",
+          "momentum": 54,
           "relatedItemIds": ["article-5", "article-6"]
         },
         {
-          "slug": "rural-bus-tour",
-          "title": "Rural bus tour spotlights energy message",
-          "date": "2024-09-26T20:00:00.000Z",
-          "description": "Surrogates barnstorm rural Ohio and Michigan touting drilling permits and farmers' fuel costs, capturing local TV coverage.",
-          "momentum": 48,
+          "slug": "bbl-retention-deadline",
+          "title": "BBL clubs lock in retention picks",
+          "date": "2024-10-02T09:00:00.000Z",
+          "description": "Sydney Sixers keep hold of Tom Curran as Brisbane Heat chase another power hitter ahead of the overseas draft.",
+          "momentum": 57,
           "relatedItemIds": ["article-7"]
         },
         {
-          "slug": "latino-faith-outreach",
-          "title": "Latino faith outreach adds bilingual voter guides",
-          "date": "2024-09-28T17:00:00.000Z",
-          "description": "Church partnerships distribute Spanish-language voter packets, part of a broader move to chip into Biden's coalition.",
-          "momentum": 50,
+          "slug": "wncl-fast-bowler",
+          "title": "WNCL quick clocks 130 km/h in season opener",
+          "date": "2024-10-04T03:30:00.000Z",
+          "description": "Teenager Chloe Ainsworth rips through Victoria with a five-wicket haul, raising talk of an Australia A berth.",
+          "momentum": 58,
           "relatedItemIds": ["article-8"]
         }
       ]
     },
     {
-      "slug": "issue-messaging",
-      "title": "Issue Messaging & Narrative Testing",
-      "summary": "Rapid-response talking points on immigration, inflation, and foreign policy tested across conservative media.",
-      "curatedCopy": "## Narrative Testing\nCampaign pollsters feed nightly findings into surrogate briefings. Messaging pivots quickly to keep the news cycle on favorable terrain, often marrying immigration with inflation to hold focus.\n\n#### Channels\n- Late-night Truth Social posts.\n- Podcast blitzes hosted by allied influencers.\n- Geo-targeted pre-roll ads that shift by state.",
+      "slug": "pathways",
+      "title": "Pathways and participation",
+      "summary": "Grassroots programs and Australia A tours shaping the next generation.",
+      "curatedCopy": "## Building the pipeline\nCricket Australia is funnelling extra support into remote communities while academy coaches celebrate cross-code recruits. The Australia A schedule doubles as a trial for future World Cup squads, and Premier Cricket clubs are experimenting with twilight rounds to draw bigger crowds.\n\n### Spotlight initiatives\n- First Nations cricket festivals expanding into the NT.\n- PlayCricket club grants for regional Victoria.\n- Australia A mixed-format tour giving fringe players multi-day exposure.",
       "callouts": [
         {
-          "title": "Rapid-response cadence",
-          "markdown": "Clip packages are cut within 45 minutes of any major Biden gaffe and sent to a 2,000-person surrogate list."
+          "title": "Participation snapshot",
+          "markdown": "- Junior registrations up 11% year-on-year.\n- 42% of new sign-ups are girls or women."
         }
       ],
       "spotlightIds": ["article-9"],
       "momentumSeries": [
-        { "date": "2024-09-18", "value": 41 },
-        { "date": "2024-09-22", "value": 43 },
-        { "date": "2024-09-25", "value": 47 },
-        { "date": "2024-09-27", "value": 52 },
-        { "date": "2024-09-30", "value": 55 }
+        { "date": "2024-09-25", "value": 28 },
+        { "date": "2024-09-28", "value": 31 },
+        { "date": "2024-09-30", "value": 35 },
+        { "date": "2024-10-02", "value": 39 },
+        { "date": "2024-10-05", "value": 44 }
       ],
       "events": [
         {
-          "slug": "immigration-ad-blitz",
-          "title": "Immigration ad blitz ties border to inflation",
-          "date": "2024-09-25T12:00:00.000Z",
-          "description": "A wave of digital ads claims rising grocery prices stem from federal spending on migrants, a talking point echoed by surrogates on radio.",
-          "momentum": 53,
-          "relatedItemIds": ["article-9", "article-10"]
+          "slug": "australia-a-tour",
+          "title": "Australia A squad named for NZ tour",
+          "date": "2024-09-27T01:00:00.000Z",
+          "description": "A youth-heavy squad will contest red and white-ball fixtures, with selectors highlighting versatility as the key metric.",
+          "momentum": 42,
+          "relatedItemIds": ["article-9"]
         },
         {
-          "slug": "debate-prep-messaging",
-          "title": "Debate prep memos leak to conservative outlets",
-          "date": "2024-09-29T11:00:00.000Z",
-          "description": "Selective leaks preview attacks on Biden's foreign policy, keeping the focus on Afghanistan while framing Trump as steady on world affairs.",
-          "momentum": 57,
-          "relatedItemIds": ["article-11"]
+          "slug": "playcricket-grants",
+          "title": "PlayCricket grants open for regional clubs",
+          "date": "2024-10-03T20:00:00.000Z",
+          "description": "Clubs can access equipment funding aimed at growing girls' and all-abilities programs before summer.",
+          "momentum": 45,
+          "relatedItemIds": ["article-10"]
         }
       ]
     }
@@ -139,157 +139,143 @@
   "items": [
     {
       "id": "article-1",
-      "title": "Trump campaign blasts Georgia prosecutors after trial delay",
-      "link": "https://example.com/trump-georgia-delay",
-      "pubDate": "2024-09-23T15:45:00.000Z",
-      "content": "Senior aides told reporters the delay proves the case is political, urging supporters to donate to \"finish the fight\".",
-      "source": "Politico",
-      "category": "Legal",
-      "imageUrl": "https://images.example.com/trump-court.jpg",
-      "topics": ["legal-battles"],
-      "eventSlug": "georgia-ruling",
+      "title": "Australia weigh three quicks for opening India Test",
+      "link": "https://www.cricket.com.au/news/australia-india-test-selection-pace-attack/2024-09-30",
+      "pubDate": "2024-09-30T04:45:00.000Z",
+      "content": "Pat Cummins signals confidence in his quicks with Cameron Green on standby as an all-round option.",
+      "source": "cricket.com.au",
+      "category": "International",
+      "imageUrl": "https://images.example.com/australia-pace-group.jpg",
+      "topics": ["international-tours"],
+      "eventSlug": "perth-test-selection",
       "sentiment": "positive",
-      "momentumScore": 58
+      "momentumScore": 61
     },
     {
       "id": "article-2",
-      "title": "Fundraising text blitz follows Georgia ruling",
-      "link": "https://example.com/fundraising-texts",
-      "pubDate": "2024-09-24T02:30:00.000Z",
-      "content": "Within hours of the judge's order, the campaign sent seven fundraising texts referencing \"witch hunt delays\".",
-      "source": "Axios",
-      "category": "Campaign Finance",
-      "imageUrl": "https://images.example.com/text-blitz.jpg",
-      "topics": ["legal-battles", "ground-game"],
-      "eventSlug": "georgia-ruling",
-      "sentiment": "positive",
-      "momentumScore": 57
+      "title": "Smith rests up with minor wrist niggle",
+      "link": "https://www.espncricinfo.com/story/steven-smith-wrist-injury-india-series-update-1413569",
+      "pubDate": "2024-10-01T01:15:00.000Z",
+      "content": "Batting coach Michael Di Venuto says the veteran will be fit for Perth after missing the final ODI in Trinidad.",
+      "source": "ESPNcricinfo",
+      "category": "International",
+      "imageUrl": "https://images.example.com/smith-fitness.jpg",
+      "topics": ["international-tours"],
+      "eventSlug": "perth-test-selection",
+      "sentiment": "neutral",
+      "momentumScore": 58
     },
     {
       "id": "article-3",
-      "title": "Trump allies decry gag order on conservative media",
-      "link": "https://example.com/gag-order-response",
-      "pubDate": "2024-09-27T22:10:00.000Z",
-      "content": "Surrogates lined up on talk radio to argue that the gag order is really aimed at silencing supporters.",
-      "source": "Fox News",
-      "category": "Media",
-      "imageUrl": "https://images.example.com/gag-order.jpg",
-      "topics": ["legal-battles", "issue-messaging"],
-      "eventSlug": "gag-order-fight",
+      "title": "Lanning leads high-intensity camp on Gold Coast",
+      "link": "https://www.cricket.com.au/news/australia-women-ashes-prep-gold-coast-camp/2024-10-02",
+      "pubDate": "2024-10-02T06:05:00.000Z",
+      "content": "The skipper says younger quicks are pushing speeds that rival established stars ahead of the Ashes.",
+      "source": "cricket.com.au",
+      "category": "Women",
+      "imageUrl": "https://images.example.com/womens-camp.jpg",
+      "topics": ["international-tours"],
+      "eventSlug": "womens-ashes-camp",
       "sentiment": "positive",
       "momentumScore": 62
     },
     {
       "id": "article-4",
-      "title": "Campaign previews Supreme Court immunity appeal",
-      "link": "https://example.com/immunity-appeal",
-      "pubDate": "2024-09-29T16:05:00.000Z",
-      "content": "Advisers say a conservative majority will rein in the Department of Justice, promising day-one reforms.",
-      "source": "Wall Street Journal",
-      "category": "Legal",
-      "imageUrl": "https://images.example.com/supreme-court.jpg",
-      "topics": ["legal-battles", "issue-messaging"],
-      "eventSlug": "immunity-appeal",
+      "title": "Maxwell embraces floating finisher role in Caribbean",
+      "link": "https://www.smh.com.au/sport/cricket/maxwell-caribbean-t20-tour-role-20241004-p5bg88.html",
+      "pubDate": "2024-10-04T14:20:00.000Z",
+      "content": "Australia consider Glenn Maxwell as a flexible option after Matthew Wade's hamstring concern.",
+      "source": "Sydney Morning Herald",
+      "category": "International",
+      "imageUrl": "https://images.example.com/maxwell-caribbean.jpg",
+      "topics": ["international-tours"],
+      "eventSlug": "caribbean-t20-shuffle",
       "sentiment": "positive",
-      "momentumScore": 64
+      "momentumScore": 65
     },
     {
       "id": "article-5",
-      "title": "Trump opens six field offices across Pennsylvania",
-      "link": "https://example.com/pennsylvania-field",
-      "pubDate": "2024-09-24T18:30:00.000Z",
-      "content": "Ribbon cuttings featured local lawmakers and targeted messages about energy prices.",
-      "source": "Philadelphia Inquirer",
-      "category": "Ground Game",
-      "imageUrl": "https://images.example.com/field-office.jpg",
-      "topics": ["ground-game"],
-      "eventSlug": "pennsylvania-field-offices",
+      "title": "Pucovski double-ton drives Victoria to bonus points",
+      "link": "https://www.theage.com.au/sport/cricket/pucovski-double-ton-puts-victoria-in-the-frame-20240929-p5bfy0.html",
+      "pubDate": "2024-09-29T07:30:00.000Z",
+      "content": "A 202-run marathon sees Victoria leapfrog South Australia on the Shield ladder.",
+      "source": "The Age",
+      "category": "Sheffield Shield",
+      "imageUrl": "https://images.example.com/pucovski-celebrates.jpg",
+      "topics": ["domestic-leagues"],
+      "eventSlug": "shield-double-ton",
       "sentiment": "positive",
-      "momentumScore": 46
+      "momentumScore": 54
     },
     {
       "id": "article-6",
-      "title": "Volunteer sign-ups surge after field office blitz",
-      "link": "https://example.com/volunteer-surge",
-      "pubDate": "2024-09-25T14:20:00.000Z",
-      "content": "Campaign claims 8,000 new volunteers, though Democrats dispute the number.",
-      "source": "NBC News",
-      "category": "Ground Game",
-      "imageUrl": "https://images.example.com/volunteers.jpg",
-      "topics": ["ground-game"],
-      "eventSlug": "pennsylvania-field-offices",
-      "sentiment": "neutral",
-      "momentumScore": 44
+      "title": "Queensland climb with gritty Gabba draw",
+      "link": "https://www.cricket.com.au/news/sheffield-shield-queensland-draw-tasmania-table-update/2024-10-01",
+      "pubDate": "2024-10-01T03:55:00.000Z",
+      "content": "Usman Khawaja's final-day 89 anchors the Bulls as they move into second on the ladder.",
+      "source": "cricket.com.au",
+      "category": "Sheffield Shield",
+      "imageUrl": "https://images.example.com/khawaja-gabba.jpg",
+      "topics": ["domestic-leagues"],
+      "eventSlug": "shield-double-ton",
+      "sentiment": "positive",
+      "momentumScore": 52
     },
     {
       "id": "article-7",
-      "title": "Rural bus tour amplifies energy message",
-      "link": "https://example.com/rural-bus",
-      "pubDate": "2024-09-26T22:40:00.000Z",
-      "content": "The bus tour stops at small-town diners with local radio hits about drilling and inflation.",
-      "source": "Cleveland Plain Dealer",
-      "category": "Ground Game",
-      "imageUrl": "https://images.example.com/bus-tour.jpg",
-      "topics": ["ground-game", "issue-messaging"],
-      "eventSlug": "rural-bus-tour",
+      "title": "Sixers retain Curran ahead of BBL overseas draft",
+      "link": "https://www.foxsports.com.au/cricket/bbl/sydney-sixers-tom-curran-retention-window-2024/news-story",
+      "pubDate": "2024-10-02T10:10:00.000Z",
+      "content": "Sydney lock in the English quick while Brisbane Heat pursue a power hitter for the top order.",
+      "source": "Fox Sports",
+      "category": "BBL",
+      "imageUrl": "https://images.example.com/curran-bbl.jpg",
+      "topics": ["domestic-leagues"],
+      "eventSlug": "bbl-retention-deadline",
       "sentiment": "positive",
-      "momentumScore": 48
+      "momentumScore": 57
     },
     {
       "id": "article-8",
-      "title": "Latino pastors partner with Trump team on voter guides",
-      "link": "https://example.com/latino-voter-guides",
-      "pubDate": "2024-09-28T19:15:00.000Z",
-      "content": "Spanish-language voter packets are distributed alongside food drives in Phoenix and Orlando.",
-      "source": "Univision",
-      "category": "Outreach",
-      "imageUrl": "https://images.example.com/latino-outreach.jpg",
-      "topics": ["ground-game"],
-      "eventSlug": "latino-faith-outreach",
+      "title": "Ainsworth five-for headlines WNCL opener",
+      "link": "https://www.cricket.com.au/news/wncl-chloe-ainsworth-five-wicket-haul-2024-25/2024-10-04",
+      "pubDate": "2024-10-04T04:50:00.000Z",
+      "content": "The teenage quick clocks 130 km/h and rips through Victoria to open the season in style.",
+      "source": "cricket.com.au",
+      "category": "WNCL",
+      "imageUrl": "https://images.example.com/ainsworth-wncl.jpg",
+      "topics": ["domestic-leagues"],
+      "eventSlug": "wncl-fast-bowler",
       "sentiment": "positive",
-      "momentumScore": 50
+      "momentumScore": 58
     },
     {
       "id": "article-9",
-      "title": "Immigration ad blitz links border to inflation",
-      "link": "https://example.com/immigration-ads",
-      "pubDate": "2024-09-25T13:10:00.000Z",
-      "content": "Ads feature grocery carts and Border Patrol footage, testing a new hybrid message.",
-      "source": "Washington Post",
-      "category": "Advertising",
-      "imageUrl": "https://images.example.com/immigration-ads.jpg",
-      "topics": ["issue-messaging"],
-      "eventSlug": "immigration-ad-blitz",
+      "title": "Youthful Australia A squad locks in NZ itinerary",
+      "link": "https://www.cricket.com.au/news/australia-a-squad-new-zealand-tour-announced/2024-09-27",
+      "pubDate": "2024-09-27T02:30:00.000Z",
+      "content": "Led by Nathan McSweeney, the group will play two four-day matches and three T20s across the ditch.",
+      "source": "cricket.com.au",
+      "category": "Australia A",
+      "imageUrl": "https://images.example.com/australia-a-squad.jpg",
+      "topics": ["pathways"],
+      "eventSlug": "australia-a-tour",
       "sentiment": "positive",
-      "momentumScore": 53
+      "momentumScore": 42
     },
     {
       "id": "article-10",
-      "title": "Fact-checkers push back on ad claims about migrant spending",
-      "link": "https://example.com/fact-check",
-      "pubDate": "2024-09-26T09:00:00.000Z",
-      "content": "Independent fact-checkers say the numbers are exaggerated, but the campaign doubles down in response videos.",
-      "source": "AP",
-      "category": "Fact Check",
-      "imageUrl": "https://images.example.com/fact-check.jpg",
-      "topics": ["issue-messaging", "legal-battles"],
-      "eventSlug": "immigration-ad-blitz",
-      "sentiment": "negative",
-      "momentumScore": 48
-    },
-    {
-      "id": "article-11",
-      "title": "Debate prep memo outlines foreign policy attacks",
-      "link": "https://example.com/debate-memo",
-      "pubDate": "2024-09-29T13:55:00.000Z",
-      "content": "Leaked slides suggest a focus on Afghanistan, arguing Biden cannot handle crises abroad.",
-      "source": "Bloomberg",
-      "category": "Debate",
-      "imageUrl": "https://images.example.com/debate-prep.jpg",
-      "topics": ["issue-messaging", "legal-battles"],
-      "eventSlug": "debate-prep-messaging",
+      "title": "PlayCricket grants expand girls' programs",
+      "link": "https://www.community.cricket.com.au/clubs/playcricket-grants-2024",
+      "pubDate": "2024-10-03T22:45:00.000Z",
+      "content": "Regional clubs can apply for $5,000 equipment packages aimed at girls' and all-abilities teams.",
+      "source": "Community Cricket",
+      "category": "Participation",
+      "imageUrl": "https://images.example.com/community-cricket-grants.jpg",
+      "topics": ["pathways"],
+      "eventSlug": "playcricket-grants",
       "sentiment": "positive",
-      "momentumScore": 57
+      "momentumScore": 45
     }
   ]
 }

--- a/src/index.html
+++ b/src/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="utf-8">
-  <title>TrumpTracker</title>
+  <title>Aussie Cricket Pulse</title>
   <base href="/">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="icon" type="image/x-icon" href="favicon.ico">


### PR DESCRIPTION
## Summary
- Rebrand navigation, layout shell, and engagement components around the Aussie Cricket Pulse theme.
- Replace legacy campaign data with Australian cricket topics, fixtures, and insights.
- Update server aggregations and utilities to target Australian cricket sources and tracking metadata.

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: ChromeHeadless binary not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68eab9a7cbb08326a89a77ffd6a73e50